### PR TITLE
WIN/UNIX MAKEFILE

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-ifndef SYSTEMROOT
+ifeq ($(OS),Windows_NT)
 		BIN=node_modules\.bin
 		PATHSEP2=\\
 		RM=del -r


### PR DESCRIPTION
the makefile is now modifiyed to decide between windows and linux based systems.

and for debug resons you can use
make <target> LOG=yes to get an output of the commands from the makefile