### PR TITLE
v0.2.0 Refactor to object

### DIFF
--- a/.esdoc.json
+++ b/.esdoc.json
@@ -17,12 +17,12 @@
         "typeInference": {"enable": true},
         "brand": {
           "logo": "",
-          "title": "fritzing-parts-api-client",
-          "description": "fritzing parts api client",
-          "repository": "https://github.com/paulvollmer/fritzing-parts-api-client",
-          "site": "https://paulvollmer.net",
-          "author": "https://github.com/paulvollmer",
-          "image": "https://github.com/paulvollmer/logo.png"
+          "title": "fritzing-parts-api-client-js",
+          "description": "fritzing parts javascript api client",
+          "repository": "https://github.com/fritzing/fritzing-parts-api-client-js",
+          "site": "https://fritzing.org",
+          "author": "https://github.com/fritzing",
+          "image": ""
         },
         "test": {
           "source": "./test/",
@@ -35,6 +35,7 @@
     {
       "name": "esdoc-ecmascript-proposal-plugin",
       "option": {
+        "all": true,
         "classProperties": true,
         "objectRestSpread": true,
         "doExpressions": true,

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,7 +1,8 @@
 {
   "extends": "google",
   "rules": {
-    "max-len": ["error", { "code": 120 }]
+    "max-len": ["error", { "code": 120 }],
+    "no-unused-vars": ["error", { "vars": "all", "args": "after-used", "ignoreRestSiblings": false }]
   },
   "parserOptions": {
     "ecmaVersion": 6,

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ sudo: required
 language: node_js
 node_js:
   - "8"
-  - "6"
 notifications:
   email: false
 before_script:

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2018 Fritzing
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -24,13 +24,15 @@ npm install fritzing/fritzing-parts-api-client-js --save
 ## Usage
 initialize an api client and fetch /fzps endpoint
 ```javascript
-import ApiClient from 'fritzing-parts-api-client-js'
+import {ApiClient} from 'fritzing-parts-api-client-js'
 
-const apiclient = new ApiClient()
-apiclient.getFzps().then(data => {
-  // do something with the data
-}).catch(err => {
-  // do something with the error catch
+const client = new ApiClient()
+client.getFzps()
+.then((fzpz) => {
+  console.log(fzps)
+})
+.catch((err) => {
+  console.error(err)
 })
 ```
 

--- a/README.md
+++ b/README.md
@@ -24,10 +24,9 @@ npm install fritzing/fritzing-parts-api-client-js --save
 ## Usage
 initialize an api client and fetch /fzps endpoint
 ```javascript
-import {ApiClient} from 'fritzing-parts-api-client-js'
+import {FritzingPartsAPIClient} from 'fritzing-parts-api-client-js'
 
-const client = new ApiClient()
-client.getFzps()
+FritzingPartsAPIClient.getFzps()
 .then((fzpz) => {
   console.log(fzps)
 })

--- a/docs/ast/source/index.js.json
+++ b/docs/ast/source/index.js.json
@@ -1,28 +1,28 @@
 {
   "type": "File",
   "start": 0,
-  "end": 2944,
+  "end": 4465,
   "loc": {
     "start": {
       "line": 1,
       "column": 0
     },
     "end": {
-      "line": 130,
+      "line": 186,
       "column": 0
     }
   },
   "program": {
     "type": "Program",
     "start": 0,
-    "end": 2944,
+    "end": 4465,
     "loc": {
       "start": {
         "line": 1,
         "column": 0
       },
       "end": {
-        "line": 130,
+        "line": 186,
         "column": 0
       }
     },
@@ -134,16 +134,16 @@
         "trailingComments": [
           {
             "type": "CommentBlock",
-            "value": "*\n * Fritzing Parts API Client\n ",
+            "value": "*\n * The base url of the fritzing parts api\n *\n * @example\n * const {FritzingPartsAPI} = require('fritzing-parts-api-client-js')\n *\n * console.log(FritzingPartsAPI)\n *\n * @type {String}\n ",
             "start": 48,
-            "end": 84,
+            "end": 239,
             "loc": {
               "start": {
                 "line": 5,
                 "column": 0
               },
               "end": {
-                "line": 7,
+                "line": 14,
                 "column": 3
               }
             }
@@ -151,385 +151,402 @@
         ]
       },
       {
-        "type": "ClassDeclaration",
-        "start": 85,
-        "end": 2914,
+        "type": "VariableDeclaration",
+        "start": 240,
+        "end": 309,
         "loc": {
           "start": {
-            "line": 8,
+            "line": 15,
             "column": 0
           },
           "end": {
-            "line": 127,
-            "column": 1
+            "line": 15,
+            "column": 69
           }
         },
-        "id": {
-          "type": "Identifier",
-          "start": 91,
-          "end": 100,
-          "loc": {
-            "start": {
-              "line": 8,
-              "column": 6
+        "declarations": [
+          {
+            "type": "VariableDeclarator",
+            "start": 246,
+            "end": 308,
+            "loc": {
+              "start": {
+                "line": 15,
+                "column": 6
+              },
+              "end": {
+                "line": 15,
+                "column": 68
+              }
             },
-            "end": {
-              "line": 8,
-              "column": 15
+            "id": {
+              "type": "Identifier",
+              "start": 246,
+              "end": 262,
+              "loc": {
+                "start": {
+                  "line": 15,
+                  "column": 6
+                },
+                "end": {
+                  "line": 15,
+                  "column": 22
+                },
+                "identifierName": "FritzingPartsAPI"
+              },
+              "name": "FritzingPartsAPI",
+              "leadingComments": null
             },
-            "identifierName": "ApiClient"
-          },
-          "name": "ApiClient",
-          "leadingComments": null
-        },
-        "superClass": null,
-        "body": {
-          "type": "ClassBody",
-          "start": 101,
-          "end": 2914,
-          "loc": {
-            "start": {
-              "line": 8,
-              "column": 16
+            "init": {
+              "type": "StringLiteral",
+              "start": 265,
+              "end": 308,
+              "loc": {
+                "start": {
+                  "line": 15,
+                  "column": 25
+                },
+                "end": {
+                  "line": 15,
+                  "column": 68
+                }
+              },
+              "extra": {
+                "rawValue": "https://fritzing.github.io/fritzing-parts",
+                "raw": "'https://fritzing.github.io/fritzing-parts'"
+              },
+              "value": "https://fritzing.github.io/fritzing-parts"
             },
-            "end": {
-              "line": 127,
-              "column": 1
+            "leadingComments": null
+          }
+        ],
+        "kind": "const",
+        "leadingComments": [
+          {
+            "type": "CommentBlock",
+            "value": "*\n * The base url of the fritzing parts api\n *\n * @example\n * const {FritzingPartsAPI} = require('fritzing-parts-api-client-js')\n *\n * console.log(FritzingPartsAPI)\n *\n * @type {String}\n ",
+            "start": 48,
+            "end": 239,
+            "loc": {
+              "start": {
+                "line": 5,
+                "column": 0
+              },
+              "end": {
+                "line": 14,
+                "column": 3
+              }
             }
+          }
+        ],
+        "trailingComments": [
+          {
+            "type": "CommentBlock",
+            "value": "*\n * Get a list of all FZP files\n *\n * @type   {Function}\n * @param  {String} url - The base URL of the parts api\n * @return {Promise}\n ",
+            "start": 311,
+            "end": 451,
+            "loc": {
+              "start": {
+                "line": 17,
+                "column": 0
+              },
+              "end": {
+                "line": 23,
+                "column": 3
+              }
+            }
+          }
+        ]
+      },
+      {
+        "type": "VariableDeclaration",
+        "start": 452,
+        "end": 625,
+        "loc": {
+          "start": {
+            "line": 24,
+            "column": 0
           },
-          "body": [
-            {
-              "type": "ClassMethod",
-              "start": 146,
-              "end": 225,
-              "loc": {
-                "start": {
-                  "line": 12,
-                  "column": 2
-                },
-                "end": {
-                  "line": 14,
-                  "column": 3
-                }
+          "end": {
+            "line": 29,
+            "column": 2
+          }
+        },
+        "declarations": [
+          {
+            "type": "VariableDeclarator",
+            "start": 458,
+            "end": 624,
+            "loc": {
+              "start": {
+                "line": 24,
+                "column": 6
               },
-              "static": false,
-              "computed": false,
-              "key": {
-                "type": "Identifier",
-                "start": 146,
-                "end": 157,
-                "loc": {
-                  "start": {
-                    "line": 12,
-                    "column": 2
-                  },
-                  "end": {
-                    "line": 12,
-                    "column": 13
-                  },
-                  "identifierName": "constructor"
-                },
-                "name": "constructor",
-                "leadingComments": null
-              },
-              "kind": "constructor",
-              "id": null,
-              "generator": false,
-              "expression": false,
-              "async": false,
-              "params": [],
-              "body": {
-                "type": "BlockStatement",
-                "start": 160,
-                "end": 225,
-                "loc": {
-                  "start": {
-                    "line": 12,
-                    "column": 16
-                  },
-                  "end": {
-                    "line": 14,
-                    "column": 3
-                  }
-                },
-                "body": [
-                  {
-                    "type": "ExpressionStatement",
-                    "start": 166,
-                    "end": 221,
-                    "loc": {
-                      "start": {
-                        "line": 13,
-                        "column": 4
-                      },
-                      "end": {
-                        "line": 13,
-                        "column": 59
-                      }
-                    },
-                    "expression": {
-                      "type": "AssignmentExpression",
-                      "start": 166,
-                      "end": 220,
-                      "loc": {
-                        "start": {
-                          "line": 13,
-                          "column": 4
-                        },
-                        "end": {
-                          "line": 13,
-                          "column": 58
-                        }
-                      },
-                      "operator": "=",
-                      "left": {
-                        "type": "MemberExpression",
-                        "start": 166,
-                        "end": 174,
-                        "loc": {
-                          "start": {
-                            "line": 13,
-                            "column": 4
-                          },
-                          "end": {
-                            "line": 13,
-                            "column": 12
-                          }
-                        },
-                        "object": {
-                          "type": "ThisExpression",
-                          "start": 166,
-                          "end": 170,
-                          "loc": {
-                            "start": {
-                              "line": 13,
-                              "column": 4
-                            },
-                            "end": {
-                              "line": 13,
-                              "column": 8
-                            }
-                          }
-                        },
-                        "property": {
-                          "type": "Identifier",
-                          "start": 171,
-                          "end": 174,
-                          "loc": {
-                            "start": {
-                              "line": 13,
-                              "column": 9
-                            },
-                            "end": {
-                              "line": 13,
-                              "column": 12
-                            },
-                            "identifierName": "url"
-                          },
-                          "name": "url"
-                        },
-                        "computed": false
-                      },
-                      "right": {
-                        "type": "StringLiteral",
-                        "start": 177,
-                        "end": 220,
-                        "loc": {
-                          "start": {
-                            "line": 13,
-                            "column": 15
-                          },
-                          "end": {
-                            "line": 13,
-                            "column": 58
-                          }
-                        },
-                        "extra": {
-                          "rawValue": "https://fritzing.github.io/fritzing-parts",
-                          "raw": "'https://fritzing.github.io/fritzing-parts'"
-                        },
-                        "value": "https://fritzing.github.io/fritzing-parts"
-                      }
-                    }
-                  }
-                ],
-                "directives": [],
-                "trailingComments": null
-              },
-              "leadingComments": [
-                {
-                  "type": "CommentBlock",
-                  "value": "*\n   * Construct the ApiClient\n   ",
-                  "start": 105,
-                  "end": 143,
-                  "loc": {
-                    "start": {
-                      "line": 9,
-                      "column": 2
-                    },
-                    "end": {
-                      "line": 11,
-                      "column": 5
-                    }
-                  }
-                }
-              ],
-              "trailingComments": [
-                {
-                  "type": "CommentBlock",
-                  "value": "*\n   * Get a list of all FZP files\n   * @return {Promise}\n   ",
-                  "start": 229,
-                  "end": 294,
-                  "loc": {
-                    "start": {
-                      "line": 16,
-                      "column": 2
-                    },
-                    "end": {
-                      "line": 19,
-                      "column": 5
-                    }
-                  }
-                }
-              ]
+              "end": {
+                "line": 29,
+                "column": 1
+              }
             },
-            {
-              "type": "ClassMethod",
-              "start": 297,
-              "end": 426,
+            "id": {
+              "type": "Identifier",
+              "start": 458,
+              "end": 465,
               "loc": {
                 "start": {
-                  "line": 20,
-                  "column": 2
+                  "line": 24,
+                  "column": 6
                 },
                 "end": {
-                  "line": 25,
-                  "column": 3
+                  "line": 24,
+                  "column": 13
+                },
+                "identifierName": "getFzps"
+              },
+              "name": "getFzps",
+              "leadingComments": null
+            },
+            "init": {
+              "type": "FunctionExpression",
+              "start": 468,
+              "end": 624,
+              "loc": {
+                "start": {
+                  "line": 24,
+                  "column": 16
+                },
+                "end": {
+                  "line": 29,
+                  "column": 1
                 }
               },
-              "static": false,
-              "computed": false,
-              "key": {
+              "id": {
                 "type": "Identifier",
-                "start": 297,
-                "end": 304,
+                "start": 458,
+                "end": 465,
                 "loc": {
                   "start": {
-                    "line": 20,
-                    "column": 2
+                    "line": 24,
+                    "column": 6
                   },
                   "end": {
-                    "line": 20,
-                    "column": 9
+                    "line": 24,
+                    "column": 13
                   },
                   "identifierName": "getFzps"
                 },
                 "name": "getFzps",
                 "leadingComments": null
               },
-              "kind": "method",
-              "id": null,
               "generator": false,
               "expression": false,
               "async": false,
-              "params": [],
-              "body": {
-                "type": "BlockStatement",
-                "start": 307,
-                "end": 426,
-                "loc": {
-                  "start": {
-                    "line": 20,
-                    "column": 12
+              "params": [
+                {
+                  "type": "AssignmentPattern",
+                  "start": 477,
+                  "end": 508,
+                  "loc": {
+                    "start": {
+                      "line": 24,
+                      "column": 25
+                    },
+                    "end": {
+                      "line": 24,
+                      "column": 56
+                    }
                   },
-                  "end": {
-                    "line": 25,
-                    "column": 3
-                  }
-                },
-                "body": [
-                  {
-                    "type": "ReturnStatement",
-                    "start": 313,
-                    "end": 422,
+                  "left": {
+                    "type": "Identifier",
+                    "start": 477,
+                    "end": 480,
                     "loc": {
                       "start": {
-                        "line": 21,
-                        "column": 4
+                        "line": 24,
+                        "column": 25
                       },
                       "end": {
                         "line": 24,
-                        "column": 7
+                        "column": 28
+                      },
+                      "identifierName": "url"
+                    },
+                    "name": "url"
+                  },
+                  "right": {
+                    "type": "TemplateLiteral",
+                    "start": 483,
+                    "end": 508,
+                    "loc": {
+                      "start": {
+                        "line": 24,
+                        "column": 31
+                      },
+                      "end": {
+                        "line": 24,
+                        "column": 56
+                      }
+                    },
+                    "expressions": [
+                      {
+                        "type": "Identifier",
+                        "start": 486,
+                        "end": 502,
+                        "loc": {
+                          "start": {
+                            "line": 24,
+                            "column": 34
+                          },
+                          "end": {
+                            "line": 24,
+                            "column": 50
+                          },
+                          "identifierName": "FritzingPartsAPI"
+                        },
+                        "name": "FritzingPartsAPI"
+                      }
+                    ],
+                    "quasis": [
+                      {
+                        "type": "TemplateElement",
+                        "start": 484,
+                        "end": 484,
+                        "loc": {
+                          "start": {
+                            "line": 24,
+                            "column": 32
+                          },
+                          "end": {
+                            "line": 24,
+                            "column": 32
+                          }
+                        },
+                        "value": {
+                          "raw": "",
+                          "cooked": ""
+                        },
+                        "tail": false
+                      },
+                      {
+                        "type": "TemplateElement",
+                        "start": 503,
+                        "end": 507,
+                        "loc": {
+                          "start": {
+                            "line": 24,
+                            "column": 51
+                          },
+                          "end": {
+                            "line": 24,
+                            "column": 55
+                          }
+                        },
+                        "value": {
+                          "raw": "/fzp",
+                          "cooked": "/fzp"
+                        },
+                        "tail": true
+                      }
+                    ]
+                  }
+                }
+              ],
+              "body": {
+                "type": "BlockStatement",
+                "start": 510,
+                "end": 624,
+                "loc": {
+                  "start": {
+                    "line": 24,
+                    "column": 58
+                  },
+                  "end": {
+                    "line": 29,
+                    "column": 1
+                  }
+                },
+                "body": [
+                  {
+                    "type": "ReturnStatement",
+                    "start": 514,
+                    "end": 622,
+                    "loc": {
+                      "start": {
+                        "line": 25,
+                        "column": 2
+                      },
+                      "end": {
+                        "line": 28,
+                        "column": 5
                       }
                     },
                     "argument": {
                       "type": "CallExpression",
-                      "start": 320,
-                      "end": 421,
+                      "start": 521,
+                      "end": 621,
                       "loc": {
                         "start": {
-                          "line": 21,
-                          "column": 11
+                          "line": 25,
+                          "column": 9
                         },
                         "end": {
-                          "line": 24,
-                          "column": 6
+                          "line": 28,
+                          "column": 4
                         }
                       },
                       "callee": {
                         "type": "MemberExpression",
-                        "start": 320,
-                        "end": 380,
+                        "start": 521,
+                        "end": 567,
                         "loc": {
                           "start": {
-                            "line": 21,
-                            "column": 11
+                            "line": 25,
+                            "column": 9
                           },
                           "end": {
-                            "line": 22,
-                            "column": 9
+                            "line": 26,
+                            "column": 7
                           }
                         },
                         "object": {
                           "type": "CallExpression",
-                          "start": 320,
-                          "end": 370,
+                          "start": 521,
+                          "end": 559,
                           "loc": {
                             "start": {
-                              "line": 21,
-                              "column": 11
+                              "line": 25,
+                              "column": 9
                             },
                             "end": {
-                              "line": 21,
-                              "column": 61
+                              "line": 25,
+                              "column": 47
                             }
                           },
                           "callee": {
                             "type": "MemberExpression",
-                            "start": 320,
-                            "end": 329,
+                            "start": 521,
+                            "end": 530,
                             "loc": {
                               "start": {
-                                "line": 21,
-                                "column": 11
+                                "line": 25,
+                                "column": 9
                               },
                               "end": {
-                                "line": 21,
-                                "column": 20
+                                "line": 25,
+                                "column": 18
                               }
                             },
                             "object": {
                               "type": "Identifier",
-                              "start": 320,
-                              "end": 325,
+                              "start": 521,
+                              "end": 526,
                               "loc": {
                                 "start": {
-                                  "line": 21,
-                                  "column": 11
+                                  "line": 25,
+                                  "column": 9
                                 },
                                 "end": {
-                                  "line": 21,
-                                  "column": 16
+                                  "line": 25,
+                                  "column": 14
                                 },
                                 "identifierName": "axios"
                               },
@@ -537,16 +554,16 @@
                             },
                             "property": {
                               "type": "Identifier",
-                              "start": 326,
-                              "end": 329,
+                              "start": 527,
+                              "end": 530,
                               "loc": {
                                 "start": {
-                                  "line": 21,
-                                  "column": 17
+                                  "line": 25,
+                                  "column": 15
                                 },
                                 "end": {
-                                  "line": 21,
-                                  "column": 20
+                                  "line": 25,
+                                  "column": 18
                                 },
                                 "identifierName": "get"
                               },
@@ -556,4967 +573,49 @@
                           },
                           "arguments": [
                             {
-                              "type": "BinaryExpression",
-                              "start": 330,
-                              "end": 345,
-                              "loc": {
-                                "start": {
-                                  "line": 21,
-                                  "column": 21
-                                },
-                                "end": {
-                                  "line": 21,
-                                  "column": 36
-                                }
-                              },
-                              "left": {
-                                "type": "MemberExpression",
-                                "start": 330,
-                                "end": 338,
-                                "loc": {
-                                  "start": {
-                                    "line": 21,
-                                    "column": 21
-                                  },
-                                  "end": {
-                                    "line": 21,
-                                    "column": 29
-                                  }
-                                },
-                                "object": {
-                                  "type": "ThisExpression",
-                                  "start": 330,
-                                  "end": 334,
-                                  "loc": {
-                                    "start": {
-                                      "line": 21,
-                                      "column": 21
-                                    },
-                                    "end": {
-                                      "line": 21,
-                                      "column": 25
-                                    }
-                                  }
-                                },
-                                "property": {
-                                  "type": "Identifier",
-                                  "start": 335,
-                                  "end": 338,
-                                  "loc": {
-                                    "start": {
-                                      "line": 21,
-                                      "column": 26
-                                    },
-                                    "end": {
-                                      "line": 21,
-                                      "column": 29
-                                    },
-                                    "identifierName": "url"
-                                  },
-                                  "name": "url"
-                                },
-                                "computed": false
-                              },
-                              "operator": "+",
-                              "right": {
-                                "type": "StringLiteral",
-                                "start": 339,
-                                "end": 345,
-                                "loc": {
-                                  "start": {
-                                    "line": 21,
-                                    "column": 30
-                                  },
-                                  "end": {
-                                    "line": 21,
-                                    "column": 36
-                                  }
-                                },
-                                "extra": {
-                                  "rawValue": "/fzp",
-                                  "raw": "'/fzp'"
-                                },
-                                "value": "/fzp"
-                              }
-                            },
-                            {
-                              "type": "ObjectExpression",
-                              "start": 347,
-                              "end": 369,
-                              "loc": {
-                                "start": {
-                                  "line": 21,
-                                  "column": 38
-                                },
-                                "end": {
-                                  "line": 21,
-                                  "column": 60
-                                }
-                              },
-                              "properties": [
-                                {
-                                  "type": "ObjectProperty",
-                                  "start": 348,
-                                  "end": 368,
-                                  "loc": {
-                                    "start": {
-                                      "line": 21,
-                                      "column": 39
-                                    },
-                                    "end": {
-                                      "line": 21,
-                                      "column": 59
-                                    }
-                                  },
-                                  "method": false,
-                                  "shorthand": false,
-                                  "computed": false,
-                                  "key": {
-                                    "type": "Identifier",
-                                    "start": 348,
-                                    "end": 360,
-                                    "loc": {
-                                      "start": {
-                                        "line": 21,
-                                        "column": 39
-                                      },
-                                      "end": {
-                                        "line": 21,
-                                        "column": 51
-                                      },
-                                      "identifierName": "responseType"
-                                    },
-                                    "name": "responseType"
-                                  },
-                                  "value": {
-                                    "type": "StringLiteral",
-                                    "start": 362,
-                                    "end": 368,
-                                    "loc": {
-                                      "start": {
-                                        "line": 21,
-                                        "column": 53
-                                      },
-                                      "end": {
-                                        "line": 21,
-                                        "column": 59
-                                      }
-                                    },
-                                    "extra": {
-                                      "rawValue": "json",
-                                      "raw": "'json'"
-                                    },
-                                    "value": "json"
-                                  }
-                                }
-                              ]
-                            }
-                          ]
-                        },
-                        "property": {
-                          "type": "Identifier",
-                          "start": 376,
-                          "end": 380,
-                          "loc": {
-                            "start": {
-                              "line": 22,
-                              "column": 5
-                            },
-                            "end": {
-                              "line": 22,
-                              "column": 9
-                            },
-                            "identifierName": "then"
-                          },
-                          "name": "then"
-                        },
-                        "computed": false
-                      },
-                      "arguments": [
-                        {
-                          "type": "ArrowFunctionExpression",
-                          "start": 381,
-                          "end": 420,
-                          "loc": {
-                            "start": {
-                              "line": 22,
-                              "column": 10
-                            },
-                            "end": {
-                              "line": 24,
-                              "column": 5
-                            }
-                          },
-                          "id": null,
-                          "generator": false,
-                          "expression": false,
-                          "async": false,
-                          "params": [
-                            {
                               "type": "Identifier",
-                              "start": 382,
-                              "end": 385,
-                              "loc": {
-                                "start": {
-                                  "line": 22,
-                                  "column": 11
-                                },
-                                "end": {
-                                  "line": 22,
-                                  "column": 14
-                                },
-                                "identifierName": "res"
-                              },
-                              "name": "res"
-                            }
-                          ],
-                          "body": {
-                            "type": "BlockStatement",
-                            "start": 390,
-                            "end": 420,
-                            "loc": {
-                              "start": {
-                                "line": 22,
-                                "column": 19
-                              },
-                              "end": {
-                                "line": 24,
-                                "column": 5
-                              }
-                            },
-                            "body": [
-                              {
-                                "type": "ReturnStatement",
-                                "start": 398,
-                                "end": 414,
-                                "loc": {
-                                  "start": {
-                                    "line": 23,
-                                    "column": 6
-                                  },
-                                  "end": {
-                                    "line": 23,
-                                    "column": 22
-                                  }
-                                },
-                                "argument": {
-                                  "type": "MemberExpression",
-                                  "start": 405,
-                                  "end": 413,
-                                  "loc": {
-                                    "start": {
-                                      "line": 23,
-                                      "column": 13
-                                    },
-                                    "end": {
-                                      "line": 23,
-                                      "column": 21
-                                    }
-                                  },
-                                  "object": {
-                                    "type": "Identifier",
-                                    "start": 405,
-                                    "end": 408,
-                                    "loc": {
-                                      "start": {
-                                        "line": 23,
-                                        "column": 13
-                                      },
-                                      "end": {
-                                        "line": 23,
-                                        "column": 16
-                                      },
-                                      "identifierName": "res"
-                                    },
-                                    "name": "res"
-                                  },
-                                  "property": {
-                                    "type": "Identifier",
-                                    "start": 409,
-                                    "end": 413,
-                                    "loc": {
-                                      "start": {
-                                        "line": 23,
-                                        "column": 17
-                                      },
-                                      "end": {
-                                        "line": 23,
-                                        "column": 21
-                                      },
-                                      "identifierName": "data"
-                                    },
-                                    "name": "data"
-                                  },
-                                  "computed": false
-                                }
-                              }
-                            ],
-                            "directives": []
-                          }
-                        }
-                      ]
-                    }
-                  }
-                ],
-                "directives": [],
-                "trailingComments": null
-              },
-              "leadingComments": [
-                {
-                  "type": "CommentBlock",
-                  "value": "*\n   * Get a list of all FZP files\n   * @return {Promise}\n   ",
-                  "start": 229,
-                  "end": 294,
-                  "loc": {
-                    "start": {
-                      "line": 16,
-                      "column": 2
-                    },
-                    "end": {
-                      "line": 19,
-                      "column": 5
-                    }
-                  }
-                }
-              ],
-              "trailingComments": [
-                {
-                  "type": "CommentBlock",
-                  "value": "*\n   * Get a list of all Core-FZP files\n   * @return {Promise}\n   ",
-                  "start": 429,
-                  "end": 499,
-                  "loc": {
-                    "start": {
-                      "line": 26,
-                      "column": 2
-                    },
-                    "end": {
-                      "line": 29,
-                      "column": 5
-                    }
-                  }
-                }
-              ]
-            },
-            {
-              "type": "ClassMethod",
-              "start": 502,
-              "end": 640,
-              "loc": {
-                "start": {
-                  "line": 30,
-                  "column": 2
-                },
-                "end": {
-                  "line": 35,
-                  "column": 3
-                }
-              },
-              "static": false,
-              "computed": false,
-              "key": {
-                "type": "Identifier",
-                "start": 502,
-                "end": 513,
-                "loc": {
-                  "start": {
-                    "line": 30,
-                    "column": 2
-                  },
-                  "end": {
-                    "line": 30,
-                    "column": 13
-                  },
-                  "identifierName": "getFzpsCore"
-                },
-                "name": "getFzpsCore",
-                "leadingComments": null
-              },
-              "kind": "method",
-              "id": null,
-              "generator": false,
-              "expression": false,
-              "async": false,
-              "params": [],
-              "body": {
-                "type": "BlockStatement",
-                "start": 516,
-                "end": 640,
-                "loc": {
-                  "start": {
-                    "line": 30,
-                    "column": 16
-                  },
-                  "end": {
-                    "line": 35,
-                    "column": 3
-                  }
-                },
-                "body": [
-                  {
-                    "type": "ReturnStatement",
-                    "start": 522,
-                    "end": 636,
-                    "loc": {
-                      "start": {
-                        "line": 31,
-                        "column": 4
-                      },
-                      "end": {
-                        "line": 34,
-                        "column": 7
-                      }
-                    },
-                    "argument": {
-                      "type": "CallExpression",
-                      "start": 529,
-                      "end": 635,
-                      "loc": {
-                        "start": {
-                          "line": 31,
-                          "column": 11
-                        },
-                        "end": {
-                          "line": 34,
-                          "column": 6
-                        }
-                      },
-                      "callee": {
-                        "type": "MemberExpression",
-                        "start": 529,
-                        "end": 594,
-                        "loc": {
-                          "start": {
-                            "line": 31,
-                            "column": 11
-                          },
-                          "end": {
-                            "line": 32,
-                            "column": 9
-                          }
-                        },
-                        "object": {
-                          "type": "CallExpression",
-                          "start": 529,
-                          "end": 584,
-                          "loc": {
-                            "start": {
-                              "line": 31,
-                              "column": 11
-                            },
-                            "end": {
-                              "line": 31,
-                              "column": 66
-                            }
-                          },
-                          "callee": {
-                            "type": "MemberExpression",
-                            "start": 529,
-                            "end": 538,
-                            "loc": {
-                              "start": {
-                                "line": 31,
-                                "column": 11
-                              },
-                              "end": {
-                                "line": 31,
-                                "column": 20
-                              }
-                            },
-                            "object": {
-                              "type": "Identifier",
-                              "start": 529,
+                              "start": 531,
                               "end": 534,
                               "loc": {
                                 "start": {
-                                  "line": 31,
-                                  "column": 11
+                                  "line": 25,
+                                  "column": 19
                                 },
                                 "end": {
-                                  "line": 31,
-                                  "column": 16
-                                },
-                                "identifierName": "axios"
-                              },
-                              "name": "axios"
-                            },
-                            "property": {
-                              "type": "Identifier",
-                              "start": 535,
-                              "end": 538,
-                              "loc": {
-                                "start": {
-                                  "line": 31,
-                                  "column": 17
-                                },
-                                "end": {
-                                  "line": 31,
-                                  "column": 20
-                                },
-                                "identifierName": "get"
-                              },
-                              "name": "get"
-                            },
-                            "computed": false
-                          },
-                          "arguments": [
-                            {
-                              "type": "BinaryExpression",
-                              "start": 539,
-                              "end": 559,
-                              "loc": {
-                                "start": {
-                                  "line": 31,
-                                  "column": 21
-                                },
-                                "end": {
-                                  "line": 31,
-                                  "column": 41
-                                }
-                              },
-                              "left": {
-                                "type": "MemberExpression",
-                                "start": 539,
-                                "end": 547,
-                                "loc": {
-                                  "start": {
-                                    "line": 31,
-                                    "column": 21
-                                  },
-                                  "end": {
-                                    "line": 31,
-                                    "column": 29
-                                  }
-                                },
-                                "object": {
-                                  "type": "ThisExpression",
-                                  "start": 539,
-                                  "end": 543,
-                                  "loc": {
-                                    "start": {
-                                      "line": 31,
-                                      "column": 21
-                                    },
-                                    "end": {
-                                      "line": 31,
-                                      "column": 25
-                                    }
-                                  }
-                                },
-                                "property": {
-                                  "type": "Identifier",
-                                  "start": 544,
-                                  "end": 547,
-                                  "loc": {
-                                    "start": {
-                                      "line": 31,
-                                      "column": 26
-                                    },
-                                    "end": {
-                                      "line": 31,
-                                      "column": 29
-                                    },
-                                    "identifierName": "url"
-                                  },
-                                  "name": "url"
-                                },
-                                "computed": false
-                              },
-                              "operator": "+",
-                              "right": {
-                                "type": "StringLiteral",
-                                "start": 548,
-                                "end": 559,
-                                "loc": {
-                                  "start": {
-                                    "line": 31,
-                                    "column": 30
-                                  },
-                                  "end": {
-                                    "line": 31,
-                                    "column": 41
-                                  }
-                                },
-                                "extra": {
-                                  "rawValue": "/fzp/core",
-                                  "raw": "'/fzp/core'"
-                                },
-                                "value": "/fzp/core"
-                              }
-                            },
-                            {
-                              "type": "ObjectExpression",
-                              "start": 561,
-                              "end": 583,
-                              "loc": {
-                                "start": {
-                                  "line": 31,
-                                  "column": 43
-                                },
-                                "end": {
-                                  "line": 31,
-                                  "column": 65
-                                }
-                              },
-                              "properties": [
-                                {
-                                  "type": "ObjectProperty",
-                                  "start": 562,
-                                  "end": 582,
-                                  "loc": {
-                                    "start": {
-                                      "line": 31,
-                                      "column": 44
-                                    },
-                                    "end": {
-                                      "line": 31,
-                                      "column": 64
-                                    }
-                                  },
-                                  "method": false,
-                                  "shorthand": false,
-                                  "computed": false,
-                                  "key": {
-                                    "type": "Identifier",
-                                    "start": 562,
-                                    "end": 574,
-                                    "loc": {
-                                      "start": {
-                                        "line": 31,
-                                        "column": 44
-                                      },
-                                      "end": {
-                                        "line": 31,
-                                        "column": 56
-                                      },
-                                      "identifierName": "responseType"
-                                    },
-                                    "name": "responseType"
-                                  },
-                                  "value": {
-                                    "type": "StringLiteral",
-                                    "start": 576,
-                                    "end": 582,
-                                    "loc": {
-                                      "start": {
-                                        "line": 31,
-                                        "column": 58
-                                      },
-                                      "end": {
-                                        "line": 31,
-                                        "column": 64
-                                      }
-                                    },
-                                    "extra": {
-                                      "rawValue": "json",
-                                      "raw": "'json'"
-                                    },
-                                    "value": "json"
-                                  }
-                                }
-                              ]
-                            }
-                          ]
-                        },
-                        "property": {
-                          "type": "Identifier",
-                          "start": 590,
-                          "end": 594,
-                          "loc": {
-                            "start": {
-                              "line": 32,
-                              "column": 5
-                            },
-                            "end": {
-                              "line": 32,
-                              "column": 9
-                            },
-                            "identifierName": "then"
-                          },
-                          "name": "then"
-                        },
-                        "computed": false
-                      },
-                      "arguments": [
-                        {
-                          "type": "ArrowFunctionExpression",
-                          "start": 595,
-                          "end": 634,
-                          "loc": {
-                            "start": {
-                              "line": 32,
-                              "column": 10
-                            },
-                            "end": {
-                              "line": 34,
-                              "column": 5
-                            }
-                          },
-                          "id": null,
-                          "generator": false,
-                          "expression": false,
-                          "async": false,
-                          "params": [
-                            {
-                              "type": "Identifier",
-                              "start": 596,
-                              "end": 599,
-                              "loc": {
-                                "start": {
-                                  "line": 32,
-                                  "column": 11
-                                },
-                                "end": {
-                                  "line": 32,
-                                  "column": 14
-                                },
-                                "identifierName": "res"
-                              },
-                              "name": "res"
-                            }
-                          ],
-                          "body": {
-                            "type": "BlockStatement",
-                            "start": 604,
-                            "end": 634,
-                            "loc": {
-                              "start": {
-                                "line": 32,
-                                "column": 19
-                              },
-                              "end": {
-                                "line": 34,
-                                "column": 5
-                              }
-                            },
-                            "body": [
-                              {
-                                "type": "ReturnStatement",
-                                "start": 612,
-                                "end": 628,
-                                "loc": {
-                                  "start": {
-                                    "line": 33,
-                                    "column": 6
-                                  },
-                                  "end": {
-                                    "line": 33,
-                                    "column": 22
-                                  }
-                                },
-                                "argument": {
-                                  "type": "MemberExpression",
-                                  "start": 619,
-                                  "end": 627,
-                                  "loc": {
-                                    "start": {
-                                      "line": 33,
-                                      "column": 13
-                                    },
-                                    "end": {
-                                      "line": 33,
-                                      "column": 21
-                                    }
-                                  },
-                                  "object": {
-                                    "type": "Identifier",
-                                    "start": 619,
-                                    "end": 622,
-                                    "loc": {
-                                      "start": {
-                                        "line": 33,
-                                        "column": 13
-                                      },
-                                      "end": {
-                                        "line": 33,
-                                        "column": 16
-                                      },
-                                      "identifierName": "res"
-                                    },
-                                    "name": "res"
-                                  },
-                                  "property": {
-                                    "type": "Identifier",
-                                    "start": 623,
-                                    "end": 627,
-                                    "loc": {
-                                      "start": {
-                                        "line": 33,
-                                        "column": 17
-                                      },
-                                      "end": {
-                                        "line": 33,
-                                        "column": 21
-                                      },
-                                      "identifierName": "data"
-                                    },
-                                    "name": "data"
-                                  },
-                                  "computed": false
-                                }
-                              }
-                            ],
-                            "directives": []
-                          }
-                        }
-                      ]
-                    }
-                  }
-                ],
-                "directives": [],
-                "trailingComments": null
-              },
-              "leadingComments": [
-                {
-                  "type": "CommentBlock",
-                  "value": "*\n   * Get a list of all Core-FZP files\n   * @return {Promise}\n   ",
-                  "start": 429,
-                  "end": 499,
-                  "loc": {
-                    "start": {
-                      "line": 26,
-                      "column": 2
-                    },
-                    "end": {
-                      "line": 29,
-                      "column": 5
-                    }
-                  }
-                }
-              ],
-              "trailingComments": [
-                {
-                  "type": "CommentBlock",
-                  "value": "*\n   * Get a list of all Obsolete-FZP files. for old sketches only!\n   * @return {Promise}\n   ",
-                  "start": 643,
-                  "end": 741,
-                  "loc": {
-                    "start": {
-                      "line": 36,
-                      "column": 2
-                    },
-                    "end": {
-                      "line": 39,
-                      "column": 5
-                    }
-                  }
-                }
-              ]
-            },
-            {
-              "type": "ClassMethod",
-              "start": 744,
-              "end": 890,
-              "loc": {
-                "start": {
-                  "line": 40,
-                  "column": 2
-                },
-                "end": {
-                  "line": 45,
-                  "column": 3
-                }
-              },
-              "static": false,
-              "computed": false,
-              "key": {
-                "type": "Identifier",
-                "start": 744,
-                "end": 759,
-                "loc": {
-                  "start": {
-                    "line": 40,
-                    "column": 2
-                  },
-                  "end": {
-                    "line": 40,
-                    "column": 17
-                  },
-                  "identifierName": "getFzpsObsolete"
-                },
-                "name": "getFzpsObsolete",
-                "leadingComments": null
-              },
-              "kind": "method",
-              "id": null,
-              "generator": false,
-              "expression": false,
-              "async": false,
-              "params": [],
-              "body": {
-                "type": "BlockStatement",
-                "start": 762,
-                "end": 890,
-                "loc": {
-                  "start": {
-                    "line": 40,
-                    "column": 20
-                  },
-                  "end": {
-                    "line": 45,
-                    "column": 3
-                  }
-                },
-                "body": [
-                  {
-                    "type": "ReturnStatement",
-                    "start": 768,
-                    "end": 886,
-                    "loc": {
-                      "start": {
-                        "line": 41,
-                        "column": 4
-                      },
-                      "end": {
-                        "line": 44,
-                        "column": 7
-                      }
-                    },
-                    "argument": {
-                      "type": "CallExpression",
-                      "start": 775,
-                      "end": 885,
-                      "loc": {
-                        "start": {
-                          "line": 41,
-                          "column": 11
-                        },
-                        "end": {
-                          "line": 44,
-                          "column": 6
-                        }
-                      },
-                      "callee": {
-                        "type": "MemberExpression",
-                        "start": 775,
-                        "end": 844,
-                        "loc": {
-                          "start": {
-                            "line": 41,
-                            "column": 11
-                          },
-                          "end": {
-                            "line": 42,
-                            "column": 9
-                          }
-                        },
-                        "object": {
-                          "type": "CallExpression",
-                          "start": 775,
-                          "end": 834,
-                          "loc": {
-                            "start": {
-                              "line": 41,
-                              "column": 11
-                            },
-                            "end": {
-                              "line": 41,
-                              "column": 70
-                            }
-                          },
-                          "callee": {
-                            "type": "MemberExpression",
-                            "start": 775,
-                            "end": 784,
-                            "loc": {
-                              "start": {
-                                "line": 41,
-                                "column": 11
-                              },
-                              "end": {
-                                "line": 41,
-                                "column": 20
-                              }
-                            },
-                            "object": {
-                              "type": "Identifier",
-                              "start": 775,
-                              "end": 780,
-                              "loc": {
-                                "start": {
-                                  "line": 41,
-                                  "column": 11
-                                },
-                                "end": {
-                                  "line": 41,
-                                  "column": 16
-                                },
-                                "identifierName": "axios"
-                              },
-                              "name": "axios"
-                            },
-                            "property": {
-                              "type": "Identifier",
-                              "start": 781,
-                              "end": 784,
-                              "loc": {
-                                "start": {
-                                  "line": 41,
-                                  "column": 17
-                                },
-                                "end": {
-                                  "line": 41,
-                                  "column": 20
-                                },
-                                "identifierName": "get"
-                              },
-                              "name": "get"
-                            },
-                            "computed": false
-                          },
-                          "arguments": [
-                            {
-                              "type": "BinaryExpression",
-                              "start": 785,
-                              "end": 809,
-                              "loc": {
-                                "start": {
-                                  "line": 41,
-                                  "column": 21
-                                },
-                                "end": {
-                                  "line": 41,
-                                  "column": 45
-                                }
-                              },
-                              "left": {
-                                "type": "MemberExpression",
-                                "start": 785,
-                                "end": 793,
-                                "loc": {
-                                  "start": {
-                                    "line": 41,
-                                    "column": 21
-                                  },
-                                  "end": {
-                                    "line": 41,
-                                    "column": 29
-                                  }
-                                },
-                                "object": {
-                                  "type": "ThisExpression",
-                                  "start": 785,
-                                  "end": 789,
-                                  "loc": {
-                                    "start": {
-                                      "line": 41,
-                                      "column": 21
-                                    },
-                                    "end": {
-                                      "line": 41,
-                                      "column": 25
-                                    }
-                                  }
-                                },
-                                "property": {
-                                  "type": "Identifier",
-                                  "start": 790,
-                                  "end": 793,
-                                  "loc": {
-                                    "start": {
-                                      "line": 41,
-                                      "column": 26
-                                    },
-                                    "end": {
-                                      "line": 41,
-                                      "column": 29
-                                    },
-                                    "identifierName": "url"
-                                  },
-                                  "name": "url"
-                                },
-                                "computed": false
-                              },
-                              "operator": "+",
-                              "right": {
-                                "type": "StringLiteral",
-                                "start": 794,
-                                "end": 809,
-                                "loc": {
-                                  "start": {
-                                    "line": 41,
-                                    "column": 30
-                                  },
-                                  "end": {
-                                    "line": 41,
-                                    "column": 45
-                                  }
-                                },
-                                "extra": {
-                                  "rawValue": "/fzp/obsolete",
-                                  "raw": "'/fzp/obsolete'"
-                                },
-                                "value": "/fzp/obsolete"
-                              }
-                            },
-                            {
-                              "type": "ObjectExpression",
-                              "start": 811,
-                              "end": 833,
-                              "loc": {
-                                "start": {
-                                  "line": 41,
-                                  "column": 47
-                                },
-                                "end": {
-                                  "line": 41,
-                                  "column": 69
-                                }
-                              },
-                              "properties": [
-                                {
-                                  "type": "ObjectProperty",
-                                  "start": 812,
-                                  "end": 832,
-                                  "loc": {
-                                    "start": {
-                                      "line": 41,
-                                      "column": 48
-                                    },
-                                    "end": {
-                                      "line": 41,
-                                      "column": 68
-                                    }
-                                  },
-                                  "method": false,
-                                  "shorthand": false,
-                                  "computed": false,
-                                  "key": {
-                                    "type": "Identifier",
-                                    "start": 812,
-                                    "end": 824,
-                                    "loc": {
-                                      "start": {
-                                        "line": 41,
-                                        "column": 48
-                                      },
-                                      "end": {
-                                        "line": 41,
-                                        "column": 60
-                                      },
-                                      "identifierName": "responseType"
-                                    },
-                                    "name": "responseType"
-                                  },
-                                  "value": {
-                                    "type": "StringLiteral",
-                                    "start": 826,
-                                    "end": 832,
-                                    "loc": {
-                                      "start": {
-                                        "line": 41,
-                                        "column": 62
-                                      },
-                                      "end": {
-                                        "line": 41,
-                                        "column": 68
-                                      }
-                                    },
-                                    "extra": {
-                                      "rawValue": "json",
-                                      "raw": "'json'"
-                                    },
-                                    "value": "json"
-                                  }
-                                }
-                              ]
-                            }
-                          ]
-                        },
-                        "property": {
-                          "type": "Identifier",
-                          "start": 840,
-                          "end": 844,
-                          "loc": {
-                            "start": {
-                              "line": 42,
-                              "column": 5
-                            },
-                            "end": {
-                              "line": 42,
-                              "column": 9
-                            },
-                            "identifierName": "then"
-                          },
-                          "name": "then"
-                        },
-                        "computed": false
-                      },
-                      "arguments": [
-                        {
-                          "type": "ArrowFunctionExpression",
-                          "start": 845,
-                          "end": 884,
-                          "loc": {
-                            "start": {
-                              "line": 42,
-                              "column": 10
-                            },
-                            "end": {
-                              "line": 44,
-                              "column": 5
-                            }
-                          },
-                          "id": null,
-                          "generator": false,
-                          "expression": false,
-                          "async": false,
-                          "params": [
-                            {
-                              "type": "Identifier",
-                              "start": 846,
-                              "end": 849,
-                              "loc": {
-                                "start": {
-                                  "line": 42,
-                                  "column": 11
-                                },
-                                "end": {
-                                  "line": 42,
-                                  "column": 14
-                                },
-                                "identifierName": "res"
-                              },
-                              "name": "res"
-                            }
-                          ],
-                          "body": {
-                            "type": "BlockStatement",
-                            "start": 854,
-                            "end": 884,
-                            "loc": {
-                              "start": {
-                                "line": 42,
-                                "column": 19
-                              },
-                              "end": {
-                                "line": 44,
-                                "column": 5
-                              }
-                            },
-                            "body": [
-                              {
-                                "type": "ReturnStatement",
-                                "start": 862,
-                                "end": 878,
-                                "loc": {
-                                  "start": {
-                                    "line": 43,
-                                    "column": 6
-                                  },
-                                  "end": {
-                                    "line": 43,
-                                    "column": 22
-                                  }
-                                },
-                                "argument": {
-                                  "type": "MemberExpression",
-                                  "start": 869,
-                                  "end": 877,
-                                  "loc": {
-                                    "start": {
-                                      "line": 43,
-                                      "column": 13
-                                    },
-                                    "end": {
-                                      "line": 43,
-                                      "column": 21
-                                    }
-                                  },
-                                  "object": {
-                                    "type": "Identifier",
-                                    "start": 869,
-                                    "end": 872,
-                                    "loc": {
-                                      "start": {
-                                        "line": 43,
-                                        "column": 13
-                                      },
-                                      "end": {
-                                        "line": 43,
-                                        "column": 16
-                                      },
-                                      "identifierName": "res"
-                                    },
-                                    "name": "res"
-                                  },
-                                  "property": {
-                                    "type": "Identifier",
-                                    "start": 873,
-                                    "end": 877,
-                                    "loc": {
-                                      "start": {
-                                        "line": 43,
-                                        "column": 17
-                                      },
-                                      "end": {
-                                        "line": 43,
-                                        "column": 21
-                                      },
-                                      "identifierName": "data"
-                                    },
-                                    "name": "data"
-                                  },
-                                  "computed": false
-                                }
-                              }
-                            ],
-                            "directives": []
-                          }
-                        }
-                      ]
-                    }
-                  }
-                ],
-                "directives": [],
-                "trailingComments": null
-              },
-              "leadingComments": [
-                {
-                  "type": "CommentBlock",
-                  "value": "*\n   * Get a list of all Obsolete-FZP files. for old sketches only!\n   * @return {Promise}\n   ",
-                  "start": 643,
-                  "end": 741,
-                  "loc": {
-                    "start": {
-                      "line": 36,
-                      "column": 2
-                    },
-                    "end": {
-                      "line": 39,
-                      "column": 5
-                    }
-                  }
-                }
-              ],
-              "trailingComments": [
-                {
-                  "type": "CommentBlock",
-                  "value": "*\n   * Get a single FZP and response the xml as a string\n   * @param  {String} src\n   * @return {Promise} the fetch promise\n   ",
-                  "start": 894,
-                  "end": 1025,
-                  "loc": {
-                    "start": {
-                      "line": 47,
-                      "column": 2
-                    },
-                    "end": {
-                      "line": 51,
-                      "column": 5
-                    }
-                  }
-                }
-              ]
-            },
-            {
-              "type": "ClassMethod",
-              "start": 1029,
-              "end": 1165,
-              "loc": {
-                "start": {
-                  "line": 52,
-                  "column": 3
-                },
-                "end": {
-                  "line": 57,
-                  "column": 4
-                }
-              },
-              "static": false,
-              "computed": false,
-              "key": {
-                "type": "Identifier",
-                "start": 1029,
-                "end": 1035,
-                "loc": {
-                  "start": {
-                    "line": 52,
-                    "column": 3
-                  },
-                  "end": {
-                    "line": 52,
-                    "column": 9
-                  },
-                  "identifierName": "getFzp"
-                },
-                "name": "getFzp",
-                "leadingComments": null
-              },
-              "kind": "method",
-              "id": null,
-              "generator": false,
-              "expression": false,
-              "async": false,
-              "params": [
-                {
-                  "type": "Identifier",
-                  "start": 1036,
-                  "end": 1039,
-                  "loc": {
-                    "start": {
-                      "line": 52,
-                      "column": 10
-                    },
-                    "end": {
-                      "line": 52,
-                      "column": 13
-                    },
-                    "identifierName": "src"
-                  },
-                  "name": "src"
-                }
-              ],
-              "body": {
-                "type": "BlockStatement",
-                "start": 1041,
-                "end": 1165,
-                "loc": {
-                  "start": {
-                    "line": 52,
-                    "column": 15
-                  },
-                  "end": {
-                    "line": 57,
-                    "column": 4
-                  }
-                },
-                "body": [
-                  {
-                    "type": "ReturnStatement",
-                    "start": 1048,
-                    "end": 1160,
-                    "loc": {
-                      "start": {
-                        "line": 53,
-                        "column": 5
-                      },
-                      "end": {
-                        "line": 56,
-                        "column": 8
-                      }
-                    },
-                    "argument": {
-                      "type": "CallExpression",
-                      "start": 1055,
-                      "end": 1159,
-                      "loc": {
-                        "start": {
-                          "line": 53,
-                          "column": 12
-                        },
-                        "end": {
-                          "line": 56,
-                          "column": 7
-                        }
-                      },
-                      "callee": {
-                        "type": "MemberExpression",
-                        "start": 1055,
-                        "end": 1116,
-                        "loc": {
-                          "start": {
-                            "line": 53,
-                            "column": 12
-                          },
-                          "end": {
-                            "line": 54,
-                            "column": 10
-                          }
-                        },
-                        "object": {
-                          "type": "CallExpression",
-                          "start": 1055,
-                          "end": 1105,
-                          "loc": {
-                            "start": {
-                              "line": 53,
-                              "column": 12
-                            },
-                            "end": {
-                              "line": 53,
-                              "column": 62
-                            }
-                          },
-                          "callee": {
-                            "type": "MemberExpression",
-                            "start": 1055,
-                            "end": 1064,
-                            "loc": {
-                              "start": {
-                                "line": 53,
-                                "column": 12
-                              },
-                              "end": {
-                                "line": 53,
-                                "column": 21
-                              }
-                            },
-                            "object": {
-                              "type": "Identifier",
-                              "start": 1055,
-                              "end": 1060,
-                              "loc": {
-                                "start": {
-                                  "line": 53,
-                                  "column": 12
-                                },
-                                "end": {
-                                  "line": 53,
-                                  "column": 17
-                                },
-                                "identifierName": "axios"
-                              },
-                              "name": "axios"
-                            },
-                            "property": {
-                              "type": "Identifier",
-                              "start": 1061,
-                              "end": 1064,
-                              "loc": {
-                                "start": {
-                                  "line": 53,
-                                  "column": 18
-                                },
-                                "end": {
-                                  "line": 53,
-                                  "column": 21
-                                },
-                                "identifierName": "get"
-                              },
-                              "name": "get"
-                            },
-                            "computed": false
-                          },
-                          "arguments": [
-                            {
-                              "type": "BinaryExpression",
-                              "start": 1065,
-                              "end": 1081,
-                              "loc": {
-                                "start": {
-                                  "line": 53,
+                                  "line": 25,
                                   "column": 22
                                 },
-                                "end": {
-                                  "line": 53,
-                                  "column": 38
-                                }
+                                "identifierName": "url"
                               },
-                              "left": {
-                                "type": "BinaryExpression",
-                                "start": 1065,
-                                "end": 1077,
-                                "loc": {
-                                  "start": {
-                                    "line": 53,
-                                    "column": 22
-                                  },
-                                  "end": {
-                                    "line": 53,
-                                    "column": 34
-                                  }
-                                },
-                                "left": {
-                                  "type": "MemberExpression",
-                                  "start": 1065,
-                                  "end": 1073,
-                                  "loc": {
-                                    "start": {
-                                      "line": 53,
-                                      "column": 22
-                                    },
-                                    "end": {
-                                      "line": 53,
-                                      "column": 30
-                                    }
-                                  },
-                                  "object": {
-                                    "type": "ThisExpression",
-                                    "start": 1065,
-                                    "end": 1069,
-                                    "loc": {
-                                      "start": {
-                                        "line": 53,
-                                        "column": 22
-                                      },
-                                      "end": {
-                                        "line": 53,
-                                        "column": 26
-                                      }
-                                    }
-                                  },
-                                  "property": {
-                                    "type": "Identifier",
-                                    "start": 1070,
-                                    "end": 1073,
-                                    "loc": {
-                                      "start": {
-                                        "line": 53,
-                                        "column": 27
-                                      },
-                                      "end": {
-                                        "line": 53,
-                                        "column": 30
-                                      },
-                                      "identifierName": "url"
-                                    },
-                                    "name": "url"
-                                  },
-                                  "computed": false
-                                },
-                                "operator": "+",
-                                "right": {
-                                  "type": "StringLiteral",
-                                  "start": 1074,
-                                  "end": 1077,
-                                  "loc": {
-                                    "start": {
-                                      "line": 53,
-                                      "column": 31
-                                    },
-                                    "end": {
-                                      "line": 53,
-                                      "column": 34
-                                    }
-                                  },
-                                  "extra": {
-                                    "rawValue": "/",
-                                    "raw": "'/'"
-                                  },
-                                  "value": "/"
-                                }
-                              },
-                              "operator": "+",
-                              "right": {
-                                "type": "Identifier",
-                                "start": 1078,
-                                "end": 1081,
-                                "loc": {
-                                  "start": {
-                                    "line": 53,
-                                    "column": 35
-                                  },
-                                  "end": {
-                                    "line": 53,
-                                    "column": 38
-                                  },
-                                  "identifierName": "src"
-                                },
-                                "name": "src"
-                              }
+                              "name": "url"
                             },
                             {
                               "type": "ObjectExpression",
-                              "start": 1083,
-                              "end": 1104,
+                              "start": 536,
+                              "end": 558,
                               "loc": {
                                 "start": {
-                                  "line": 53,
-                                  "column": 40
+                                  "line": 25,
+                                  "column": 24
                                 },
                                 "end": {
-                                  "line": 53,
-                                  "column": 61
-                                }
-                              },
-                              "properties": [
-                                {
-                                  "type": "ObjectProperty",
-                                  "start": 1084,
-                                  "end": 1103,
-                                  "loc": {
-                                    "start": {
-                                      "line": 53,
-                                      "column": 41
-                                    },
-                                    "end": {
-                                      "line": 53,
-                                      "column": 60
-                                    }
-                                  },
-                                  "method": false,
-                                  "shorthand": false,
-                                  "computed": false,
-                                  "key": {
-                                    "type": "Identifier",
-                                    "start": 1084,
-                                    "end": 1096,
-                                    "loc": {
-                                      "start": {
-                                        "line": 53,
-                                        "column": 41
-                                      },
-                                      "end": {
-                                        "line": 53,
-                                        "column": 53
-                                      },
-                                      "identifierName": "responseType"
-                                    },
-                                    "name": "responseType"
-                                  },
-                                  "value": {
-                                    "type": "StringLiteral",
-                                    "start": 1098,
-                                    "end": 1103,
-                                    "loc": {
-                                      "start": {
-                                        "line": 53,
-                                        "column": 55
-                                      },
-                                      "end": {
-                                        "line": 53,
-                                        "column": 60
-                                      }
-                                    },
-                                    "extra": {
-                                      "rawValue": "xml",
-                                      "raw": "'xml'"
-                                    },
-                                    "value": "xml"
-                                  }
-                                }
-                              ]
-                            }
-                          ]
-                        },
-                        "property": {
-                          "type": "Identifier",
-                          "start": 1112,
-                          "end": 1116,
-                          "loc": {
-                            "start": {
-                              "line": 54,
-                              "column": 6
-                            },
-                            "end": {
-                              "line": 54,
-                              "column": 10
-                            },
-                            "identifierName": "then"
-                          },
-                          "name": "then"
-                        },
-                        "computed": false
-                      },
-                      "arguments": [
-                        {
-                          "type": "ArrowFunctionExpression",
-                          "start": 1117,
-                          "end": 1158,
-                          "loc": {
-                            "start": {
-                              "line": 54,
-                              "column": 11
-                            },
-                            "end": {
-                              "line": 56,
-                              "column": 6
-                            }
-                          },
-                          "id": null,
-                          "generator": false,
-                          "expression": false,
-                          "async": false,
-                          "params": [
-                            {
-                              "type": "Identifier",
-                              "start": 1118,
-                              "end": 1121,
-                              "loc": {
-                                "start": {
-                                  "line": 54,
-                                  "column": 12
-                                },
-                                "end": {
-                                  "line": 54,
-                                  "column": 15
-                                },
-                                "identifierName": "res"
-                              },
-                              "name": "res"
-                            }
-                          ],
-                          "body": {
-                            "type": "BlockStatement",
-                            "start": 1126,
-                            "end": 1158,
-                            "loc": {
-                              "start": {
-                                "line": 54,
-                                "column": 20
-                              },
-                              "end": {
-                                "line": 56,
-                                "column": 6
-                              }
-                            },
-                            "body": [
-                              {
-                                "type": "ReturnStatement",
-                                "start": 1135,
-                                "end": 1151,
-                                "loc": {
-                                  "start": {
-                                    "line": 55,
-                                    "column": 7
-                                  },
-                                  "end": {
-                                    "line": 55,
-                                    "column": 23
-                                  }
-                                },
-                                "argument": {
-                                  "type": "MemberExpression",
-                                  "start": 1142,
-                                  "end": 1150,
-                                  "loc": {
-                                    "start": {
-                                      "line": 55,
-                                      "column": 14
-                                    },
-                                    "end": {
-                                      "line": 55,
-                                      "column": 22
-                                    }
-                                  },
-                                  "object": {
-                                    "type": "Identifier",
-                                    "start": 1142,
-                                    "end": 1145,
-                                    "loc": {
-                                      "start": {
-                                        "line": 55,
-                                        "column": 14
-                                      },
-                                      "end": {
-                                        "line": 55,
-                                        "column": 17
-                                      },
-                                      "identifierName": "res"
-                                    },
-                                    "name": "res"
-                                  },
-                                  "property": {
-                                    "type": "Identifier",
-                                    "start": 1146,
-                                    "end": 1150,
-                                    "loc": {
-                                      "start": {
-                                        "line": 55,
-                                        "column": 18
-                                      },
-                                      "end": {
-                                        "line": 55,
-                                        "column": 22
-                                      },
-                                      "identifierName": "data"
-                                    },
-                                    "name": "data"
-                                  },
-                                  "computed": false
-                                }
-                              }
-                            ],
-                            "directives": []
-                          }
-                        }
-                      ]
-                    }
-                  }
-                ],
-                "directives": [],
-                "trailingComments": null
-              },
-              "leadingComments": [
-                {
-                  "type": "CommentBlock",
-                  "value": "*\n   * Get a single FZP and response the xml as a string\n   * @param  {String} src\n   * @return {Promise} the fetch promise\n   ",
-                  "start": 894,
-                  "end": 1025,
-                  "loc": {
-                    "start": {
-                      "line": 47,
-                      "column": 2
-                    },
-                    "end": {
-                      "line": 51,
-                      "column": 5
-                    }
-                  }
-                }
-              ],
-              "trailingComments": [
-                {
-                  "type": "CommentBlock",
-                  "value": "*\n    * Get a single part fzp from the core parts\n    * @param  {String} src\n    * @return {Promise} the fetch promise returns xml\n    ",
-                  "start": 1170,
-                  "end": 1309,
-                  "loc": {
-                    "start": {
-                      "line": 59,
-                      "column": 3
-                    },
-                    "end": {
-                      "line": 63,
-                      "column": 6
-                    }
-                  }
-                }
-              ]
-            },
-            {
-              "type": "ClassMethod",
-              "start": 1312,
-              "end": 1452,
-              "loc": {
-                "start": {
-                  "line": 64,
-                  "column": 2
-                },
-                "end": {
-                  "line": 69,
-                  "column": 3
-                }
-              },
-              "static": false,
-              "computed": false,
-              "key": {
-                "type": "Identifier",
-                "start": 1312,
-                "end": 1322,
-                "loc": {
-                  "start": {
-                    "line": 64,
-                    "column": 2
-                  },
-                  "end": {
-                    "line": 64,
-                    "column": 12
-                  },
-                  "identifierName": "getFzpCore"
-                },
-                "name": "getFzpCore",
-                "leadingComments": null
-              },
-              "kind": "method",
-              "id": null,
-              "generator": false,
-              "expression": false,
-              "async": false,
-              "params": [
-                {
-                  "type": "Identifier",
-                  "start": 1323,
-                  "end": 1326,
-                  "loc": {
-                    "start": {
-                      "line": 64,
-                      "column": 13
-                    },
-                    "end": {
-                      "line": 64,
-                      "column": 16
-                    },
-                    "identifierName": "src"
-                  },
-                  "name": "src"
-                }
-              ],
-              "body": {
-                "type": "BlockStatement",
-                "start": 1328,
-                "end": 1452,
-                "loc": {
-                  "start": {
-                    "line": 64,
-                    "column": 18
-                  },
-                  "end": {
-                    "line": 69,
-                    "column": 3
-                  }
-                },
-                "body": [
-                  {
-                    "type": "ReturnStatement",
-                    "start": 1334,
-                    "end": 1448,
-                    "loc": {
-                      "start": {
-                        "line": 65,
-                        "column": 4
-                      },
-                      "end": {
-                        "line": 68,
-                        "column": 7
-                      }
-                    },
-                    "argument": {
-                      "type": "CallExpression",
-                      "start": 1341,
-                      "end": 1447,
-                      "loc": {
-                        "start": {
-                          "line": 65,
-                          "column": 11
-                        },
-                        "end": {
-                          "line": 68,
-                          "column": 6
-                        }
-                      },
-                      "callee": {
-                        "type": "MemberExpression",
-                        "start": 1341,
-                        "end": 1406,
-                        "loc": {
-                          "start": {
-                            "line": 65,
-                            "column": 11
-                          },
-                          "end": {
-                            "line": 66,
-                            "column": 9
-                          }
-                        },
-                        "object": {
-                          "type": "CallExpression",
-                          "start": 1341,
-                          "end": 1396,
-                          "loc": {
-                            "start": {
-                              "line": 65,
-                              "column": 11
-                            },
-                            "end": {
-                              "line": 65,
-                              "column": 66
-                            }
-                          },
-                          "callee": {
-                            "type": "MemberExpression",
-                            "start": 1341,
-                            "end": 1350,
-                            "loc": {
-                              "start": {
-                                "line": 65,
-                                "column": 11
-                              },
-                              "end": {
-                                "line": 65,
-                                "column": 20
-                              }
-                            },
-                            "object": {
-                              "type": "Identifier",
-                              "start": 1341,
-                              "end": 1346,
-                              "loc": {
-                                "start": {
-                                  "line": 65,
-                                  "column": 11
-                                },
-                                "end": {
-                                  "line": 65,
-                                  "column": 16
-                                },
-                                "identifierName": "axios"
-                              },
-                              "name": "axios"
-                            },
-                            "property": {
-                              "type": "Identifier",
-                              "start": 1347,
-                              "end": 1350,
-                              "loc": {
-                                "start": {
-                                  "line": 65,
-                                  "column": 17
-                                },
-                                "end": {
-                                  "line": 65,
-                                  "column": 20
-                                },
-                                "identifierName": "get"
-                              },
-                              "name": "get"
-                            },
-                            "computed": false
-                          },
-                          "arguments": [
-                            {
-                              "type": "BinaryExpression",
-                              "start": 1351,
-                              "end": 1372,
-                              "loc": {
-                                "start": {
-                                  "line": 65,
-                                  "column": 21
-                                },
-                                "end": {
-                                  "line": 65,
-                                  "column": 42
-                                }
-                              },
-                              "left": {
-                                "type": "BinaryExpression",
-                                "start": 1351,
-                                "end": 1368,
-                                "loc": {
-                                  "start": {
-                                    "line": 65,
-                                    "column": 21
-                                  },
-                                  "end": {
-                                    "line": 65,
-                                    "column": 38
-                                  }
-                                },
-                                "left": {
-                                  "type": "MemberExpression",
-                                  "start": 1351,
-                                  "end": 1359,
-                                  "loc": {
-                                    "start": {
-                                      "line": 65,
-                                      "column": 21
-                                    },
-                                    "end": {
-                                      "line": 65,
-                                      "column": 29
-                                    }
-                                  },
-                                  "object": {
-                                    "type": "ThisExpression",
-                                    "start": 1351,
-                                    "end": 1355,
-                                    "loc": {
-                                      "start": {
-                                        "line": 65,
-                                        "column": 21
-                                      },
-                                      "end": {
-                                        "line": 65,
-                                        "column": 25
-                                      }
-                                    }
-                                  },
-                                  "property": {
-                                    "type": "Identifier",
-                                    "start": 1356,
-                                    "end": 1359,
-                                    "loc": {
-                                      "start": {
-                                        "line": 65,
-                                        "column": 26
-                                      },
-                                      "end": {
-                                        "line": 65,
-                                        "column": 29
-                                      },
-                                      "identifierName": "url"
-                                    },
-                                    "name": "url"
-                                  },
-                                  "computed": false
-                                },
-                                "operator": "+",
-                                "right": {
-                                  "type": "StringLiteral",
-                                  "start": 1360,
-                                  "end": 1368,
-                                  "loc": {
-                                    "start": {
-                                      "line": 65,
-                                      "column": 30
-                                    },
-                                    "end": {
-                                      "line": 65,
-                                      "column": 38
-                                    }
-                                  },
-                                  "extra": {
-                                    "rawValue": "/core/",
-                                    "raw": "'/core/'"
-                                  },
-                                  "value": "/core/"
-                                }
-                              },
-                              "operator": "+",
-                              "right": {
-                                "type": "Identifier",
-                                "start": 1369,
-                                "end": 1372,
-                                "loc": {
-                                  "start": {
-                                    "line": 65,
-                                    "column": 39
-                                  },
-                                  "end": {
-                                    "line": 65,
-                                    "column": 42
-                                  },
-                                  "identifierName": "src"
-                                },
-                                "name": "src"
-                              }
-                            },
-                            {
-                              "type": "ObjectExpression",
-                              "start": 1374,
-                              "end": 1395,
-                              "loc": {
-                                "start": {
-                                  "line": 65,
-                                  "column": 44
-                                },
-                                "end": {
-                                  "line": 65,
-                                  "column": 65
-                                }
-                              },
-                              "properties": [
-                                {
-                                  "type": "ObjectProperty",
-                                  "start": 1375,
-                                  "end": 1394,
-                                  "loc": {
-                                    "start": {
-                                      "line": 65,
-                                      "column": 45
-                                    },
-                                    "end": {
-                                      "line": 65,
-                                      "column": 64
-                                    }
-                                  },
-                                  "method": false,
-                                  "shorthand": false,
-                                  "computed": false,
-                                  "key": {
-                                    "type": "Identifier",
-                                    "start": 1375,
-                                    "end": 1387,
-                                    "loc": {
-                                      "start": {
-                                        "line": 65,
-                                        "column": 45
-                                      },
-                                      "end": {
-                                        "line": 65,
-                                        "column": 57
-                                      },
-                                      "identifierName": "responseType"
-                                    },
-                                    "name": "responseType"
-                                  },
-                                  "value": {
-                                    "type": "StringLiteral",
-                                    "start": 1389,
-                                    "end": 1394,
-                                    "loc": {
-                                      "start": {
-                                        "line": 65,
-                                        "column": 59
-                                      },
-                                      "end": {
-                                        "line": 65,
-                                        "column": 64
-                                      }
-                                    },
-                                    "extra": {
-                                      "rawValue": "xml",
-                                      "raw": "'xml'"
-                                    },
-                                    "value": "xml"
-                                  }
-                                }
-                              ]
-                            }
-                          ]
-                        },
-                        "property": {
-                          "type": "Identifier",
-                          "start": 1402,
-                          "end": 1406,
-                          "loc": {
-                            "start": {
-                              "line": 66,
-                              "column": 5
-                            },
-                            "end": {
-                              "line": 66,
-                              "column": 9
-                            },
-                            "identifierName": "then"
-                          },
-                          "name": "then"
-                        },
-                        "computed": false
-                      },
-                      "arguments": [
-                        {
-                          "type": "ArrowFunctionExpression",
-                          "start": 1407,
-                          "end": 1446,
-                          "loc": {
-                            "start": {
-                              "line": 66,
-                              "column": 10
-                            },
-                            "end": {
-                              "line": 68,
-                              "column": 5
-                            }
-                          },
-                          "id": null,
-                          "generator": false,
-                          "expression": false,
-                          "async": false,
-                          "params": [
-                            {
-                              "type": "Identifier",
-                              "start": 1408,
-                              "end": 1411,
-                              "loc": {
-                                "start": {
-                                  "line": 66,
-                                  "column": 11
-                                },
-                                "end": {
-                                  "line": 66,
-                                  "column": 14
-                                },
-                                "identifierName": "res"
-                              },
-                              "name": "res"
-                            }
-                          ],
-                          "body": {
-                            "type": "BlockStatement",
-                            "start": 1416,
-                            "end": 1446,
-                            "loc": {
-                              "start": {
-                                "line": 66,
-                                "column": 19
-                              },
-                              "end": {
-                                "line": 68,
-                                "column": 5
-                              }
-                            },
-                            "body": [
-                              {
-                                "type": "ReturnStatement",
-                                "start": 1424,
-                                "end": 1440,
-                                "loc": {
-                                  "start": {
-                                    "line": 67,
-                                    "column": 6
-                                  },
-                                  "end": {
-                                    "line": 67,
-                                    "column": 22
-                                  }
-                                },
-                                "argument": {
-                                  "type": "MemberExpression",
-                                  "start": 1431,
-                                  "end": 1439,
-                                  "loc": {
-                                    "start": {
-                                      "line": 67,
-                                      "column": 13
-                                    },
-                                    "end": {
-                                      "line": 67,
-                                      "column": 21
-                                    }
-                                  },
-                                  "object": {
-                                    "type": "Identifier",
-                                    "start": 1431,
-                                    "end": 1434,
-                                    "loc": {
-                                      "start": {
-                                        "line": 67,
-                                        "column": 13
-                                      },
-                                      "end": {
-                                        "line": 67,
-                                        "column": 16
-                                      },
-                                      "identifierName": "res"
-                                    },
-                                    "name": "res"
-                                  },
-                                  "property": {
-                                    "type": "Identifier",
-                                    "start": 1435,
-                                    "end": 1439,
-                                    "loc": {
-                                      "start": {
-                                        "line": 67,
-                                        "column": 17
-                                      },
-                                      "end": {
-                                        "line": 67,
-                                        "column": 21
-                                      },
-                                      "identifierName": "data"
-                                    },
-                                    "name": "data"
-                                  },
-                                  "computed": false
-                                }
-                              }
-                            ],
-                            "directives": []
-                          }
-                        }
-                      ]
-                    }
-                  }
-                ],
-                "directives": [],
-                "trailingComments": null
-              },
-              "leadingComments": [
-                {
-                  "type": "CommentBlock",
-                  "value": "*\n    * Get a single part fzp from the core parts\n    * @param  {String} src\n    * @return {Promise} the fetch promise returns xml\n    ",
-                  "start": 1170,
-                  "end": 1309,
-                  "loc": {
-                    "start": {
-                      "line": 59,
-                      "column": 3
-                    },
-                    "end": {
-                      "line": 63,
-                      "column": 6
-                    }
-                  }
-                }
-              ],
-              "trailingComments": [
-                {
-                  "type": "CommentBlock",
-                  "value": "*\n   * Get a single part fzp from the obsolete parts, this is for old sketches only!\n   * @param  {String} src\n   * @return {Promise} the fetch promise returns xml\n   ",
-                  "start": 1455,
-                  "end": 1626,
-                  "loc": {
-                    "start": {
-                      "line": 70,
-                      "column": 2
-                    },
-                    "end": {
-                      "line": 74,
-                      "column": 5
-                    }
-                  }
-                }
-              ]
-            },
-            {
-              "type": "ClassMethod",
-              "start": 1629,
-              "end": 1777,
-              "loc": {
-                "start": {
-                  "line": 75,
-                  "column": 2
-                },
-                "end": {
-                  "line": 80,
-                  "column": 3
-                }
-              },
-              "static": false,
-              "computed": false,
-              "key": {
-                "type": "Identifier",
-                "start": 1629,
-                "end": 1643,
-                "loc": {
-                  "start": {
-                    "line": 75,
-                    "column": 2
-                  },
-                  "end": {
-                    "line": 75,
-                    "column": 16
-                  },
-                  "identifierName": "getFzpObsolete"
-                },
-                "name": "getFzpObsolete",
-                "leadingComments": null
-              },
-              "kind": "method",
-              "id": null,
-              "generator": false,
-              "expression": false,
-              "async": false,
-              "params": [
-                {
-                  "type": "Identifier",
-                  "start": 1644,
-                  "end": 1647,
-                  "loc": {
-                    "start": {
-                      "line": 75,
-                      "column": 17
-                    },
-                    "end": {
-                      "line": 75,
-                      "column": 20
-                    },
-                    "identifierName": "src"
-                  },
-                  "name": "src"
-                }
-              ],
-              "body": {
-                "type": "BlockStatement",
-                "start": 1649,
-                "end": 1777,
-                "loc": {
-                  "start": {
-                    "line": 75,
-                    "column": 22
-                  },
-                  "end": {
-                    "line": 80,
-                    "column": 3
-                  }
-                },
-                "body": [
-                  {
-                    "type": "ReturnStatement",
-                    "start": 1655,
-                    "end": 1773,
-                    "loc": {
-                      "start": {
-                        "line": 76,
-                        "column": 4
-                      },
-                      "end": {
-                        "line": 79,
-                        "column": 7
-                      }
-                    },
-                    "argument": {
-                      "type": "CallExpression",
-                      "start": 1662,
-                      "end": 1772,
-                      "loc": {
-                        "start": {
-                          "line": 76,
-                          "column": 11
-                        },
-                        "end": {
-                          "line": 79,
-                          "column": 6
-                        }
-                      },
-                      "callee": {
-                        "type": "MemberExpression",
-                        "start": 1662,
-                        "end": 1731,
-                        "loc": {
-                          "start": {
-                            "line": 76,
-                            "column": 11
-                          },
-                          "end": {
-                            "line": 77,
-                            "column": 9
-                          }
-                        },
-                        "object": {
-                          "type": "CallExpression",
-                          "start": 1662,
-                          "end": 1721,
-                          "loc": {
-                            "start": {
-                              "line": 76,
-                              "column": 11
-                            },
-                            "end": {
-                              "line": 76,
-                              "column": 70
-                            }
-                          },
-                          "callee": {
-                            "type": "MemberExpression",
-                            "start": 1662,
-                            "end": 1671,
-                            "loc": {
-                              "start": {
-                                "line": 76,
-                                "column": 11
-                              },
-                              "end": {
-                                "line": 76,
-                                "column": 20
-                              }
-                            },
-                            "object": {
-                              "type": "Identifier",
-                              "start": 1662,
-                              "end": 1667,
-                              "loc": {
-                                "start": {
-                                  "line": 76,
-                                  "column": 11
-                                },
-                                "end": {
-                                  "line": 76,
-                                  "column": 16
-                                },
-                                "identifierName": "axios"
-                              },
-                              "name": "axios"
-                            },
-                            "property": {
-                              "type": "Identifier",
-                              "start": 1668,
-                              "end": 1671,
-                              "loc": {
-                                "start": {
-                                  "line": 76,
-                                  "column": 17
-                                },
-                                "end": {
-                                  "line": 76,
-                                  "column": 20
-                                },
-                                "identifierName": "get"
-                              },
-                              "name": "get"
-                            },
-                            "computed": false
-                          },
-                          "arguments": [
-                            {
-                              "type": "BinaryExpression",
-                              "start": 1672,
-                              "end": 1697,
-                              "loc": {
-                                "start": {
-                                  "line": 76,
-                                  "column": 21
-                                },
-                                "end": {
-                                  "line": 76,
+                                  "line": 25,
                                   "column": 46
                                 }
                               },
-                              "left": {
-                                "type": "BinaryExpression",
-                                "start": 1672,
-                                "end": 1693,
-                                "loc": {
-                                  "start": {
-                                    "line": 76,
-                                    "column": 21
-                                  },
-                                  "end": {
-                                    "line": 76,
-                                    "column": 42
-                                  }
-                                },
-                                "left": {
-                                  "type": "MemberExpression",
-                                  "start": 1672,
-                                  "end": 1680,
-                                  "loc": {
-                                    "start": {
-                                      "line": 76,
-                                      "column": 21
-                                    },
-                                    "end": {
-                                      "line": 76,
-                                      "column": 29
-                                    }
-                                  },
-                                  "object": {
-                                    "type": "ThisExpression",
-                                    "start": 1672,
-                                    "end": 1676,
-                                    "loc": {
-                                      "start": {
-                                        "line": 76,
-                                        "column": 21
-                                      },
-                                      "end": {
-                                        "line": 76,
-                                        "column": 25
-                                      }
-                                    }
-                                  },
-                                  "property": {
-                                    "type": "Identifier",
-                                    "start": 1677,
-                                    "end": 1680,
-                                    "loc": {
-                                      "start": {
-                                        "line": 76,
-                                        "column": 26
-                                      },
-                                      "end": {
-                                        "line": 76,
-                                        "column": 29
-                                      },
-                                      "identifierName": "url"
-                                    },
-                                    "name": "url"
-                                  },
-                                  "computed": false
-                                },
-                                "operator": "+",
-                                "right": {
-                                  "type": "StringLiteral",
-                                  "start": 1681,
-                                  "end": 1693,
-                                  "loc": {
-                                    "start": {
-                                      "line": 76,
-                                      "column": 30
-                                    },
-                                    "end": {
-                                      "line": 76,
-                                      "column": 42
-                                    }
-                                  },
-                                  "extra": {
-                                    "rawValue": "/obsolete/",
-                                    "raw": "'/obsolete/'"
-                                  },
-                                  "value": "/obsolete/"
-                                }
-                              },
-                              "operator": "+",
-                              "right": {
-                                "type": "Identifier",
-                                "start": 1694,
-                                "end": 1697,
-                                "loc": {
-                                  "start": {
-                                    "line": 76,
-                                    "column": 43
-                                  },
-                                  "end": {
-                                    "line": 76,
-                                    "column": 46
-                                  },
-                                  "identifierName": "src"
-                                },
-                                "name": "src"
-                              }
-                            },
-                            {
-                              "type": "ObjectExpression",
-                              "start": 1699,
-                              "end": 1720,
-                              "loc": {
-                                "start": {
-                                  "line": 76,
-                                  "column": 48
-                                },
-                                "end": {
-                                  "line": 76,
-                                  "column": 69
-                                }
-                              },
                               "properties": [
                                 {
                                   "type": "ObjectProperty",
-                                  "start": 1700,
-                                  "end": 1719,
+                                  "start": 537,
+                                  "end": 557,
                                   "loc": {
                                     "start": {
-                                      "line": 76,
-                                      "column": 49
-                                    },
-                                    "end": {
-                                      "line": 76,
-                                      "column": 68
-                                    }
-                                  },
-                                  "method": false,
-                                  "shorthand": false,
-                                  "computed": false,
-                                  "key": {
-                                    "type": "Identifier",
-                                    "start": 1700,
-                                    "end": 1712,
-                                    "loc": {
-                                      "start": {
-                                        "line": 76,
-                                        "column": 49
-                                      },
-                                      "end": {
-                                        "line": 76,
-                                        "column": 61
-                                      },
-                                      "identifierName": "responseType"
-                                    },
-                                    "name": "responseType"
-                                  },
-                                  "value": {
-                                    "type": "StringLiteral",
-                                    "start": 1714,
-                                    "end": 1719,
-                                    "loc": {
-                                      "start": {
-                                        "line": 76,
-                                        "column": 63
-                                      },
-                                      "end": {
-                                        "line": 76,
-                                        "column": 68
-                                      }
-                                    },
-                                    "extra": {
-                                      "rawValue": "xml",
-                                      "raw": "'xml'"
-                                    },
-                                    "value": "xml"
-                                  }
-                                }
-                              ]
-                            }
-                          ]
-                        },
-                        "property": {
-                          "type": "Identifier",
-                          "start": 1727,
-                          "end": 1731,
-                          "loc": {
-                            "start": {
-                              "line": 77,
-                              "column": 5
-                            },
-                            "end": {
-                              "line": 77,
-                              "column": 9
-                            },
-                            "identifierName": "then"
-                          },
-                          "name": "then"
-                        },
-                        "computed": false
-                      },
-                      "arguments": [
-                        {
-                          "type": "ArrowFunctionExpression",
-                          "start": 1732,
-                          "end": 1771,
-                          "loc": {
-                            "start": {
-                              "line": 77,
-                              "column": 10
-                            },
-                            "end": {
-                              "line": 79,
-                              "column": 5
-                            }
-                          },
-                          "id": null,
-                          "generator": false,
-                          "expression": false,
-                          "async": false,
-                          "params": [
-                            {
-                              "type": "Identifier",
-                              "start": 1733,
-                              "end": 1736,
-                              "loc": {
-                                "start": {
-                                  "line": 77,
-                                  "column": 11
-                                },
-                                "end": {
-                                  "line": 77,
-                                  "column": 14
-                                },
-                                "identifierName": "res"
-                              },
-                              "name": "res"
-                            }
-                          ],
-                          "body": {
-                            "type": "BlockStatement",
-                            "start": 1741,
-                            "end": 1771,
-                            "loc": {
-                              "start": {
-                                "line": 77,
-                                "column": 19
-                              },
-                              "end": {
-                                "line": 79,
-                                "column": 5
-                              }
-                            },
-                            "body": [
-                              {
-                                "type": "ReturnStatement",
-                                "start": 1749,
-                                "end": 1765,
-                                "loc": {
-                                  "start": {
-                                    "line": 78,
-                                    "column": 6
-                                  },
-                                  "end": {
-                                    "line": 78,
-                                    "column": 22
-                                  }
-                                },
-                                "argument": {
-                                  "type": "MemberExpression",
-                                  "start": 1756,
-                                  "end": 1764,
-                                  "loc": {
-                                    "start": {
-                                      "line": 78,
-                                      "column": 13
-                                    },
-                                    "end": {
-                                      "line": 78,
-                                      "column": 21
-                                    }
-                                  },
-                                  "object": {
-                                    "type": "Identifier",
-                                    "start": 1756,
-                                    "end": 1759,
-                                    "loc": {
-                                      "start": {
-                                        "line": 78,
-                                        "column": 13
-                                      },
-                                      "end": {
-                                        "line": 78,
-                                        "column": 16
-                                      },
-                                      "identifierName": "res"
-                                    },
-                                    "name": "res"
-                                  },
-                                  "property": {
-                                    "type": "Identifier",
-                                    "start": 1760,
-                                    "end": 1764,
-                                    "loc": {
-                                      "start": {
-                                        "line": 78,
-                                        "column": 17
-                                      },
-                                      "end": {
-                                        "line": 78,
-                                        "column": 21
-                                      },
-                                      "identifierName": "data"
-                                    },
-                                    "name": "data"
-                                  },
-                                  "computed": false
-                                }
-                              }
-                            ],
-                            "directives": []
-                          }
-                        }
-                      ]
-                    }
-                  }
-                ],
-                "directives": [],
-                "trailingComments": null
-              },
-              "leadingComments": [
-                {
-                  "type": "CommentBlock",
-                  "value": "*\n   * Get a single part fzp from the obsolete parts, this is for old sketches only!\n   * @param  {String} src\n   * @return {Promise} the fetch promise returns xml\n   ",
-                  "start": 1455,
-                  "end": 1626,
-                  "loc": {
-                    "start": {
-                      "line": 70,
-                      "column": 2
-                    },
-                    "end": {
-                      "line": 74,
-                      "column": 5
-                    }
-                  }
-                }
-              ],
-              "trailingComments": [
-                {
-                  "type": "CommentBlock",
-                  "value": "*\n   * Get a single part svg and response the svg as a string\n   * @param  {String} src\n   * @return {Promise} the fetch promise\n   ",
-                  "start": 1782,
-                  "end": 1918,
-                  "loc": {
-                    "start": {
-                      "line": 83,
-                      "column": 2
-                    },
-                    "end": {
-                      "line": 87,
-                      "column": 5
-                    }
-                  }
-                }
-              ]
-            },
-            {
-              "type": "ClassMethod",
-              "start": 1922,
-              "end": 2062,
-              "loc": {
-                "start": {
-                  "line": 88,
-                  "column": 3
-                },
-                "end": {
-                  "line": 93,
-                  "column": 4
-                }
-              },
-              "static": false,
-              "computed": false,
-              "key": {
-                "type": "Identifier",
-                "start": 1922,
-                "end": 1928,
-                "loc": {
-                  "start": {
-                    "line": 88,
-                    "column": 3
-                  },
-                  "end": {
-                    "line": 88,
-                    "column": 9
-                  },
-                  "identifierName": "getSvg"
-                },
-                "name": "getSvg",
-                "leadingComments": null
-              },
-              "kind": "method",
-              "id": null,
-              "generator": false,
-              "expression": false,
-              "async": false,
-              "params": [
-                {
-                  "type": "Identifier",
-                  "start": 1929,
-                  "end": 1932,
-                  "loc": {
-                    "start": {
-                      "line": 88,
-                      "column": 10
-                    },
-                    "end": {
-                      "line": 88,
-                      "column": 13
-                    },
-                    "identifierName": "src"
-                  },
-                  "name": "src"
-                }
-              ],
-              "body": {
-                "type": "BlockStatement",
-                "start": 1934,
-                "end": 2062,
-                "loc": {
-                  "start": {
-                    "line": 88,
-                    "column": 15
-                  },
-                  "end": {
-                    "line": 93,
-                    "column": 4
-                  }
-                },
-                "body": [
-                  {
-                    "type": "ReturnStatement",
-                    "start": 1941,
-                    "end": 2057,
-                    "loc": {
-                      "start": {
-                        "line": 89,
-                        "column": 5
-                      },
-                      "end": {
-                        "line": 92,
-                        "column": 8
-                      }
-                    },
-                    "argument": {
-                      "type": "CallExpression",
-                      "start": 1948,
-                      "end": 2056,
-                      "loc": {
-                        "start": {
-                          "line": 89,
-                          "column": 12
-                        },
-                        "end": {
-                          "line": 92,
-                          "column": 7
-                        }
-                      },
-                      "callee": {
-                        "type": "MemberExpression",
-                        "start": 1948,
-                        "end": 2013,
-                        "loc": {
-                          "start": {
-                            "line": 89,
-                            "column": 12
-                          },
-                          "end": {
-                            "line": 90,
-                            "column": 10
-                          }
-                        },
-                        "object": {
-                          "type": "CallExpression",
-                          "start": 1948,
-                          "end": 2002,
-                          "loc": {
-                            "start": {
-                              "line": 89,
-                              "column": 12
-                            },
-                            "end": {
-                              "line": 89,
-                              "column": 66
-                            }
-                          },
-                          "callee": {
-                            "type": "MemberExpression",
-                            "start": 1948,
-                            "end": 1957,
-                            "loc": {
-                              "start": {
-                                "line": 89,
-                                "column": 12
-                              },
-                              "end": {
-                                "line": 89,
-                                "column": 21
-                              }
-                            },
-                            "object": {
-                              "type": "Identifier",
-                              "start": 1948,
-                              "end": 1953,
-                              "loc": {
-                                "start": {
-                                  "line": 89,
-                                  "column": 12
-                                },
-                                "end": {
-                                  "line": 89,
-                                  "column": 17
-                                },
-                                "identifierName": "axios"
-                              },
-                              "name": "axios"
-                            },
-                            "property": {
-                              "type": "Identifier",
-                              "start": 1954,
-                              "end": 1957,
-                              "loc": {
-                                "start": {
-                                  "line": 89,
-                                  "column": 18
-                                },
-                                "end": {
-                                  "line": 89,
-                                  "column": 21
-                                },
-                                "identifierName": "get"
-                              },
-                              "name": "get"
-                            },
-                            "computed": false
-                          },
-                          "arguments": [
-                            {
-                              "type": "BinaryExpression",
-                              "start": 1958,
-                              "end": 1978,
-                              "loc": {
-                                "start": {
-                                  "line": 89,
-                                  "column": 22
-                                },
-                                "end": {
-                                  "line": 89,
-                                  "column": 42
-                                }
-                              },
-                              "left": {
-                                "type": "BinaryExpression",
-                                "start": 1958,
-                                "end": 1974,
-                                "loc": {
-                                  "start": {
-                                    "line": 89,
-                                    "column": 22
-                                  },
-                                  "end": {
-                                    "line": 89,
-                                    "column": 38
-                                  }
-                                },
-                                "left": {
-                                  "type": "MemberExpression",
-                                  "start": 1958,
-                                  "end": 1966,
-                                  "loc": {
-                                    "start": {
-                                      "line": 89,
-                                      "column": 22
-                                    },
-                                    "end": {
-                                      "line": 89,
-                                      "column": 30
-                                    }
-                                  },
-                                  "object": {
-                                    "type": "ThisExpression",
-                                    "start": 1958,
-                                    "end": 1962,
-                                    "loc": {
-                                      "start": {
-                                        "line": 89,
-                                        "column": 22
-                                      },
-                                      "end": {
-                                        "line": 89,
-                                        "column": 26
-                                      }
-                                    }
-                                  },
-                                  "property": {
-                                    "type": "Identifier",
-                                    "start": 1963,
-                                    "end": 1966,
-                                    "loc": {
-                                      "start": {
-                                        "line": 89,
-                                        "column": 27
-                                      },
-                                      "end": {
-                                        "line": 89,
-                                        "column": 30
-                                      },
-                                      "identifierName": "url"
-                                    },
-                                    "name": "url"
-                                  },
-                                  "computed": false
-                                },
-                                "operator": "+",
-                                "right": {
-                                  "type": "StringLiteral",
-                                  "start": 1967,
-                                  "end": 1974,
-                                  "loc": {
-                                    "start": {
-                                      "line": 89,
-                                      "column": 31
-                                    },
-                                    "end": {
-                                      "line": 89,
-                                      "column": 38
-                                    }
-                                  },
-                                  "extra": {
-                                    "rawValue": "/svg/",
-                                    "raw": "'/svg/'"
-                                  },
-                                  "value": "/svg/"
-                                }
-                              },
-                              "operator": "+",
-                              "right": {
-                                "type": "Identifier",
-                                "start": 1975,
-                                "end": 1978,
-                                "loc": {
-                                  "start": {
-                                    "line": 89,
-                                    "column": 39
-                                  },
-                                  "end": {
-                                    "line": 89,
-                                    "column": 42
-                                  },
-                                  "identifierName": "src"
-                                },
-                                "name": "src"
-                              }
-                            },
-                            {
-                              "type": "ObjectExpression",
-                              "start": 1980,
-                              "end": 2001,
-                              "loc": {
-                                "start": {
-                                  "line": 89,
-                                  "column": 44
-                                },
-                                "end": {
-                                  "line": 89,
-                                  "column": 65
-                                }
-                              },
-                              "properties": [
-                                {
-                                  "type": "ObjectProperty",
-                                  "start": 1981,
-                                  "end": 2000,
-                                  "loc": {
-                                    "start": {
-                                      "line": 89,
-                                      "column": 45
-                                    },
-                                    "end": {
-                                      "line": 89,
-                                      "column": 64
-                                    }
-                                  },
-                                  "method": false,
-                                  "shorthand": false,
-                                  "computed": false,
-                                  "key": {
-                                    "type": "Identifier",
-                                    "start": 1981,
-                                    "end": 1993,
-                                    "loc": {
-                                      "start": {
-                                        "line": 89,
-                                        "column": 45
-                                      },
-                                      "end": {
-                                        "line": 89,
-                                        "column": 57
-                                      },
-                                      "identifierName": "responseType"
-                                    },
-                                    "name": "responseType"
-                                  },
-                                  "value": {
-                                    "type": "StringLiteral",
-                                    "start": 1995,
-                                    "end": 2000,
-                                    "loc": {
-                                      "start": {
-                                        "line": 89,
-                                        "column": 59
-                                      },
-                                      "end": {
-                                        "line": 89,
-                                        "column": 64
-                                      }
-                                    },
-                                    "extra": {
-                                      "rawValue": "xml",
-                                      "raw": "'xml'"
-                                    },
-                                    "value": "xml"
-                                  }
-                                }
-                              ]
-                            }
-                          ]
-                        },
-                        "property": {
-                          "type": "Identifier",
-                          "start": 2009,
-                          "end": 2013,
-                          "loc": {
-                            "start": {
-                              "line": 90,
-                              "column": 6
-                            },
-                            "end": {
-                              "line": 90,
-                              "column": 10
-                            },
-                            "identifierName": "then"
-                          },
-                          "name": "then"
-                        },
-                        "computed": false
-                      },
-                      "arguments": [
-                        {
-                          "type": "ArrowFunctionExpression",
-                          "start": 2014,
-                          "end": 2055,
-                          "loc": {
-                            "start": {
-                              "line": 90,
-                              "column": 11
-                            },
-                            "end": {
-                              "line": 92,
-                              "column": 6
-                            }
-                          },
-                          "id": null,
-                          "generator": false,
-                          "expression": false,
-                          "async": false,
-                          "params": [
-                            {
-                              "type": "Identifier",
-                              "start": 2015,
-                              "end": 2018,
-                              "loc": {
-                                "start": {
-                                  "line": 90,
-                                  "column": 12
-                                },
-                                "end": {
-                                  "line": 90,
-                                  "column": 15
-                                },
-                                "identifierName": "res"
-                              },
-                              "name": "res"
-                            }
-                          ],
-                          "body": {
-                            "type": "BlockStatement",
-                            "start": 2023,
-                            "end": 2055,
-                            "loc": {
-                              "start": {
-                                "line": 90,
-                                "column": 20
-                              },
-                              "end": {
-                                "line": 92,
-                                "column": 6
-                              }
-                            },
-                            "body": [
-                              {
-                                "type": "ReturnStatement",
-                                "start": 2032,
-                                "end": 2048,
-                                "loc": {
-                                  "start": {
-                                    "line": 91,
-                                    "column": 7
-                                  },
-                                  "end": {
-                                    "line": 91,
-                                    "column": 23
-                                  }
-                                },
-                                "argument": {
-                                  "type": "MemberExpression",
-                                  "start": 2039,
-                                  "end": 2047,
-                                  "loc": {
-                                    "start": {
-                                      "line": 91,
-                                      "column": 14
-                                    },
-                                    "end": {
-                                      "line": 91,
-                                      "column": 22
-                                    }
-                                  },
-                                  "object": {
-                                    "type": "Identifier",
-                                    "start": 2039,
-                                    "end": 2042,
-                                    "loc": {
-                                      "start": {
-                                        "line": 91,
-                                        "column": 14
-                                      },
-                                      "end": {
-                                        "line": 91,
-                                        "column": 17
-                                      },
-                                      "identifierName": "res"
-                                    },
-                                    "name": "res"
-                                  },
-                                  "property": {
-                                    "type": "Identifier",
-                                    "start": 2043,
-                                    "end": 2047,
-                                    "loc": {
-                                      "start": {
-                                        "line": 91,
-                                        "column": 18
-                                      },
-                                      "end": {
-                                        "line": 91,
-                                        "column": 22
-                                      },
-                                      "identifierName": "data"
-                                    },
-                                    "name": "data"
-                                  },
-                                  "computed": false
-                                }
-                              }
-                            ],
-                            "directives": []
-                          }
-                        }
-                      ]
-                    }
-                  }
-                ],
-                "directives": [],
-                "trailingComments": null
-              },
-              "leadingComments": [
-                {
-                  "type": "CommentBlock",
-                  "value": "*\n   * Get a single part svg and response the svg as a string\n   * @param  {String} src\n   * @return {Promise} the fetch promise\n   ",
-                  "start": 1782,
-                  "end": 1918,
-                  "loc": {
-                    "start": {
-                      "line": 83,
-                      "column": 2
-                    },
-                    "end": {
-                      "line": 87,
-                      "column": 5
-                    }
-                  }
-                }
-              ],
-              "trailingComments": [
-                {
-                  "type": "CommentBlock",
-                  "value": "*\n    * Get a single part svg from the core parts as svg-string\n    * @param  {String} src\n    * @return {Promise} the fetch promise returns xml\n    ",
-                  "start": 2066,
-                  "end": 2219,
-                  "loc": {
-                    "start": {
-                      "line": 94,
-                      "column": 3
-                    },
-                    "end": {
-                      "line": 98,
-                      "column": 6
-                    }
-                  }
-                }
-              ]
-            },
-            {
-              "type": "ClassMethod",
-              "start": 2222,
-              "end": 2366,
-              "loc": {
-                "start": {
-                  "line": 99,
-                  "column": 2
-                },
-                "end": {
-                  "line": 104,
-                  "column": 3
-                }
-              },
-              "static": false,
-              "computed": false,
-              "key": {
-                "type": "Identifier",
-                "start": 2222,
-                "end": 2232,
-                "loc": {
-                  "start": {
-                    "line": 99,
-                    "column": 2
-                  },
-                  "end": {
-                    "line": 99,
-                    "column": 12
-                  },
-                  "identifierName": "getSvgCore"
-                },
-                "name": "getSvgCore",
-                "leadingComments": null
-              },
-              "kind": "method",
-              "id": null,
-              "generator": false,
-              "expression": false,
-              "async": false,
-              "params": [
-                {
-                  "type": "Identifier",
-                  "start": 2233,
-                  "end": 2236,
-                  "loc": {
-                    "start": {
-                      "line": 99,
-                      "column": 13
-                    },
-                    "end": {
-                      "line": 99,
-                      "column": 16
-                    },
-                    "identifierName": "src"
-                  },
-                  "name": "src"
-                }
-              ],
-              "body": {
-                "type": "BlockStatement",
-                "start": 2238,
-                "end": 2366,
-                "loc": {
-                  "start": {
-                    "line": 99,
-                    "column": 18
-                  },
-                  "end": {
-                    "line": 104,
-                    "column": 3
-                  }
-                },
-                "body": [
-                  {
-                    "type": "ReturnStatement",
-                    "start": 2244,
-                    "end": 2362,
-                    "loc": {
-                      "start": {
-                        "line": 100,
-                        "column": 4
-                      },
-                      "end": {
-                        "line": 103,
-                        "column": 7
-                      }
-                    },
-                    "argument": {
-                      "type": "CallExpression",
-                      "start": 2251,
-                      "end": 2361,
-                      "loc": {
-                        "start": {
-                          "line": 100,
-                          "column": 11
-                        },
-                        "end": {
-                          "line": 103,
-                          "column": 6
-                        }
-                      },
-                      "callee": {
-                        "type": "MemberExpression",
-                        "start": 2251,
-                        "end": 2320,
-                        "loc": {
-                          "start": {
-                            "line": 100,
-                            "column": 11
-                          },
-                          "end": {
-                            "line": 101,
-                            "column": 9
-                          }
-                        },
-                        "object": {
-                          "type": "CallExpression",
-                          "start": 2251,
-                          "end": 2310,
-                          "loc": {
-                            "start": {
-                              "line": 100,
-                              "column": 11
-                            },
-                            "end": {
-                              "line": 100,
-                              "column": 70
-                            }
-                          },
-                          "callee": {
-                            "type": "MemberExpression",
-                            "start": 2251,
-                            "end": 2260,
-                            "loc": {
-                              "start": {
-                                "line": 100,
-                                "column": 11
-                              },
-                              "end": {
-                                "line": 100,
-                                "column": 20
-                              }
-                            },
-                            "object": {
-                              "type": "Identifier",
-                              "start": 2251,
-                              "end": 2256,
-                              "loc": {
-                                "start": {
-                                  "line": 100,
-                                  "column": 11
-                                },
-                                "end": {
-                                  "line": 100,
-                                  "column": 16
-                                },
-                                "identifierName": "axios"
-                              },
-                              "name": "axios"
-                            },
-                            "property": {
-                              "type": "Identifier",
-                              "start": 2257,
-                              "end": 2260,
-                              "loc": {
-                                "start": {
-                                  "line": 100,
-                                  "column": 17
-                                },
-                                "end": {
-                                  "line": 100,
-                                  "column": 20
-                                },
-                                "identifierName": "get"
-                              },
-                              "name": "get"
-                            },
-                            "computed": false
-                          },
-                          "arguments": [
-                            {
-                              "type": "BinaryExpression",
-                              "start": 2261,
-                              "end": 2286,
-                              "loc": {
-                                "start": {
-                                  "line": 100,
-                                  "column": 21
-                                },
-                                "end": {
-                                  "line": 100,
-                                  "column": 46
-                                }
-                              },
-                              "left": {
-                                "type": "BinaryExpression",
-                                "start": 2261,
-                                "end": 2282,
-                                "loc": {
-                                  "start": {
-                                    "line": 100,
-                                    "column": 21
-                                  },
-                                  "end": {
-                                    "line": 100,
-                                    "column": 42
-                                  }
-                                },
-                                "left": {
-                                  "type": "MemberExpression",
-                                  "start": 2261,
-                                  "end": 2269,
-                                  "loc": {
-                                    "start": {
-                                      "line": 100,
-                                      "column": 21
-                                    },
-                                    "end": {
-                                      "line": 100,
-                                      "column": 29
-                                    }
-                                  },
-                                  "object": {
-                                    "type": "ThisExpression",
-                                    "start": 2261,
-                                    "end": 2265,
-                                    "loc": {
-                                      "start": {
-                                        "line": 100,
-                                        "column": 21
-                                      },
-                                      "end": {
-                                        "line": 100,
-                                        "column": 25
-                                      }
-                                    }
-                                  },
-                                  "property": {
-                                    "type": "Identifier",
-                                    "start": 2266,
-                                    "end": 2269,
-                                    "loc": {
-                                      "start": {
-                                        "line": 100,
-                                        "column": 26
-                                      },
-                                      "end": {
-                                        "line": 100,
-                                        "column": 29
-                                      },
-                                      "identifierName": "url"
-                                    },
-                                    "name": "url"
-                                  },
-                                  "computed": false
-                                },
-                                "operator": "+",
-                                "right": {
-                                  "type": "StringLiteral",
-                                  "start": 2270,
-                                  "end": 2282,
-                                  "loc": {
-                                    "start": {
-                                      "line": 100,
-                                      "column": 30
-                                    },
-                                    "end": {
-                                      "line": 100,
-                                      "column": 42
-                                    }
-                                  },
-                                  "extra": {
-                                    "rawValue": "/svg/core/",
-                                    "raw": "'/svg/core/'"
-                                  },
-                                  "value": "/svg/core/"
-                                }
-                              },
-                              "operator": "+",
-                              "right": {
-                                "type": "Identifier",
-                                "start": 2283,
-                                "end": 2286,
-                                "loc": {
-                                  "start": {
-                                    "line": 100,
-                                    "column": 43
-                                  },
-                                  "end": {
-                                    "line": 100,
-                                    "column": 46
-                                  },
-                                  "identifierName": "src"
-                                },
-                                "name": "src"
-                              }
-                            },
-                            {
-                              "type": "ObjectExpression",
-                              "start": 2288,
-                              "end": 2309,
-                              "loc": {
-                                "start": {
-                                  "line": 100,
-                                  "column": 48
-                                },
-                                "end": {
-                                  "line": 100,
-                                  "column": 69
-                                }
-                              },
-                              "properties": [
-                                {
-                                  "type": "ObjectProperty",
-                                  "start": 2289,
-                                  "end": 2308,
-                                  "loc": {
-                                    "start": {
-                                      "line": 100,
-                                      "column": 49
-                                    },
-                                    "end": {
-                                      "line": 100,
-                                      "column": 68
-                                    }
-                                  },
-                                  "method": false,
-                                  "shorthand": false,
-                                  "computed": false,
-                                  "key": {
-                                    "type": "Identifier",
-                                    "start": 2289,
-                                    "end": 2301,
-                                    "loc": {
-                                      "start": {
-                                        "line": 100,
-                                        "column": 49
-                                      },
-                                      "end": {
-                                        "line": 100,
-                                        "column": 61
-                                      },
-                                      "identifierName": "responseType"
-                                    },
-                                    "name": "responseType"
-                                  },
-                                  "value": {
-                                    "type": "StringLiteral",
-                                    "start": 2303,
-                                    "end": 2308,
-                                    "loc": {
-                                      "start": {
-                                        "line": 100,
-                                        "column": 63
-                                      },
-                                      "end": {
-                                        "line": 100,
-                                        "column": 68
-                                      }
-                                    },
-                                    "extra": {
-                                      "rawValue": "xml",
-                                      "raw": "'xml'"
-                                    },
-                                    "value": "xml"
-                                  }
-                                }
-                              ]
-                            }
-                          ]
-                        },
-                        "property": {
-                          "type": "Identifier",
-                          "start": 2316,
-                          "end": 2320,
-                          "loc": {
-                            "start": {
-                              "line": 101,
-                              "column": 5
-                            },
-                            "end": {
-                              "line": 101,
-                              "column": 9
-                            },
-                            "identifierName": "then"
-                          },
-                          "name": "then"
-                        },
-                        "computed": false
-                      },
-                      "arguments": [
-                        {
-                          "type": "ArrowFunctionExpression",
-                          "start": 2321,
-                          "end": 2360,
-                          "loc": {
-                            "start": {
-                              "line": 101,
-                              "column": 10
-                            },
-                            "end": {
-                              "line": 103,
-                              "column": 5
-                            }
-                          },
-                          "id": null,
-                          "generator": false,
-                          "expression": false,
-                          "async": false,
-                          "params": [
-                            {
-                              "type": "Identifier",
-                              "start": 2322,
-                              "end": 2325,
-                              "loc": {
-                                "start": {
-                                  "line": 101,
-                                  "column": 11
-                                },
-                                "end": {
-                                  "line": 101,
-                                  "column": 14
-                                },
-                                "identifierName": "res"
-                              },
-                              "name": "res"
-                            }
-                          ],
-                          "body": {
-                            "type": "BlockStatement",
-                            "start": 2330,
-                            "end": 2360,
-                            "loc": {
-                              "start": {
-                                "line": 101,
-                                "column": 19
-                              },
-                              "end": {
-                                "line": 103,
-                                "column": 5
-                              }
-                            },
-                            "body": [
-                              {
-                                "type": "ReturnStatement",
-                                "start": 2338,
-                                "end": 2354,
-                                "loc": {
-                                  "start": {
-                                    "line": 102,
-                                    "column": 6
-                                  },
-                                  "end": {
-                                    "line": 102,
-                                    "column": 22
-                                  }
-                                },
-                                "argument": {
-                                  "type": "MemberExpression",
-                                  "start": 2345,
-                                  "end": 2353,
-                                  "loc": {
-                                    "start": {
-                                      "line": 102,
-                                      "column": 13
-                                    },
-                                    "end": {
-                                      "line": 102,
-                                      "column": 21
-                                    }
-                                  },
-                                  "object": {
-                                    "type": "Identifier",
-                                    "start": 2345,
-                                    "end": 2348,
-                                    "loc": {
-                                      "start": {
-                                        "line": 102,
-                                        "column": 13
-                                      },
-                                      "end": {
-                                        "line": 102,
-                                        "column": 16
-                                      },
-                                      "identifierName": "res"
-                                    },
-                                    "name": "res"
-                                  },
-                                  "property": {
-                                    "type": "Identifier",
-                                    "start": 2349,
-                                    "end": 2353,
-                                    "loc": {
-                                      "start": {
-                                        "line": 102,
-                                        "column": 17
-                                      },
-                                      "end": {
-                                        "line": 102,
-                                        "column": 21
-                                      },
-                                      "identifierName": "data"
-                                    },
-                                    "name": "data"
-                                  },
-                                  "computed": false
-                                }
-                              }
-                            ],
-                            "directives": []
-                          }
-                        }
-                      ]
-                    }
-                  }
-                ],
-                "directives": [],
-                "trailingComments": null
-              },
-              "leadingComments": [
-                {
-                  "type": "CommentBlock",
-                  "value": "*\n    * Get a single part svg from the core parts as svg-string\n    * @param  {String} src\n    * @return {Promise} the fetch promise returns xml\n    ",
-                  "start": 2066,
-                  "end": 2219,
-                  "loc": {
-                    "start": {
-                      "line": 94,
-                      "column": 3
-                    },
-                    "end": {
-                      "line": 98,
-                      "column": 6
-                    }
-                  }
-                }
-              ],
-              "trailingComments": [
-                {
-                  "type": "CommentBlock",
-                  "value": "*\n   * Get a single part svg from the obsolete svgs, this is for old-sketches only! the response is a svg-string\n   * @param  {String} src\n   * @return {Promise} the fetch promise\n   ",
-                  "start": 2369,
-                  "end": 2556,
-                  "loc": {
-                    "start": {
-                      "line": 105,
-                      "column": 2
-                    },
-                    "end": {
-                      "line": 109,
-                      "column": 5
-                    }
-                  }
-                }
-              ]
-            },
-            {
-              "type": "ClassMethod",
-              "start": 2559,
-              "end": 2711,
-              "loc": {
-                "start": {
-                  "line": 110,
-                  "column": 2
-                },
-                "end": {
-                  "line": 115,
-                  "column": 3
-                }
-              },
-              "static": false,
-              "computed": false,
-              "key": {
-                "type": "Identifier",
-                "start": 2559,
-                "end": 2573,
-                "loc": {
-                  "start": {
-                    "line": 110,
-                    "column": 2
-                  },
-                  "end": {
-                    "line": 110,
-                    "column": 16
-                  },
-                  "identifierName": "getSvgObsolete"
-                },
-                "name": "getSvgObsolete",
-                "leadingComments": null
-              },
-              "kind": "method",
-              "id": null,
-              "generator": false,
-              "expression": false,
-              "async": false,
-              "params": [
-                {
-                  "type": "Identifier",
-                  "start": 2574,
-                  "end": 2577,
-                  "loc": {
-                    "start": {
-                      "line": 110,
-                      "column": 17
-                    },
-                    "end": {
-                      "line": 110,
-                      "column": 20
-                    },
-                    "identifierName": "src"
-                  },
-                  "name": "src"
-                }
-              ],
-              "body": {
-                "type": "BlockStatement",
-                "start": 2579,
-                "end": 2711,
-                "loc": {
-                  "start": {
-                    "line": 110,
-                    "column": 22
-                  },
-                  "end": {
-                    "line": 115,
-                    "column": 3
-                  }
-                },
-                "body": [
-                  {
-                    "type": "ReturnStatement",
-                    "start": 2585,
-                    "end": 2707,
-                    "loc": {
-                      "start": {
-                        "line": 111,
-                        "column": 4
-                      },
-                      "end": {
-                        "line": 114,
-                        "column": 7
-                      }
-                    },
-                    "argument": {
-                      "type": "CallExpression",
-                      "start": 2592,
-                      "end": 2706,
-                      "loc": {
-                        "start": {
-                          "line": 111,
-                          "column": 11
-                        },
-                        "end": {
-                          "line": 114,
-                          "column": 6
-                        }
-                      },
-                      "callee": {
-                        "type": "MemberExpression",
-                        "start": 2592,
-                        "end": 2665,
-                        "loc": {
-                          "start": {
-                            "line": 111,
-                            "column": 11
-                          },
-                          "end": {
-                            "line": 112,
-                            "column": 9
-                          }
-                        },
-                        "object": {
-                          "type": "CallExpression",
-                          "start": 2592,
-                          "end": 2655,
-                          "loc": {
-                            "start": {
-                              "line": 111,
-                              "column": 11
-                            },
-                            "end": {
-                              "line": 111,
-                              "column": 74
-                            }
-                          },
-                          "callee": {
-                            "type": "MemberExpression",
-                            "start": 2592,
-                            "end": 2601,
-                            "loc": {
-                              "start": {
-                                "line": 111,
-                                "column": 11
-                              },
-                              "end": {
-                                "line": 111,
-                                "column": 20
-                              }
-                            },
-                            "object": {
-                              "type": "Identifier",
-                              "start": 2592,
-                              "end": 2597,
-                              "loc": {
-                                "start": {
-                                  "line": 111,
-                                  "column": 11
-                                },
-                                "end": {
-                                  "line": 111,
-                                  "column": 16
-                                },
-                                "identifierName": "axios"
-                              },
-                              "name": "axios"
-                            },
-                            "property": {
-                              "type": "Identifier",
-                              "start": 2598,
-                              "end": 2601,
-                              "loc": {
-                                "start": {
-                                  "line": 111,
-                                  "column": 17
-                                },
-                                "end": {
-                                  "line": 111,
-                                  "column": 20
-                                },
-                                "identifierName": "get"
-                              },
-                              "name": "get"
-                            },
-                            "computed": false
-                          },
-                          "arguments": [
-                            {
-                              "type": "BinaryExpression",
-                              "start": 2602,
-                              "end": 2631,
-                              "loc": {
-                                "start": {
-                                  "line": 111,
-                                  "column": 21
-                                },
-                                "end": {
-                                  "line": 111,
-                                  "column": 50
-                                }
-                              },
-                              "left": {
-                                "type": "BinaryExpression",
-                                "start": 2602,
-                                "end": 2627,
-                                "loc": {
-                                  "start": {
-                                    "line": 111,
-                                    "column": 21
-                                  },
-                                  "end": {
-                                    "line": 111,
-                                    "column": 46
-                                  }
-                                },
-                                "left": {
-                                  "type": "MemberExpression",
-                                  "start": 2602,
-                                  "end": 2610,
-                                  "loc": {
-                                    "start": {
-                                      "line": 111,
-                                      "column": 21
-                                    },
-                                    "end": {
-                                      "line": 111,
-                                      "column": 29
-                                    }
-                                  },
-                                  "object": {
-                                    "type": "ThisExpression",
-                                    "start": 2602,
-                                    "end": 2606,
-                                    "loc": {
-                                      "start": {
-                                        "line": 111,
-                                        "column": 21
-                                      },
-                                      "end": {
-                                        "line": 111,
-                                        "column": 25
-                                      }
-                                    }
-                                  },
-                                  "property": {
-                                    "type": "Identifier",
-                                    "start": 2607,
-                                    "end": 2610,
-                                    "loc": {
-                                      "start": {
-                                        "line": 111,
-                                        "column": 26
-                                      },
-                                      "end": {
-                                        "line": 111,
-                                        "column": 29
-                                      },
-                                      "identifierName": "url"
-                                    },
-                                    "name": "url"
-                                  },
-                                  "computed": false
-                                },
-                                "operator": "+",
-                                "right": {
-                                  "type": "StringLiteral",
-                                  "start": 2611,
-                                  "end": 2627,
-                                  "loc": {
-                                    "start": {
-                                      "line": 111,
-                                      "column": 30
-                                    },
-                                    "end": {
-                                      "line": 111,
-                                      "column": 46
-                                    }
-                                  },
-                                  "extra": {
-                                    "rawValue": "/svg/obsolete/",
-                                    "raw": "'/svg/obsolete/'"
-                                  },
-                                  "value": "/svg/obsolete/"
-                                }
-                              },
-                              "operator": "+",
-                              "right": {
-                                "type": "Identifier",
-                                "start": 2628,
-                                "end": 2631,
-                                "loc": {
-                                  "start": {
-                                    "line": 111,
-                                    "column": 47
-                                  },
-                                  "end": {
-                                    "line": 111,
-                                    "column": 50
-                                  },
-                                  "identifierName": "src"
-                                },
-                                "name": "src"
-                              }
-                            },
-                            {
-                              "type": "ObjectExpression",
-                              "start": 2633,
-                              "end": 2654,
-                              "loc": {
-                                "start": {
-                                  "line": 111,
-                                  "column": 52
-                                },
-                                "end": {
-                                  "line": 111,
-                                  "column": 73
-                                }
-                              },
-                              "properties": [
-                                {
-                                  "type": "ObjectProperty",
-                                  "start": 2634,
-                                  "end": 2653,
-                                  "loc": {
-                                    "start": {
-                                      "line": 111,
-                                      "column": 53
-                                    },
-                                    "end": {
-                                      "line": 111,
-                                      "column": 72
-                                    }
-                                  },
-                                  "method": false,
-                                  "shorthand": false,
-                                  "computed": false,
-                                  "key": {
-                                    "type": "Identifier",
-                                    "start": 2634,
-                                    "end": 2646,
-                                    "loc": {
-                                      "start": {
-                                        "line": 111,
-                                        "column": 53
-                                      },
-                                      "end": {
-                                        "line": 111,
-                                        "column": 65
-                                      },
-                                      "identifierName": "responseType"
-                                    },
-                                    "name": "responseType"
-                                  },
-                                  "value": {
-                                    "type": "StringLiteral",
-                                    "start": 2648,
-                                    "end": 2653,
-                                    "loc": {
-                                      "start": {
-                                        "line": 111,
-                                        "column": 67
-                                      },
-                                      "end": {
-                                        "line": 111,
-                                        "column": 72
-                                      }
-                                    },
-                                    "extra": {
-                                      "rawValue": "xml",
-                                      "raw": "'xml'"
-                                    },
-                                    "value": "xml"
-                                  }
-                                }
-                              ]
-                            }
-                          ]
-                        },
-                        "property": {
-                          "type": "Identifier",
-                          "start": 2661,
-                          "end": 2665,
-                          "loc": {
-                            "start": {
-                              "line": 112,
-                              "column": 5
-                            },
-                            "end": {
-                              "line": 112,
-                              "column": 9
-                            },
-                            "identifierName": "then"
-                          },
-                          "name": "then"
-                        },
-                        "computed": false
-                      },
-                      "arguments": [
-                        {
-                          "type": "ArrowFunctionExpression",
-                          "start": 2666,
-                          "end": 2705,
-                          "loc": {
-                            "start": {
-                              "line": 112,
-                              "column": 10
-                            },
-                            "end": {
-                              "line": 114,
-                              "column": 5
-                            }
-                          },
-                          "id": null,
-                          "generator": false,
-                          "expression": false,
-                          "async": false,
-                          "params": [
-                            {
-                              "type": "Identifier",
-                              "start": 2667,
-                              "end": 2670,
-                              "loc": {
-                                "start": {
-                                  "line": 112,
-                                  "column": 11
-                                },
-                                "end": {
-                                  "line": 112,
-                                  "column": 14
-                                },
-                                "identifierName": "res"
-                              },
-                              "name": "res"
-                            }
-                          ],
-                          "body": {
-                            "type": "BlockStatement",
-                            "start": 2675,
-                            "end": 2705,
-                            "loc": {
-                              "start": {
-                                "line": 112,
-                                "column": 19
-                              },
-                              "end": {
-                                "line": 114,
-                                "column": 5
-                              }
-                            },
-                            "body": [
-                              {
-                                "type": "ReturnStatement",
-                                "start": 2683,
-                                "end": 2699,
-                                "loc": {
-                                  "start": {
-                                    "line": 113,
-                                    "column": 6
-                                  },
-                                  "end": {
-                                    "line": 113,
-                                    "column": 22
-                                  }
-                                },
-                                "argument": {
-                                  "type": "MemberExpression",
-                                  "start": 2690,
-                                  "end": 2698,
-                                  "loc": {
-                                    "start": {
-                                      "line": 113,
-                                      "column": 13
-                                    },
-                                    "end": {
-                                      "line": 113,
-                                      "column": 21
-                                    }
-                                  },
-                                  "object": {
-                                    "type": "Identifier",
-                                    "start": 2690,
-                                    "end": 2693,
-                                    "loc": {
-                                      "start": {
-                                        "line": 113,
-                                        "column": 13
-                                      },
-                                      "end": {
-                                        "line": 113,
-                                        "column": 16
-                                      },
-                                      "identifierName": "res"
-                                    },
-                                    "name": "res"
-                                  },
-                                  "property": {
-                                    "type": "Identifier",
-                                    "start": 2694,
-                                    "end": 2698,
-                                    "loc": {
-                                      "start": {
-                                        "line": 113,
-                                        "column": 17
-                                      },
-                                      "end": {
-                                        "line": 113,
-                                        "column": 21
-                                      },
-                                      "identifierName": "data"
-                                    },
-                                    "name": "data"
-                                  },
-                                  "computed": false
-                                }
-                              }
-                            ],
-                            "directives": []
-                          }
-                        }
-                      ]
-                    }
-                  }
-                ],
-                "directives": [],
-                "trailingComments": null
-              },
-              "leadingComments": [
-                {
-                  "type": "CommentBlock",
-                  "value": "*\n   * Get a single part svg from the obsolete svgs, this is for old-sketches only! the response is a svg-string\n   * @param  {String} src\n   * @return {Promise} the fetch promise\n   ",
-                  "start": 2369,
-                  "end": 2556,
-                  "loc": {
-                    "start": {
-                      "line": 105,
-                      "column": 2
-                    },
-                    "end": {
-                      "line": 109,
-                      "column": 5
-                    }
-                  }
-                }
-              ],
-              "trailingComments": [
-                {
-                  "type": "CommentBlock",
-                  "value": "*\n   * Get a list of all FZB files\n   * @return {Promise}\n   ",
-                  "start": 2715,
-                  "end": 2780,
-                  "loc": {
-                    "start": {
-                      "line": 117,
-                      "column": 2
-                    },
-                    "end": {
-                      "line": 120,
-                      "column": 5
-                    }
-                  }
-                }
-              ]
-            },
-            {
-              "type": "ClassMethod",
-              "start": 2783,
-              "end": 2912,
-              "loc": {
-                "start": {
-                  "line": 121,
-                  "column": 2
-                },
-                "end": {
-                  "line": 126,
-                  "column": 3
-                }
-              },
-              "static": false,
-              "computed": false,
-              "key": {
-                "type": "Identifier",
-                "start": 2783,
-                "end": 2790,
-                "loc": {
-                  "start": {
-                    "line": 121,
-                    "column": 2
-                  },
-                  "end": {
-                    "line": 121,
-                    "column": 9
-                  },
-                  "identifierName": "getFzbs"
-                },
-                "name": "getFzbs",
-                "leadingComments": null
-              },
-              "kind": "method",
-              "id": null,
-              "generator": false,
-              "expression": false,
-              "async": false,
-              "params": [],
-              "body": {
-                "type": "BlockStatement",
-                "start": 2793,
-                "end": 2912,
-                "loc": {
-                  "start": {
-                    "line": 121,
-                    "column": 12
-                  },
-                  "end": {
-                    "line": 126,
-                    "column": 3
-                  }
-                },
-                "body": [
-                  {
-                    "type": "ReturnStatement",
-                    "start": 2799,
-                    "end": 2908,
-                    "loc": {
-                      "start": {
-                        "line": 122,
-                        "column": 4
-                      },
-                      "end": {
-                        "line": 125,
-                        "column": 7
-                      }
-                    },
-                    "argument": {
-                      "type": "CallExpression",
-                      "start": 2806,
-                      "end": 2907,
-                      "loc": {
-                        "start": {
-                          "line": 122,
-                          "column": 11
-                        },
-                        "end": {
-                          "line": 125,
-                          "column": 6
-                        }
-                      },
-                      "callee": {
-                        "type": "MemberExpression",
-                        "start": 2806,
-                        "end": 2866,
-                        "loc": {
-                          "start": {
-                            "line": 122,
-                            "column": 11
-                          },
-                          "end": {
-                            "line": 123,
-                            "column": 9
-                          }
-                        },
-                        "object": {
-                          "type": "CallExpression",
-                          "start": 2806,
-                          "end": 2856,
-                          "loc": {
-                            "start": {
-                              "line": 122,
-                              "column": 11
-                            },
-                            "end": {
-                              "line": 122,
-                              "column": 61
-                            }
-                          },
-                          "callee": {
-                            "type": "MemberExpression",
-                            "start": 2806,
-                            "end": 2815,
-                            "loc": {
-                              "start": {
-                                "line": 122,
-                                "column": 11
-                              },
-                              "end": {
-                                "line": 122,
-                                "column": 20
-                              }
-                            },
-                            "object": {
-                              "type": "Identifier",
-                              "start": 2806,
-                              "end": 2811,
-                              "loc": {
-                                "start": {
-                                  "line": 122,
-                                  "column": 11
-                                },
-                                "end": {
-                                  "line": 122,
-                                  "column": 16
-                                },
-                                "identifierName": "axios"
-                              },
-                              "name": "axios"
-                            },
-                            "property": {
-                              "type": "Identifier",
-                              "start": 2812,
-                              "end": 2815,
-                              "loc": {
-                                "start": {
-                                  "line": 122,
-                                  "column": 17
-                                },
-                                "end": {
-                                  "line": 122,
-                                  "column": 20
-                                },
-                                "identifierName": "get"
-                              },
-                              "name": "get"
-                            },
-                            "computed": false
-                          },
-                          "arguments": [
-                            {
-                              "type": "BinaryExpression",
-                              "start": 2816,
-                              "end": 2831,
-                              "loc": {
-                                "start": {
-                                  "line": 122,
-                                  "column": 21
-                                },
-                                "end": {
-                                  "line": 122,
-                                  "column": 36
-                                }
-                              },
-                              "left": {
-                                "type": "MemberExpression",
-                                "start": 2816,
-                                "end": 2824,
-                                "loc": {
-                                  "start": {
-                                    "line": 122,
-                                    "column": 21
-                                  },
-                                  "end": {
-                                    "line": 122,
-                                    "column": 29
-                                  }
-                                },
-                                "object": {
-                                  "type": "ThisExpression",
-                                  "start": 2816,
-                                  "end": 2820,
-                                  "loc": {
-                                    "start": {
-                                      "line": 122,
-                                      "column": 21
-                                    },
-                                    "end": {
-                                      "line": 122,
+                                      "line": 25,
                                       "column": 25
-                                    }
-                                  }
-                                },
-                                "property": {
-                                  "type": "Identifier",
-                                  "start": 2821,
-                                  "end": 2824,
-                                  "loc": {
-                                    "start": {
-                                      "line": 122,
-                                      "column": 26
                                     },
                                     "end": {
-                                      "line": 122,
-                                      "column": 29
-                                    },
-                                    "identifierName": "url"
-                                  },
-                                  "name": "url"
-                                },
-                                "computed": false
-                              },
-                              "operator": "+",
-                              "right": {
-                                "type": "StringLiteral",
-                                "start": 2825,
-                                "end": 2831,
-                                "loc": {
-                                  "start": {
-                                    "line": 122,
-                                    "column": 30
-                                  },
-                                  "end": {
-                                    "line": 122,
-                                    "column": 36
-                                  }
-                                },
-                                "extra": {
-                                  "rawValue": "/fzb",
-                                  "raw": "'/fzb'"
-                                },
-                                "value": "/fzb"
-                              }
-                            },
-                            {
-                              "type": "ObjectExpression",
-                              "start": 2833,
-                              "end": 2855,
-                              "loc": {
-                                "start": {
-                                  "line": 122,
-                                  "column": 38
-                                },
-                                "end": {
-                                  "line": 122,
-                                  "column": 60
-                                }
-                              },
-                              "properties": [
-                                {
-                                  "type": "ObjectProperty",
-                                  "start": 2834,
-                                  "end": 2854,
-                                  "loc": {
-                                    "start": {
-                                      "line": 122,
-                                      "column": 39
-                                    },
-                                    "end": {
-                                      "line": 122,
-                                      "column": 59
+                                      "line": 25,
+                                      "column": 45
                                     }
                                   },
                                   "method": false,
@@ -5524,33 +623,33 @@
                                   "computed": false,
                                   "key": {
                                     "type": "Identifier",
-                                    "start": 2834,
-                                    "end": 2846,
+                                    "start": 537,
+                                    "end": 549,
                                     "loc": {
                                       "start": {
-                                        "line": 122,
+                                        "line": 25,
+                                        "column": 25
+                                      },
+                                      "end": {
+                                        "line": 25,
+                                        "column": 37
+                                      },
+                                      "identifierName": "responseType"
+                                    },
+                                    "name": "responseType"
+                                  },
+                                  "value": {
+                                    "type": "StringLiteral",
+                                    "start": 551,
+                                    "end": 557,
+                                    "loc": {
+                                      "start": {
+                                        "line": 25,
                                         "column": 39
                                       },
                                       "end": {
-                                        "line": 122,
-                                        "column": 51
-                                      },
-                                      "identifierName": "responseType"
-                                    },
-                                    "name": "responseType"
-                                  },
-                                  "value": {
-                                    "type": "StringLiteral",
-                                    "start": 2848,
-                                    "end": 2854,
-                                    "loc": {
-                                      "start": {
-                                        "line": 122,
-                                        "column": 53
-                                      },
-                                      "end": {
-                                        "line": 122,
-                                        "column": 59
+                                        "line": 25,
+                                        "column": 45
                                       }
                                     },
                                     "extra": {
@@ -5566,16 +665,16 @@
                         },
                         "property": {
                           "type": "Identifier",
-                          "start": 2862,
-                          "end": 2866,
+                          "start": 563,
+                          "end": 567,
                           "loc": {
                             "start": {
-                              "line": 123,
-                              "column": 5
+                              "line": 26,
+                              "column": 3
                             },
                             "end": {
-                              "line": 123,
-                              "column": 9
+                              "line": 26,
+                              "column": 7
                             },
                             "identifierName": "then"
                           },
@@ -5586,16 +685,16 @@
                       "arguments": [
                         {
                           "type": "ArrowFunctionExpression",
-                          "start": 2867,
-                          "end": 2906,
+                          "start": 568,
+                          "end": 620,
                           "loc": {
                             "start": {
-                              "line": 123,
-                              "column": 10
+                              "line": 26,
+                              "column": 8
                             },
                             "end": {
-                              "line": 125,
-                              "column": 5
+                              "line": 28,
+                              "column": 3
                             }
                           },
                           "id": null,
@@ -5605,16 +704,16 @@
                           "params": [
                             {
                               "type": "Identifier",
-                              "start": 2868,
-                              "end": 2871,
+                              "start": 569,
+                              "end": 572,
                               "loc": {
                                 "start": {
-                                  "line": 123,
-                                  "column": 11
+                                  "line": 26,
+                                  "column": 9
                                 },
                                 "end": {
-                                  "line": 123,
-                                  "column": 14
+                                  "line": 26,
+                                  "column": 12
                                 },
                                 "identifierName": "res"
                               },
@@ -5623,82 +722,149 @@
                           ],
                           "body": {
                             "type": "BlockStatement",
-                            "start": 2876,
-                            "end": 2906,
+                            "start": 577,
+                            "end": 620,
                             "loc": {
                               "start": {
-                                "line": 123,
-                                "column": 19
+                                "line": 26,
+                                "column": 17
                               },
                               "end": {
-                                "line": 125,
-                                "column": 5
+                                "line": 28,
+                                "column": 3
                               }
                             },
                             "body": [
                               {
                                 "type": "ReturnStatement",
-                                "start": 2884,
-                                "end": 2900,
+                                "start": 583,
+                                "end": 616,
                                 "loc": {
                                   "start": {
-                                    "line": 124,
-                                    "column": 6
+                                    "line": 27,
+                                    "column": 4
                                   },
                                   "end": {
-                                    "line": 124,
-                                    "column": 22
+                                    "line": 27,
+                                    "column": 37
                                   }
                                 },
                                 "argument": {
-                                  "type": "MemberExpression",
-                                  "start": 2891,
-                                  "end": 2899,
+                                  "type": "CallExpression",
+                                  "start": 590,
+                                  "end": 615,
                                   "loc": {
                                     "start": {
-                                      "line": 124,
-                                      "column": 13
+                                      "line": 27,
+                                      "column": 11
                                     },
                                     "end": {
-                                      "line": 124,
-                                      "column": 21
+                                      "line": 27,
+                                      "column": 36
                                     }
                                   },
-                                  "object": {
-                                    "type": "Identifier",
-                                    "start": 2891,
-                                    "end": 2894,
+                                  "callee": {
+                                    "type": "MemberExpression",
+                                    "start": 590,
+                                    "end": 605,
                                     "loc": {
                                       "start": {
-                                        "line": 124,
-                                        "column": 13
+                                        "line": 27,
+                                        "column": 11
                                       },
                                       "end": {
-                                        "line": 124,
-                                        "column": 16
-                                      },
-                                      "identifierName": "res"
+                                        "line": 27,
+                                        "column": 26
+                                      }
                                     },
-                                    "name": "res"
-                                  },
-                                  "property": {
-                                    "type": "Identifier",
-                                    "start": 2895,
-                                    "end": 2899,
-                                    "loc": {
-                                      "start": {
-                                        "line": 124,
-                                        "column": 17
+                                    "object": {
+                                      "type": "Identifier",
+                                      "start": 590,
+                                      "end": 597,
+                                      "loc": {
+                                        "start": {
+                                          "line": 27,
+                                          "column": 11
+                                        },
+                                        "end": {
+                                          "line": 27,
+                                          "column": 18
+                                        },
+                                        "identifierName": "Promise"
                                       },
-                                      "end": {
-                                        "line": 124,
-                                        "column": 21
-                                      },
-                                      "identifierName": "data"
+                                      "name": "Promise"
                                     },
-                                    "name": "data"
+                                    "property": {
+                                      "type": "Identifier",
+                                      "start": 598,
+                                      "end": 605,
+                                      "loc": {
+                                        "start": {
+                                          "line": 27,
+                                          "column": 19
+                                        },
+                                        "end": {
+                                          "line": 27,
+                                          "column": 26
+                                        },
+                                        "identifierName": "resolve"
+                                      },
+                                      "name": "resolve"
+                                    },
+                                    "computed": false
                                   },
-                                  "computed": false
+                                  "arguments": [
+                                    {
+                                      "type": "MemberExpression",
+                                      "start": 606,
+                                      "end": 614,
+                                      "loc": {
+                                        "start": {
+                                          "line": 27,
+                                          "column": 27
+                                        },
+                                        "end": {
+                                          "line": 27,
+                                          "column": 35
+                                        }
+                                      },
+                                      "object": {
+                                        "type": "Identifier",
+                                        "start": 606,
+                                        "end": 609,
+                                        "loc": {
+                                          "start": {
+                                            "line": 27,
+                                            "column": 27
+                                          },
+                                          "end": {
+                                            "line": 27,
+                                            "column": 30
+                                          },
+                                          "identifierName": "res"
+                                        },
+                                        "name": "res"
+                                      },
+                                      "property": {
+                                        "type": "Identifier",
+                                        "start": 610,
+                                        "end": 614,
+                                        "loc": {
+                                          "start": {
+                                            "line": 27,
+                                            "column": 31
+                                          },
+                                          "end": {
+                                            "line": 27,
+                                            "column": 35
+                                          },
+                                          "identifierName": "data"
+                                        },
+                                        "name": "data"
+                                      },
+                                      "computed": false
+                                    }
+                                  ]
                                 }
                               }
                             ],
@@ -5710,41 +876,43 @@
                   }
                 ],
                 "directives": []
-              },
-              "leadingComments": [
-                {
-                  "type": "CommentBlock",
-                  "value": "*\n   * Get a list of all FZB files\n   * @return {Promise}\n   ",
-                  "start": 2715,
-                  "end": 2780,
-                  "loc": {
-                    "start": {
-                      "line": 117,
-                      "column": 2
-                    },
-                    "end": {
-                      "line": 120,
-                      "column": 5
-                    }
-                  }
-                }
-              ]
-            }
-          ]
-        },
+              }
+            },
+            "leadingComments": null
+          }
+        ],
+        "kind": "const",
         "leadingComments": [
           {
             "type": "CommentBlock",
-            "value": "*\n * Fritzing Parts API Client\n ",
-            "start": 48,
-            "end": 84,
+            "value": "*\n * Get a list of all FZP files\n *\n * @type   {Function}\n * @param  {String} url - The base URL of the parts api\n * @return {Promise}\n ",
+            "start": 311,
+            "end": 451,
             "loc": {
               "start": {
-                "line": 5,
+                "line": 17,
                 "column": 0
               },
               "end": {
-                "line": 7,
+                "line": 23,
+                "column": 3
+              }
+            }
+          }
+        ],
+        "trailingComments": [
+          {
+            "type": "CommentBlock",
+            "value": "*\n * Get a list of all Core-FZP files\n *\n * @param  {String} url - The base URL of the parts api\n * @return {Promise}\n ",
+            "start": 627,
+            "end": 750,
+            "loc": {
+              "start": {
+                "line": 31,
+                "column": 0
+              },
+              "end": {
+                "line": 36,
                 "column": 3
               }
             }
@@ -5752,59 +920,6969 @@
         ]
       },
       {
-        "type": "ExpressionStatement",
-        "start": 2916,
-        "end": 2943,
+        "type": "VariableDeclaration",
+        "start": 751,
+        "end": 933,
         "loc": {
           "start": {
-            "line": 129,
+            "line": 37,
             "column": 0
           },
           "end": {
-            "line": 129,
-            "column": 27
+            "line": 42,
+            "column": 2
+          }
+        },
+        "declarations": [
+          {
+            "type": "VariableDeclarator",
+            "start": 757,
+            "end": 932,
+            "loc": {
+              "start": {
+                "line": 37,
+                "column": 6
+              },
+              "end": {
+                "line": 42,
+                "column": 1
+              }
+            },
+            "id": {
+              "type": "Identifier",
+              "start": 757,
+              "end": 768,
+              "loc": {
+                "start": {
+                  "line": 37,
+                  "column": 6
+                },
+                "end": {
+                  "line": 37,
+                  "column": 17
+                },
+                "identifierName": "getFzpsCore"
+              },
+              "name": "getFzpsCore",
+              "leadingComments": null
+            },
+            "init": {
+              "type": "FunctionExpression",
+              "start": 771,
+              "end": 932,
+              "loc": {
+                "start": {
+                  "line": 37,
+                  "column": 20
+                },
+                "end": {
+                  "line": 42,
+                  "column": 1
+                }
+              },
+              "id": {
+                "type": "Identifier",
+                "start": 757,
+                "end": 768,
+                "loc": {
+                  "start": {
+                    "line": 37,
+                    "column": 6
+                  },
+                  "end": {
+                    "line": 37,
+                    "column": 17
+                  },
+                  "identifierName": "getFzpsCore"
+                },
+                "name": "getFzpsCore",
+                "leadingComments": null
+              },
+              "generator": false,
+              "expression": false,
+              "async": false,
+              "params": [
+                {
+                  "type": "AssignmentPattern",
+                  "start": 780,
+                  "end": 816,
+                  "loc": {
+                    "start": {
+                      "line": 37,
+                      "column": 29
+                    },
+                    "end": {
+                      "line": 37,
+                      "column": 65
+                    }
+                  },
+                  "left": {
+                    "type": "Identifier",
+                    "start": 780,
+                    "end": 783,
+                    "loc": {
+                      "start": {
+                        "line": 37,
+                        "column": 29
+                      },
+                      "end": {
+                        "line": 37,
+                        "column": 32
+                      },
+                      "identifierName": "url"
+                    },
+                    "name": "url"
+                  },
+                  "right": {
+                    "type": "TemplateLiteral",
+                    "start": 786,
+                    "end": 816,
+                    "loc": {
+                      "start": {
+                        "line": 37,
+                        "column": 35
+                      },
+                      "end": {
+                        "line": 37,
+                        "column": 65
+                      }
+                    },
+                    "expressions": [
+                      {
+                        "type": "Identifier",
+                        "start": 789,
+                        "end": 805,
+                        "loc": {
+                          "start": {
+                            "line": 37,
+                            "column": 38
+                          },
+                          "end": {
+                            "line": 37,
+                            "column": 54
+                          },
+                          "identifierName": "FritzingPartsAPI"
+                        },
+                        "name": "FritzingPartsAPI"
+                      }
+                    ],
+                    "quasis": [
+                      {
+                        "type": "TemplateElement",
+                        "start": 787,
+                        "end": 787,
+                        "loc": {
+                          "start": {
+                            "line": 37,
+                            "column": 36
+                          },
+                          "end": {
+                            "line": 37,
+                            "column": 36
+                          }
+                        },
+                        "value": {
+                          "raw": "",
+                          "cooked": ""
+                        },
+                        "tail": false
+                      },
+                      {
+                        "type": "TemplateElement",
+                        "start": 806,
+                        "end": 815,
+                        "loc": {
+                          "start": {
+                            "line": 37,
+                            "column": 55
+                          },
+                          "end": {
+                            "line": 37,
+                            "column": 64
+                          }
+                        },
+                        "value": {
+                          "raw": "/fzp/core",
+                          "cooked": "/fzp/core"
+                        },
+                        "tail": true
+                      }
+                    ]
+                  }
+                }
+              ],
+              "body": {
+                "type": "BlockStatement",
+                "start": 818,
+                "end": 932,
+                "loc": {
+                  "start": {
+                    "line": 37,
+                    "column": 67
+                  },
+                  "end": {
+                    "line": 42,
+                    "column": 1
+                  }
+                },
+                "body": [
+                  {
+                    "type": "ReturnStatement",
+                    "start": 822,
+                    "end": 930,
+                    "loc": {
+                      "start": {
+                        "line": 38,
+                        "column": 2
+                      },
+                      "end": {
+                        "line": 41,
+                        "column": 5
+                      }
+                    },
+                    "argument": {
+                      "type": "CallExpression",
+                      "start": 829,
+                      "end": 929,
+                      "loc": {
+                        "start": {
+                          "line": 38,
+                          "column": 9
+                        },
+                        "end": {
+                          "line": 41,
+                          "column": 4
+                        }
+                      },
+                      "callee": {
+                        "type": "MemberExpression",
+                        "start": 829,
+                        "end": 875,
+                        "loc": {
+                          "start": {
+                            "line": 38,
+                            "column": 9
+                          },
+                          "end": {
+                            "line": 39,
+                            "column": 7
+                          }
+                        },
+                        "object": {
+                          "type": "CallExpression",
+                          "start": 829,
+                          "end": 867,
+                          "loc": {
+                            "start": {
+                              "line": 38,
+                              "column": 9
+                            },
+                            "end": {
+                              "line": 38,
+                              "column": 47
+                            }
+                          },
+                          "callee": {
+                            "type": "MemberExpression",
+                            "start": 829,
+                            "end": 838,
+                            "loc": {
+                              "start": {
+                                "line": 38,
+                                "column": 9
+                              },
+                              "end": {
+                                "line": 38,
+                                "column": 18
+                              }
+                            },
+                            "object": {
+                              "type": "Identifier",
+                              "start": 829,
+                              "end": 834,
+                              "loc": {
+                                "start": {
+                                  "line": 38,
+                                  "column": 9
+                                },
+                                "end": {
+                                  "line": 38,
+                                  "column": 14
+                                },
+                                "identifierName": "axios"
+                              },
+                              "name": "axios"
+                            },
+                            "property": {
+                              "type": "Identifier",
+                              "start": 835,
+                              "end": 838,
+                              "loc": {
+                                "start": {
+                                  "line": 38,
+                                  "column": 15
+                                },
+                                "end": {
+                                  "line": 38,
+                                  "column": 18
+                                },
+                                "identifierName": "get"
+                              },
+                              "name": "get"
+                            },
+                            "computed": false
+                          },
+                          "arguments": [
+                            {
+                              "type": "Identifier",
+                              "start": 839,
+                              "end": 842,
+                              "loc": {
+                                "start": {
+                                  "line": 38,
+                                  "column": 19
+                                },
+                                "end": {
+                                  "line": 38,
+                                  "column": 22
+                                },
+                                "identifierName": "url"
+                              },
+                              "name": "url"
+                            },
+                            {
+                              "type": "ObjectExpression",
+                              "start": 844,
+                              "end": 866,
+                              "loc": {
+                                "start": {
+                                  "line": 38,
+                                  "column": 24
+                                },
+                                "end": {
+                                  "line": 38,
+                                  "column": 46
+                                }
+                              },
+                              "properties": [
+                                {
+                                  "type": "ObjectProperty",
+                                  "start": 845,
+                                  "end": 865,
+                                  "loc": {
+                                    "start": {
+                                      "line": 38,
+                                      "column": 25
+                                    },
+                                    "end": {
+                                      "line": 38,
+                                      "column": 45
+                                    }
+                                  },
+                                  "method": false,
+                                  "shorthand": false,
+                                  "computed": false,
+                                  "key": {
+                                    "type": "Identifier",
+                                    "start": 845,
+                                    "end": 857,
+                                    "loc": {
+                                      "start": {
+                                        "line": 38,
+                                        "column": 25
+                                      },
+                                      "end": {
+                                        "line": 38,
+                                        "column": 37
+                                      },
+                                      "identifierName": "responseType"
+                                    },
+                                    "name": "responseType"
+                                  },
+                                  "value": {
+                                    "type": "StringLiteral",
+                                    "start": 859,
+                                    "end": 865,
+                                    "loc": {
+                                      "start": {
+                                        "line": 38,
+                                        "column": 39
+                                      },
+                                      "end": {
+                                        "line": 38,
+                                        "column": 45
+                                      }
+                                    },
+                                    "extra": {
+                                      "rawValue": "json",
+                                      "raw": "'json'"
+                                    },
+                                    "value": "json"
+                                  }
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        "property": {
+                          "type": "Identifier",
+                          "start": 871,
+                          "end": 875,
+                          "loc": {
+                            "start": {
+                              "line": 39,
+                              "column": 3
+                            },
+                            "end": {
+                              "line": 39,
+                              "column": 7
+                            },
+                            "identifierName": "then"
+                          },
+                          "name": "then"
+                        },
+                        "computed": false
+                      },
+                      "arguments": [
+                        {
+                          "type": "ArrowFunctionExpression",
+                          "start": 876,
+                          "end": 928,
+                          "loc": {
+                            "start": {
+                              "line": 39,
+                              "column": 8
+                            },
+                            "end": {
+                              "line": 41,
+                              "column": 3
+                            }
+                          },
+                          "id": null,
+                          "generator": false,
+                          "expression": false,
+                          "async": false,
+                          "params": [
+                            {
+                              "type": "Identifier",
+                              "start": 877,
+                              "end": 880,
+                              "loc": {
+                                "start": {
+                                  "line": 39,
+                                  "column": 9
+                                },
+                                "end": {
+                                  "line": 39,
+                                  "column": 12
+                                },
+                                "identifierName": "res"
+                              },
+                              "name": "res"
+                            }
+                          ],
+                          "body": {
+                            "type": "BlockStatement",
+                            "start": 885,
+                            "end": 928,
+                            "loc": {
+                              "start": {
+                                "line": 39,
+                                "column": 17
+                              },
+                              "end": {
+                                "line": 41,
+                                "column": 3
+                              }
+                            },
+                            "body": [
+                              {
+                                "type": "ReturnStatement",
+                                "start": 891,
+                                "end": 924,
+                                "loc": {
+                                  "start": {
+                                    "line": 40,
+                                    "column": 4
+                                  },
+                                  "end": {
+                                    "line": 40,
+                                    "column": 37
+                                  }
+                                },
+                                "argument": {
+                                  "type": "CallExpression",
+                                  "start": 898,
+                                  "end": 923,
+                                  "loc": {
+                                    "start": {
+                                      "line": 40,
+                                      "column": 11
+                                    },
+                                    "end": {
+                                      "line": 40,
+                                      "column": 36
+                                    }
+                                  },
+                                  "callee": {
+                                    "type": "MemberExpression",
+                                    "start": 898,
+                                    "end": 913,
+                                    "loc": {
+                                      "start": {
+                                        "line": 40,
+                                        "column": 11
+                                      },
+                                      "end": {
+                                        "line": 40,
+                                        "column": 26
+                                      }
+                                    },
+                                    "object": {
+                                      "type": "Identifier",
+                                      "start": 898,
+                                      "end": 905,
+                                      "loc": {
+                                        "start": {
+                                          "line": 40,
+                                          "column": 11
+                                        },
+                                        "end": {
+                                          "line": 40,
+                                          "column": 18
+                                        },
+                                        "identifierName": "Promise"
+                                      },
+                                      "name": "Promise"
+                                    },
+                                    "property": {
+                                      "type": "Identifier",
+                                      "start": 906,
+                                      "end": 913,
+                                      "loc": {
+                                        "start": {
+                                          "line": 40,
+                                          "column": 19
+                                        },
+                                        "end": {
+                                          "line": 40,
+                                          "column": 26
+                                        },
+                                        "identifierName": "resolve"
+                                      },
+                                      "name": "resolve"
+                                    },
+                                    "computed": false
+                                  },
+                                  "arguments": [
+                                    {
+                                      "type": "MemberExpression",
+                                      "start": 914,
+                                      "end": 922,
+                                      "loc": {
+                                        "start": {
+                                          "line": 40,
+                                          "column": 27
+                                        },
+                                        "end": {
+                                          "line": 40,
+                                          "column": 35
+                                        }
+                                      },
+                                      "object": {
+                                        "type": "Identifier",
+                                        "start": 914,
+                                        "end": 917,
+                                        "loc": {
+                                          "start": {
+                                            "line": 40,
+                                            "column": 27
+                                          },
+                                          "end": {
+                                            "line": 40,
+                                            "column": 30
+                                          },
+                                          "identifierName": "res"
+                                        },
+                                        "name": "res"
+                                      },
+                                      "property": {
+                                        "type": "Identifier",
+                                        "start": 918,
+                                        "end": 922,
+                                        "loc": {
+                                          "start": {
+                                            "line": 40,
+                                            "column": 31
+                                          },
+                                          "end": {
+                                            "line": 40,
+                                            "column": 35
+                                          },
+                                          "identifierName": "data"
+                                        },
+                                        "name": "data"
+                                      },
+                                      "computed": false
+                                    }
+                                  ]
+                                }
+                              }
+                            ],
+                            "directives": []
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ],
+                "directives": []
+              }
+            },
+            "leadingComments": null
+          }
+        ],
+        "kind": "const",
+        "leadingComments": [
+          {
+            "type": "CommentBlock",
+            "value": "*\n * Get a list of all Core-FZP files\n *\n * @param  {String} url - The base URL of the parts api\n * @return {Promise}\n ",
+            "start": 627,
+            "end": 750,
+            "loc": {
+              "start": {
+                "line": 31,
+                "column": 0
+              },
+              "end": {
+                "line": 36,
+                "column": 3
+              }
+            }
+          }
+        ],
+        "trailingComments": [
+          {
+            "type": "CommentBlock",
+            "value": "*\n * Get a list of all Obsolete-FZP files. for old sketches only!\n *\n * @param  {String} url - The base URL of the parts api\n * @return {Promise}\n ",
+            "start": 935,
+            "end": 1086,
+            "loc": {
+              "start": {
+                "line": 44,
+                "column": 0
+              },
+              "end": {
+                "line": 49,
+                "column": 3
+              }
+            }
+          }
+        ]
+      },
+      {
+        "type": "VariableDeclaration",
+        "start": 1087,
+        "end": 1277,
+        "loc": {
+          "start": {
+            "line": 50,
+            "column": 0
+          },
+          "end": {
+            "line": 55,
+            "column": 2
+          }
+        },
+        "declarations": [
+          {
+            "type": "VariableDeclarator",
+            "start": 1093,
+            "end": 1276,
+            "loc": {
+              "start": {
+                "line": 50,
+                "column": 6
+              },
+              "end": {
+                "line": 55,
+                "column": 1
+              }
+            },
+            "id": {
+              "type": "Identifier",
+              "start": 1093,
+              "end": 1108,
+              "loc": {
+                "start": {
+                  "line": 50,
+                  "column": 6
+                },
+                "end": {
+                  "line": 50,
+                  "column": 21
+                },
+                "identifierName": "getFzpsObsolete"
+              },
+              "name": "getFzpsObsolete",
+              "leadingComments": null
+            },
+            "init": {
+              "type": "FunctionExpression",
+              "start": 1111,
+              "end": 1276,
+              "loc": {
+                "start": {
+                  "line": 50,
+                  "column": 24
+                },
+                "end": {
+                  "line": 55,
+                  "column": 1
+                }
+              },
+              "id": {
+                "type": "Identifier",
+                "start": 1093,
+                "end": 1108,
+                "loc": {
+                  "start": {
+                    "line": 50,
+                    "column": 6
+                  },
+                  "end": {
+                    "line": 50,
+                    "column": 21
+                  },
+                  "identifierName": "getFzpsObsolete"
+                },
+                "name": "getFzpsObsolete",
+                "leadingComments": null
+              },
+              "generator": false,
+              "expression": false,
+              "async": false,
+              "params": [
+                {
+                  "type": "AssignmentPattern",
+                  "start": 1120,
+                  "end": 1160,
+                  "loc": {
+                    "start": {
+                      "line": 50,
+                      "column": 33
+                    },
+                    "end": {
+                      "line": 50,
+                      "column": 73
+                    }
+                  },
+                  "left": {
+                    "type": "Identifier",
+                    "start": 1120,
+                    "end": 1123,
+                    "loc": {
+                      "start": {
+                        "line": 50,
+                        "column": 33
+                      },
+                      "end": {
+                        "line": 50,
+                        "column": 36
+                      },
+                      "identifierName": "url"
+                    },
+                    "name": "url"
+                  },
+                  "right": {
+                    "type": "TemplateLiteral",
+                    "start": 1126,
+                    "end": 1160,
+                    "loc": {
+                      "start": {
+                        "line": 50,
+                        "column": 39
+                      },
+                      "end": {
+                        "line": 50,
+                        "column": 73
+                      }
+                    },
+                    "expressions": [
+                      {
+                        "type": "Identifier",
+                        "start": 1129,
+                        "end": 1145,
+                        "loc": {
+                          "start": {
+                            "line": 50,
+                            "column": 42
+                          },
+                          "end": {
+                            "line": 50,
+                            "column": 58
+                          },
+                          "identifierName": "FritzingPartsAPI"
+                        },
+                        "name": "FritzingPartsAPI"
+                      }
+                    ],
+                    "quasis": [
+                      {
+                        "type": "TemplateElement",
+                        "start": 1127,
+                        "end": 1127,
+                        "loc": {
+                          "start": {
+                            "line": 50,
+                            "column": 40
+                          },
+                          "end": {
+                            "line": 50,
+                            "column": 40
+                          }
+                        },
+                        "value": {
+                          "raw": "",
+                          "cooked": ""
+                        },
+                        "tail": false
+                      },
+                      {
+                        "type": "TemplateElement",
+                        "start": 1146,
+                        "end": 1159,
+                        "loc": {
+                          "start": {
+                            "line": 50,
+                            "column": 59
+                          },
+                          "end": {
+                            "line": 50,
+                            "column": 72
+                          }
+                        },
+                        "value": {
+                          "raw": "/fzp/obsolete",
+                          "cooked": "/fzp/obsolete"
+                        },
+                        "tail": true
+                      }
+                    ]
+                  }
+                }
+              ],
+              "body": {
+                "type": "BlockStatement",
+                "start": 1162,
+                "end": 1276,
+                "loc": {
+                  "start": {
+                    "line": 50,
+                    "column": 75
+                  },
+                  "end": {
+                    "line": 55,
+                    "column": 1
+                  }
+                },
+                "body": [
+                  {
+                    "type": "ReturnStatement",
+                    "start": 1166,
+                    "end": 1274,
+                    "loc": {
+                      "start": {
+                        "line": 51,
+                        "column": 2
+                      },
+                      "end": {
+                        "line": 54,
+                        "column": 5
+                      }
+                    },
+                    "argument": {
+                      "type": "CallExpression",
+                      "start": 1173,
+                      "end": 1273,
+                      "loc": {
+                        "start": {
+                          "line": 51,
+                          "column": 9
+                        },
+                        "end": {
+                          "line": 54,
+                          "column": 4
+                        }
+                      },
+                      "callee": {
+                        "type": "MemberExpression",
+                        "start": 1173,
+                        "end": 1219,
+                        "loc": {
+                          "start": {
+                            "line": 51,
+                            "column": 9
+                          },
+                          "end": {
+                            "line": 52,
+                            "column": 7
+                          }
+                        },
+                        "object": {
+                          "type": "CallExpression",
+                          "start": 1173,
+                          "end": 1211,
+                          "loc": {
+                            "start": {
+                              "line": 51,
+                              "column": 9
+                            },
+                            "end": {
+                              "line": 51,
+                              "column": 47
+                            }
+                          },
+                          "callee": {
+                            "type": "MemberExpression",
+                            "start": 1173,
+                            "end": 1182,
+                            "loc": {
+                              "start": {
+                                "line": 51,
+                                "column": 9
+                              },
+                              "end": {
+                                "line": 51,
+                                "column": 18
+                              }
+                            },
+                            "object": {
+                              "type": "Identifier",
+                              "start": 1173,
+                              "end": 1178,
+                              "loc": {
+                                "start": {
+                                  "line": 51,
+                                  "column": 9
+                                },
+                                "end": {
+                                  "line": 51,
+                                  "column": 14
+                                },
+                                "identifierName": "axios"
+                              },
+                              "name": "axios"
+                            },
+                            "property": {
+                              "type": "Identifier",
+                              "start": 1179,
+                              "end": 1182,
+                              "loc": {
+                                "start": {
+                                  "line": 51,
+                                  "column": 15
+                                },
+                                "end": {
+                                  "line": 51,
+                                  "column": 18
+                                },
+                                "identifierName": "get"
+                              },
+                              "name": "get"
+                            },
+                            "computed": false
+                          },
+                          "arguments": [
+                            {
+                              "type": "Identifier",
+                              "start": 1183,
+                              "end": 1186,
+                              "loc": {
+                                "start": {
+                                  "line": 51,
+                                  "column": 19
+                                },
+                                "end": {
+                                  "line": 51,
+                                  "column": 22
+                                },
+                                "identifierName": "url"
+                              },
+                              "name": "url"
+                            },
+                            {
+                              "type": "ObjectExpression",
+                              "start": 1188,
+                              "end": 1210,
+                              "loc": {
+                                "start": {
+                                  "line": 51,
+                                  "column": 24
+                                },
+                                "end": {
+                                  "line": 51,
+                                  "column": 46
+                                }
+                              },
+                              "properties": [
+                                {
+                                  "type": "ObjectProperty",
+                                  "start": 1189,
+                                  "end": 1209,
+                                  "loc": {
+                                    "start": {
+                                      "line": 51,
+                                      "column": 25
+                                    },
+                                    "end": {
+                                      "line": 51,
+                                      "column": 45
+                                    }
+                                  },
+                                  "method": false,
+                                  "shorthand": false,
+                                  "computed": false,
+                                  "key": {
+                                    "type": "Identifier",
+                                    "start": 1189,
+                                    "end": 1201,
+                                    "loc": {
+                                      "start": {
+                                        "line": 51,
+                                        "column": 25
+                                      },
+                                      "end": {
+                                        "line": 51,
+                                        "column": 37
+                                      },
+                                      "identifierName": "responseType"
+                                    },
+                                    "name": "responseType"
+                                  },
+                                  "value": {
+                                    "type": "StringLiteral",
+                                    "start": 1203,
+                                    "end": 1209,
+                                    "loc": {
+                                      "start": {
+                                        "line": 51,
+                                        "column": 39
+                                      },
+                                      "end": {
+                                        "line": 51,
+                                        "column": 45
+                                      }
+                                    },
+                                    "extra": {
+                                      "rawValue": "json",
+                                      "raw": "'json'"
+                                    },
+                                    "value": "json"
+                                  }
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        "property": {
+                          "type": "Identifier",
+                          "start": 1215,
+                          "end": 1219,
+                          "loc": {
+                            "start": {
+                              "line": 52,
+                              "column": 3
+                            },
+                            "end": {
+                              "line": 52,
+                              "column": 7
+                            },
+                            "identifierName": "then"
+                          },
+                          "name": "then"
+                        },
+                        "computed": false
+                      },
+                      "arguments": [
+                        {
+                          "type": "ArrowFunctionExpression",
+                          "start": 1220,
+                          "end": 1272,
+                          "loc": {
+                            "start": {
+                              "line": 52,
+                              "column": 8
+                            },
+                            "end": {
+                              "line": 54,
+                              "column": 3
+                            }
+                          },
+                          "id": null,
+                          "generator": false,
+                          "expression": false,
+                          "async": false,
+                          "params": [
+                            {
+                              "type": "Identifier",
+                              "start": 1221,
+                              "end": 1224,
+                              "loc": {
+                                "start": {
+                                  "line": 52,
+                                  "column": 9
+                                },
+                                "end": {
+                                  "line": 52,
+                                  "column": 12
+                                },
+                                "identifierName": "res"
+                              },
+                              "name": "res"
+                            }
+                          ],
+                          "body": {
+                            "type": "BlockStatement",
+                            "start": 1229,
+                            "end": 1272,
+                            "loc": {
+                              "start": {
+                                "line": 52,
+                                "column": 17
+                              },
+                              "end": {
+                                "line": 54,
+                                "column": 3
+                              }
+                            },
+                            "body": [
+                              {
+                                "type": "ReturnStatement",
+                                "start": 1235,
+                                "end": 1268,
+                                "loc": {
+                                  "start": {
+                                    "line": 53,
+                                    "column": 4
+                                  },
+                                  "end": {
+                                    "line": 53,
+                                    "column": 37
+                                  }
+                                },
+                                "argument": {
+                                  "type": "CallExpression",
+                                  "start": 1242,
+                                  "end": 1267,
+                                  "loc": {
+                                    "start": {
+                                      "line": 53,
+                                      "column": 11
+                                    },
+                                    "end": {
+                                      "line": 53,
+                                      "column": 36
+                                    }
+                                  },
+                                  "callee": {
+                                    "type": "MemberExpression",
+                                    "start": 1242,
+                                    "end": 1257,
+                                    "loc": {
+                                      "start": {
+                                        "line": 53,
+                                        "column": 11
+                                      },
+                                      "end": {
+                                        "line": 53,
+                                        "column": 26
+                                      }
+                                    },
+                                    "object": {
+                                      "type": "Identifier",
+                                      "start": 1242,
+                                      "end": 1249,
+                                      "loc": {
+                                        "start": {
+                                          "line": 53,
+                                          "column": 11
+                                        },
+                                        "end": {
+                                          "line": 53,
+                                          "column": 18
+                                        },
+                                        "identifierName": "Promise"
+                                      },
+                                      "name": "Promise"
+                                    },
+                                    "property": {
+                                      "type": "Identifier",
+                                      "start": 1250,
+                                      "end": 1257,
+                                      "loc": {
+                                        "start": {
+                                          "line": 53,
+                                          "column": 19
+                                        },
+                                        "end": {
+                                          "line": 53,
+                                          "column": 26
+                                        },
+                                        "identifierName": "resolve"
+                                      },
+                                      "name": "resolve"
+                                    },
+                                    "computed": false
+                                  },
+                                  "arguments": [
+                                    {
+                                      "type": "MemberExpression",
+                                      "start": 1258,
+                                      "end": 1266,
+                                      "loc": {
+                                        "start": {
+                                          "line": 53,
+                                          "column": 27
+                                        },
+                                        "end": {
+                                          "line": 53,
+                                          "column": 35
+                                        }
+                                      },
+                                      "object": {
+                                        "type": "Identifier",
+                                        "start": 1258,
+                                        "end": 1261,
+                                        "loc": {
+                                          "start": {
+                                            "line": 53,
+                                            "column": 27
+                                          },
+                                          "end": {
+                                            "line": 53,
+                                            "column": 30
+                                          },
+                                          "identifierName": "res"
+                                        },
+                                        "name": "res"
+                                      },
+                                      "property": {
+                                        "type": "Identifier",
+                                        "start": 1262,
+                                        "end": 1266,
+                                        "loc": {
+                                          "start": {
+                                            "line": 53,
+                                            "column": 31
+                                          },
+                                          "end": {
+                                            "line": 53,
+                                            "column": 35
+                                          },
+                                          "identifierName": "data"
+                                        },
+                                        "name": "data"
+                                      },
+                                      "computed": false
+                                    }
+                                  ]
+                                }
+                              }
+                            ],
+                            "directives": []
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ],
+                "directives": []
+              }
+            },
+            "leadingComments": null
+          }
+        ],
+        "kind": "const",
+        "leadingComments": [
+          {
+            "type": "CommentBlock",
+            "value": "*\n * Get a list of all Obsolete-FZP files. for old sketches only!\n *\n * @param  {String} url - The base URL of the parts api\n * @return {Promise}\n ",
+            "start": 935,
+            "end": 1086,
+            "loc": {
+              "start": {
+                "line": 44,
+                "column": 0
+              },
+              "end": {
+                "line": 49,
+                "column": 3
+              }
+            }
+          }
+        ],
+        "trailingComments": [
+          {
+            "type": "CommentBlock",
+            "value": "*\n * Get a single FZP and response the xml as a string\n *\n * @param  {String} src\n * @param  {String} url - The base URL of the parts api\n * @return {Promise} the fetch promise\n ",
+            "start": 1279,
+            "end": 1461,
+            "loc": {
+              "start": {
+                "line": 57,
+                "column": 0
+              },
+              "end": {
+                "line": 63,
+                "column": 3
+              }
+            }
+          }
+        ]
+      },
+      {
+        "type": "VariableDeclaration",
+        "start": 1462,
+        "end": 1641,
+        "loc": {
+          "start": {
+            "line": 64,
+            "column": 0
+          },
+          "end": {
+            "line": 69,
+            "column": 2
+          }
+        },
+        "declarations": [
+          {
+            "type": "VariableDeclarator",
+            "start": 1468,
+            "end": 1640,
+            "loc": {
+              "start": {
+                "line": 64,
+                "column": 6
+              },
+              "end": {
+                "line": 69,
+                "column": 1
+              }
+            },
+            "id": {
+              "type": "Identifier",
+              "start": 1468,
+              "end": 1474,
+              "loc": {
+                "start": {
+                  "line": 64,
+                  "column": 6
+                },
+                "end": {
+                  "line": 64,
+                  "column": 12
+                },
+                "identifierName": "getFzp"
+              },
+              "name": "getFzp",
+              "leadingComments": null
+            },
+            "init": {
+              "type": "FunctionExpression",
+              "start": 1477,
+              "end": 1640,
+              "loc": {
+                "start": {
+                  "line": 64,
+                  "column": 15
+                },
+                "end": {
+                  "line": 69,
+                  "column": 1
+                }
+              },
+              "id": {
+                "type": "Identifier",
+                "start": 1468,
+                "end": 1474,
+                "loc": {
+                  "start": {
+                    "line": 64,
+                    "column": 6
+                  },
+                  "end": {
+                    "line": 64,
+                    "column": 12
+                  },
+                  "identifierName": "getFzp"
+                },
+                "name": "getFzp",
+                "leadingComments": null
+              },
+              "generator": false,
+              "expression": false,
+              "async": false,
+              "params": [
+                {
+                  "type": "Identifier",
+                  "start": 1486,
+                  "end": 1489,
+                  "loc": {
+                    "start": {
+                      "line": 64,
+                      "column": 24
+                    },
+                    "end": {
+                      "line": 64,
+                      "column": 27
+                    },
+                    "identifierName": "src"
+                  },
+                  "name": "src"
+                },
+                {
+                  "type": "AssignmentPattern",
+                  "start": 1491,
+                  "end": 1513,
+                  "loc": {
+                    "start": {
+                      "line": 64,
+                      "column": 29
+                    },
+                    "end": {
+                      "line": 64,
+                      "column": 51
+                    }
+                  },
+                  "left": {
+                    "type": "Identifier",
+                    "start": 1491,
+                    "end": 1494,
+                    "loc": {
+                      "start": {
+                        "line": 64,
+                        "column": 29
+                      },
+                      "end": {
+                        "line": 64,
+                        "column": 32
+                      },
+                      "identifierName": "url"
+                    },
+                    "name": "url"
+                  },
+                  "right": {
+                    "type": "Identifier",
+                    "start": 1497,
+                    "end": 1513,
+                    "loc": {
+                      "start": {
+                        "line": 64,
+                        "column": 35
+                      },
+                      "end": {
+                        "line": 64,
+                        "column": 51
+                      },
+                      "identifierName": "FritzingPartsAPI"
+                    },
+                    "name": "FritzingPartsAPI"
+                  }
+                }
+              ],
+              "body": {
+                "type": "BlockStatement",
+                "start": 1515,
+                "end": 1640,
+                "loc": {
+                  "start": {
+                    "line": 64,
+                    "column": 53
+                  },
+                  "end": {
+                    "line": 69,
+                    "column": 1
+                  }
+                },
+                "body": [
+                  {
+                    "type": "ReturnStatement",
+                    "start": 1519,
+                    "end": 1638,
+                    "loc": {
+                      "start": {
+                        "line": 65,
+                        "column": 2
+                      },
+                      "end": {
+                        "line": 68,
+                        "column": 5
+                      }
+                    },
+                    "argument": {
+                      "type": "CallExpression",
+                      "start": 1526,
+                      "end": 1637,
+                      "loc": {
+                        "start": {
+                          "line": 65,
+                          "column": 9
+                        },
+                        "end": {
+                          "line": 68,
+                          "column": 4
+                        }
+                      },
+                      "callee": {
+                        "type": "MemberExpression",
+                        "start": 1526,
+                        "end": 1583,
+                        "loc": {
+                          "start": {
+                            "line": 65,
+                            "column": 9
+                          },
+                          "end": {
+                            "line": 66,
+                            "column": 7
+                          }
+                        },
+                        "object": {
+                          "type": "CallExpression",
+                          "start": 1526,
+                          "end": 1575,
+                          "loc": {
+                            "start": {
+                              "line": 65,
+                              "column": 9
+                            },
+                            "end": {
+                              "line": 65,
+                              "column": 58
+                            }
+                          },
+                          "callee": {
+                            "type": "MemberExpression",
+                            "start": 1526,
+                            "end": 1535,
+                            "loc": {
+                              "start": {
+                                "line": 65,
+                                "column": 9
+                              },
+                              "end": {
+                                "line": 65,
+                                "column": 18
+                              }
+                            },
+                            "object": {
+                              "type": "Identifier",
+                              "start": 1526,
+                              "end": 1531,
+                              "loc": {
+                                "start": {
+                                  "line": 65,
+                                  "column": 9
+                                },
+                                "end": {
+                                  "line": 65,
+                                  "column": 14
+                                },
+                                "identifierName": "axios"
+                              },
+                              "name": "axios"
+                            },
+                            "property": {
+                              "type": "Identifier",
+                              "start": 1532,
+                              "end": 1535,
+                              "loc": {
+                                "start": {
+                                  "line": 65,
+                                  "column": 15
+                                },
+                                "end": {
+                                  "line": 65,
+                                  "column": 18
+                                },
+                                "identifierName": "get"
+                              },
+                              "name": "get"
+                            },
+                            "computed": false
+                          },
+                          "arguments": [
+                            {
+                              "type": "TemplateLiteral",
+                              "start": 1536,
+                              "end": 1551,
+                              "loc": {
+                                "start": {
+                                  "line": 65,
+                                  "column": 19
+                                },
+                                "end": {
+                                  "line": 65,
+                                  "column": 34
+                                }
+                              },
+                              "expressions": [
+                                {
+                                  "type": "Identifier",
+                                  "start": 1539,
+                                  "end": 1542,
+                                  "loc": {
+                                    "start": {
+                                      "line": 65,
+                                      "column": 22
+                                    },
+                                    "end": {
+                                      "line": 65,
+                                      "column": 25
+                                    },
+                                    "identifierName": "url"
+                                  },
+                                  "name": "url"
+                                },
+                                {
+                                  "type": "Identifier",
+                                  "start": 1546,
+                                  "end": 1549,
+                                  "loc": {
+                                    "start": {
+                                      "line": 65,
+                                      "column": 29
+                                    },
+                                    "end": {
+                                      "line": 65,
+                                      "column": 32
+                                    },
+                                    "identifierName": "src"
+                                  },
+                                  "name": "src"
+                                }
+                              ],
+                              "quasis": [
+                                {
+                                  "type": "TemplateElement",
+                                  "start": 1537,
+                                  "end": 1537,
+                                  "loc": {
+                                    "start": {
+                                      "line": 65,
+                                      "column": 20
+                                    },
+                                    "end": {
+                                      "line": 65,
+                                      "column": 20
+                                    }
+                                  },
+                                  "value": {
+                                    "raw": "",
+                                    "cooked": ""
+                                  },
+                                  "tail": false
+                                },
+                                {
+                                  "type": "TemplateElement",
+                                  "start": 1543,
+                                  "end": 1544,
+                                  "loc": {
+                                    "start": {
+                                      "line": 65,
+                                      "column": 26
+                                    },
+                                    "end": {
+                                      "line": 65,
+                                      "column": 27
+                                    }
+                                  },
+                                  "value": {
+                                    "raw": "/",
+                                    "cooked": "/"
+                                  },
+                                  "tail": false
+                                },
+                                {
+                                  "type": "TemplateElement",
+                                  "start": 1550,
+                                  "end": 1550,
+                                  "loc": {
+                                    "start": {
+                                      "line": 65,
+                                      "column": 33
+                                    },
+                                    "end": {
+                                      "line": 65,
+                                      "column": 33
+                                    }
+                                  },
+                                  "value": {
+                                    "raw": "",
+                                    "cooked": ""
+                                  },
+                                  "tail": true
+                                }
+                              ]
+                            },
+                            {
+                              "type": "ObjectExpression",
+                              "start": 1553,
+                              "end": 1574,
+                              "loc": {
+                                "start": {
+                                  "line": 65,
+                                  "column": 36
+                                },
+                                "end": {
+                                  "line": 65,
+                                  "column": 57
+                                }
+                              },
+                              "properties": [
+                                {
+                                  "type": "ObjectProperty",
+                                  "start": 1554,
+                                  "end": 1573,
+                                  "loc": {
+                                    "start": {
+                                      "line": 65,
+                                      "column": 37
+                                    },
+                                    "end": {
+                                      "line": 65,
+                                      "column": 56
+                                    }
+                                  },
+                                  "method": false,
+                                  "shorthand": false,
+                                  "computed": false,
+                                  "key": {
+                                    "type": "Identifier",
+                                    "start": 1554,
+                                    "end": 1566,
+                                    "loc": {
+                                      "start": {
+                                        "line": 65,
+                                        "column": 37
+                                      },
+                                      "end": {
+                                        "line": 65,
+                                        "column": 49
+                                      },
+                                      "identifierName": "responseType"
+                                    },
+                                    "name": "responseType"
+                                  },
+                                  "value": {
+                                    "type": "StringLiteral",
+                                    "start": 1568,
+                                    "end": 1573,
+                                    "loc": {
+                                      "start": {
+                                        "line": 65,
+                                        "column": 51
+                                      },
+                                      "end": {
+                                        "line": 65,
+                                        "column": 56
+                                      }
+                                    },
+                                    "extra": {
+                                      "rawValue": "xml",
+                                      "raw": "'xml'"
+                                    },
+                                    "value": "xml"
+                                  }
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        "property": {
+                          "type": "Identifier",
+                          "start": 1579,
+                          "end": 1583,
+                          "loc": {
+                            "start": {
+                              "line": 66,
+                              "column": 3
+                            },
+                            "end": {
+                              "line": 66,
+                              "column": 7
+                            },
+                            "identifierName": "then"
+                          },
+                          "name": "then"
+                        },
+                        "computed": false
+                      },
+                      "arguments": [
+                        {
+                          "type": "ArrowFunctionExpression",
+                          "start": 1584,
+                          "end": 1636,
+                          "loc": {
+                            "start": {
+                              "line": 66,
+                              "column": 8
+                            },
+                            "end": {
+                              "line": 68,
+                              "column": 3
+                            }
+                          },
+                          "id": null,
+                          "generator": false,
+                          "expression": false,
+                          "async": false,
+                          "params": [
+                            {
+                              "type": "Identifier",
+                              "start": 1585,
+                              "end": 1588,
+                              "loc": {
+                                "start": {
+                                  "line": 66,
+                                  "column": 9
+                                },
+                                "end": {
+                                  "line": 66,
+                                  "column": 12
+                                },
+                                "identifierName": "res"
+                              },
+                              "name": "res"
+                            }
+                          ],
+                          "body": {
+                            "type": "BlockStatement",
+                            "start": 1593,
+                            "end": 1636,
+                            "loc": {
+                              "start": {
+                                "line": 66,
+                                "column": 17
+                              },
+                              "end": {
+                                "line": 68,
+                                "column": 3
+                              }
+                            },
+                            "body": [
+                              {
+                                "type": "ReturnStatement",
+                                "start": 1599,
+                                "end": 1632,
+                                "loc": {
+                                  "start": {
+                                    "line": 67,
+                                    "column": 4
+                                  },
+                                  "end": {
+                                    "line": 67,
+                                    "column": 37
+                                  }
+                                },
+                                "argument": {
+                                  "type": "CallExpression",
+                                  "start": 1606,
+                                  "end": 1631,
+                                  "loc": {
+                                    "start": {
+                                      "line": 67,
+                                      "column": 11
+                                    },
+                                    "end": {
+                                      "line": 67,
+                                      "column": 36
+                                    }
+                                  },
+                                  "callee": {
+                                    "type": "MemberExpression",
+                                    "start": 1606,
+                                    "end": 1621,
+                                    "loc": {
+                                      "start": {
+                                        "line": 67,
+                                        "column": 11
+                                      },
+                                      "end": {
+                                        "line": 67,
+                                        "column": 26
+                                      }
+                                    },
+                                    "object": {
+                                      "type": "Identifier",
+                                      "start": 1606,
+                                      "end": 1613,
+                                      "loc": {
+                                        "start": {
+                                          "line": 67,
+                                          "column": 11
+                                        },
+                                        "end": {
+                                          "line": 67,
+                                          "column": 18
+                                        },
+                                        "identifierName": "Promise"
+                                      },
+                                      "name": "Promise"
+                                    },
+                                    "property": {
+                                      "type": "Identifier",
+                                      "start": 1614,
+                                      "end": 1621,
+                                      "loc": {
+                                        "start": {
+                                          "line": 67,
+                                          "column": 19
+                                        },
+                                        "end": {
+                                          "line": 67,
+                                          "column": 26
+                                        },
+                                        "identifierName": "resolve"
+                                      },
+                                      "name": "resolve"
+                                    },
+                                    "computed": false
+                                  },
+                                  "arguments": [
+                                    {
+                                      "type": "MemberExpression",
+                                      "start": 1622,
+                                      "end": 1630,
+                                      "loc": {
+                                        "start": {
+                                          "line": 67,
+                                          "column": 27
+                                        },
+                                        "end": {
+                                          "line": 67,
+                                          "column": 35
+                                        }
+                                      },
+                                      "object": {
+                                        "type": "Identifier",
+                                        "start": 1622,
+                                        "end": 1625,
+                                        "loc": {
+                                          "start": {
+                                            "line": 67,
+                                            "column": 27
+                                          },
+                                          "end": {
+                                            "line": 67,
+                                            "column": 30
+                                          },
+                                          "identifierName": "res"
+                                        },
+                                        "name": "res"
+                                      },
+                                      "property": {
+                                        "type": "Identifier",
+                                        "start": 1626,
+                                        "end": 1630,
+                                        "loc": {
+                                          "start": {
+                                            "line": 67,
+                                            "column": 31
+                                          },
+                                          "end": {
+                                            "line": 67,
+                                            "column": 35
+                                          },
+                                          "identifierName": "data"
+                                        },
+                                        "name": "data"
+                                      },
+                                      "computed": false
+                                    }
+                                  ]
+                                }
+                              }
+                            ],
+                            "directives": []
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ],
+                "directives": []
+              }
+            },
+            "leadingComments": null
+          }
+        ],
+        "kind": "const",
+        "leadingComments": [
+          {
+            "type": "CommentBlock",
+            "value": "*\n * Get a single FZP and response the xml as a string\n *\n * @param  {String} src\n * @param  {String} url - The base URL of the parts api\n * @return {Promise} the fetch promise\n ",
+            "start": 1279,
+            "end": 1461,
+            "loc": {
+              "start": {
+                "line": 57,
+                "column": 0
+              },
+              "end": {
+                "line": 63,
+                "column": 3
+              }
+            }
+          }
+        ],
+        "trailingComments": [
+          {
+            "type": "CommentBlock",
+            "value": "*\n  * Get a single part fzp from the core parts\n  *\n  * @param  {String} src\n  * @param  {String} url - The base URL of the parts api\n  * @return {Promise} the fetch promise returns xml\n  ",
+            "start": 1644,
+            "end": 1836,
+            "loc": {
+              "start": {
+                "line": 71,
+                "column": 1
+              },
+              "end": {
+                "line": 77,
+                "column": 4
+              }
+            }
+          }
+        ]
+      },
+      {
+        "type": "VariableDeclaration",
+        "start": 1837,
+        "end": 2025,
+        "loc": {
+          "start": {
+            "line": 78,
+            "column": 0
+          },
+          "end": {
+            "line": 83,
+            "column": 2
+          }
+        },
+        "declarations": [
+          {
+            "type": "VariableDeclarator",
+            "start": 1843,
+            "end": 2024,
+            "loc": {
+              "start": {
+                "line": 78,
+                "column": 6
+              },
+              "end": {
+                "line": 83,
+                "column": 1
+              }
+            },
+            "id": {
+              "type": "Identifier",
+              "start": 1843,
+              "end": 1853,
+              "loc": {
+                "start": {
+                  "line": 78,
+                  "column": 6
+                },
+                "end": {
+                  "line": 78,
+                  "column": 16
+                },
+                "identifierName": "getFzpCore"
+              },
+              "name": "getFzpCore",
+              "leadingComments": null
+            },
+            "init": {
+              "type": "FunctionExpression",
+              "start": 1856,
+              "end": 2024,
+              "loc": {
+                "start": {
+                  "line": 78,
+                  "column": 19
+                },
+                "end": {
+                  "line": 83,
+                  "column": 1
+                }
+              },
+              "id": {
+                "type": "Identifier",
+                "start": 1843,
+                "end": 1853,
+                "loc": {
+                  "start": {
+                    "line": 78,
+                    "column": 6
+                  },
+                  "end": {
+                    "line": 78,
+                    "column": 16
+                  },
+                  "identifierName": "getFzpCore"
+                },
+                "name": "getFzpCore",
+                "leadingComments": null
+              },
+              "generator": false,
+              "expression": false,
+              "async": false,
+              "params": [
+                {
+                  "type": "Identifier",
+                  "start": 1865,
+                  "end": 1868,
+                  "loc": {
+                    "start": {
+                      "line": 78,
+                      "column": 28
+                    },
+                    "end": {
+                      "line": 78,
+                      "column": 31
+                    },
+                    "identifierName": "src"
+                  },
+                  "name": "src"
+                },
+                {
+                  "type": "AssignmentPattern",
+                  "start": 1870,
+                  "end": 1892,
+                  "loc": {
+                    "start": {
+                      "line": 78,
+                      "column": 33
+                    },
+                    "end": {
+                      "line": 78,
+                      "column": 55
+                    }
+                  },
+                  "left": {
+                    "type": "Identifier",
+                    "start": 1870,
+                    "end": 1873,
+                    "loc": {
+                      "start": {
+                        "line": 78,
+                        "column": 33
+                      },
+                      "end": {
+                        "line": 78,
+                        "column": 36
+                      },
+                      "identifierName": "url"
+                    },
+                    "name": "url"
+                  },
+                  "right": {
+                    "type": "Identifier",
+                    "start": 1876,
+                    "end": 1892,
+                    "loc": {
+                      "start": {
+                        "line": 78,
+                        "column": 39
+                      },
+                      "end": {
+                        "line": 78,
+                        "column": 55
+                      },
+                      "identifierName": "FritzingPartsAPI"
+                    },
+                    "name": "FritzingPartsAPI"
+                  }
+                }
+              ],
+              "body": {
+                "type": "BlockStatement",
+                "start": 1894,
+                "end": 2024,
+                "loc": {
+                  "start": {
+                    "line": 78,
+                    "column": 57
+                  },
+                  "end": {
+                    "line": 83,
+                    "column": 1
+                  }
+                },
+                "body": [
+                  {
+                    "type": "ReturnStatement",
+                    "start": 1898,
+                    "end": 2022,
+                    "loc": {
+                      "start": {
+                        "line": 79,
+                        "column": 2
+                      },
+                      "end": {
+                        "line": 82,
+                        "column": 5
+                      }
+                    },
+                    "argument": {
+                      "type": "CallExpression",
+                      "start": 1905,
+                      "end": 2021,
+                      "loc": {
+                        "start": {
+                          "line": 79,
+                          "column": 9
+                        },
+                        "end": {
+                          "line": 82,
+                          "column": 4
+                        }
+                      },
+                      "callee": {
+                        "type": "MemberExpression",
+                        "start": 1905,
+                        "end": 1967,
+                        "loc": {
+                          "start": {
+                            "line": 79,
+                            "column": 9
+                          },
+                          "end": {
+                            "line": 80,
+                            "column": 7
+                          }
+                        },
+                        "object": {
+                          "type": "CallExpression",
+                          "start": 1905,
+                          "end": 1959,
+                          "loc": {
+                            "start": {
+                              "line": 79,
+                              "column": 9
+                            },
+                            "end": {
+                              "line": 79,
+                              "column": 63
+                            }
+                          },
+                          "callee": {
+                            "type": "MemberExpression",
+                            "start": 1905,
+                            "end": 1914,
+                            "loc": {
+                              "start": {
+                                "line": 79,
+                                "column": 9
+                              },
+                              "end": {
+                                "line": 79,
+                                "column": 18
+                              }
+                            },
+                            "object": {
+                              "type": "Identifier",
+                              "start": 1905,
+                              "end": 1910,
+                              "loc": {
+                                "start": {
+                                  "line": 79,
+                                  "column": 9
+                                },
+                                "end": {
+                                  "line": 79,
+                                  "column": 14
+                                },
+                                "identifierName": "axios"
+                              },
+                              "name": "axios"
+                            },
+                            "property": {
+                              "type": "Identifier",
+                              "start": 1911,
+                              "end": 1914,
+                              "loc": {
+                                "start": {
+                                  "line": 79,
+                                  "column": 15
+                                },
+                                "end": {
+                                  "line": 79,
+                                  "column": 18
+                                },
+                                "identifierName": "get"
+                              },
+                              "name": "get"
+                            },
+                            "computed": false
+                          },
+                          "arguments": [
+                            {
+                              "type": "TemplateLiteral",
+                              "start": 1915,
+                              "end": 1935,
+                              "loc": {
+                                "start": {
+                                  "line": 79,
+                                  "column": 19
+                                },
+                                "end": {
+                                  "line": 79,
+                                  "column": 39
+                                }
+                              },
+                              "expressions": [
+                                {
+                                  "type": "Identifier",
+                                  "start": 1918,
+                                  "end": 1921,
+                                  "loc": {
+                                    "start": {
+                                      "line": 79,
+                                      "column": 22
+                                    },
+                                    "end": {
+                                      "line": 79,
+                                      "column": 25
+                                    },
+                                    "identifierName": "url"
+                                  },
+                                  "name": "url"
+                                },
+                                {
+                                  "type": "Identifier",
+                                  "start": 1930,
+                                  "end": 1933,
+                                  "loc": {
+                                    "start": {
+                                      "line": 79,
+                                      "column": 34
+                                    },
+                                    "end": {
+                                      "line": 79,
+                                      "column": 37
+                                    },
+                                    "identifierName": "src"
+                                  },
+                                  "name": "src"
+                                }
+                              ],
+                              "quasis": [
+                                {
+                                  "type": "TemplateElement",
+                                  "start": 1916,
+                                  "end": 1916,
+                                  "loc": {
+                                    "start": {
+                                      "line": 79,
+                                      "column": 20
+                                    },
+                                    "end": {
+                                      "line": 79,
+                                      "column": 20
+                                    }
+                                  },
+                                  "value": {
+                                    "raw": "",
+                                    "cooked": ""
+                                  },
+                                  "tail": false
+                                },
+                                {
+                                  "type": "TemplateElement",
+                                  "start": 1922,
+                                  "end": 1928,
+                                  "loc": {
+                                    "start": {
+                                      "line": 79,
+                                      "column": 26
+                                    },
+                                    "end": {
+                                      "line": 79,
+                                      "column": 32
+                                    }
+                                  },
+                                  "value": {
+                                    "raw": "/core/",
+                                    "cooked": "/core/"
+                                  },
+                                  "tail": false
+                                },
+                                {
+                                  "type": "TemplateElement",
+                                  "start": 1934,
+                                  "end": 1934,
+                                  "loc": {
+                                    "start": {
+                                      "line": 79,
+                                      "column": 38
+                                    },
+                                    "end": {
+                                      "line": 79,
+                                      "column": 38
+                                    }
+                                  },
+                                  "value": {
+                                    "raw": "",
+                                    "cooked": ""
+                                  },
+                                  "tail": true
+                                }
+                              ]
+                            },
+                            {
+                              "type": "ObjectExpression",
+                              "start": 1937,
+                              "end": 1958,
+                              "loc": {
+                                "start": {
+                                  "line": 79,
+                                  "column": 41
+                                },
+                                "end": {
+                                  "line": 79,
+                                  "column": 62
+                                }
+                              },
+                              "properties": [
+                                {
+                                  "type": "ObjectProperty",
+                                  "start": 1938,
+                                  "end": 1957,
+                                  "loc": {
+                                    "start": {
+                                      "line": 79,
+                                      "column": 42
+                                    },
+                                    "end": {
+                                      "line": 79,
+                                      "column": 61
+                                    }
+                                  },
+                                  "method": false,
+                                  "shorthand": false,
+                                  "computed": false,
+                                  "key": {
+                                    "type": "Identifier",
+                                    "start": 1938,
+                                    "end": 1950,
+                                    "loc": {
+                                      "start": {
+                                        "line": 79,
+                                        "column": 42
+                                      },
+                                      "end": {
+                                        "line": 79,
+                                        "column": 54
+                                      },
+                                      "identifierName": "responseType"
+                                    },
+                                    "name": "responseType"
+                                  },
+                                  "value": {
+                                    "type": "StringLiteral",
+                                    "start": 1952,
+                                    "end": 1957,
+                                    "loc": {
+                                      "start": {
+                                        "line": 79,
+                                        "column": 56
+                                      },
+                                      "end": {
+                                        "line": 79,
+                                        "column": 61
+                                      }
+                                    },
+                                    "extra": {
+                                      "rawValue": "xml",
+                                      "raw": "'xml'"
+                                    },
+                                    "value": "xml"
+                                  }
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        "property": {
+                          "type": "Identifier",
+                          "start": 1963,
+                          "end": 1967,
+                          "loc": {
+                            "start": {
+                              "line": 80,
+                              "column": 3
+                            },
+                            "end": {
+                              "line": 80,
+                              "column": 7
+                            },
+                            "identifierName": "then"
+                          },
+                          "name": "then"
+                        },
+                        "computed": false
+                      },
+                      "arguments": [
+                        {
+                          "type": "ArrowFunctionExpression",
+                          "start": 1968,
+                          "end": 2020,
+                          "loc": {
+                            "start": {
+                              "line": 80,
+                              "column": 8
+                            },
+                            "end": {
+                              "line": 82,
+                              "column": 3
+                            }
+                          },
+                          "id": null,
+                          "generator": false,
+                          "expression": false,
+                          "async": false,
+                          "params": [
+                            {
+                              "type": "Identifier",
+                              "start": 1969,
+                              "end": 1972,
+                              "loc": {
+                                "start": {
+                                  "line": 80,
+                                  "column": 9
+                                },
+                                "end": {
+                                  "line": 80,
+                                  "column": 12
+                                },
+                                "identifierName": "res"
+                              },
+                              "name": "res"
+                            }
+                          ],
+                          "body": {
+                            "type": "BlockStatement",
+                            "start": 1977,
+                            "end": 2020,
+                            "loc": {
+                              "start": {
+                                "line": 80,
+                                "column": 17
+                              },
+                              "end": {
+                                "line": 82,
+                                "column": 3
+                              }
+                            },
+                            "body": [
+                              {
+                                "type": "ReturnStatement",
+                                "start": 1983,
+                                "end": 2016,
+                                "loc": {
+                                  "start": {
+                                    "line": 81,
+                                    "column": 4
+                                  },
+                                  "end": {
+                                    "line": 81,
+                                    "column": 37
+                                  }
+                                },
+                                "argument": {
+                                  "type": "CallExpression",
+                                  "start": 1990,
+                                  "end": 2015,
+                                  "loc": {
+                                    "start": {
+                                      "line": 81,
+                                      "column": 11
+                                    },
+                                    "end": {
+                                      "line": 81,
+                                      "column": 36
+                                    }
+                                  },
+                                  "callee": {
+                                    "type": "MemberExpression",
+                                    "start": 1990,
+                                    "end": 2005,
+                                    "loc": {
+                                      "start": {
+                                        "line": 81,
+                                        "column": 11
+                                      },
+                                      "end": {
+                                        "line": 81,
+                                        "column": 26
+                                      }
+                                    },
+                                    "object": {
+                                      "type": "Identifier",
+                                      "start": 1990,
+                                      "end": 1997,
+                                      "loc": {
+                                        "start": {
+                                          "line": 81,
+                                          "column": 11
+                                        },
+                                        "end": {
+                                          "line": 81,
+                                          "column": 18
+                                        },
+                                        "identifierName": "Promise"
+                                      },
+                                      "name": "Promise"
+                                    },
+                                    "property": {
+                                      "type": "Identifier",
+                                      "start": 1998,
+                                      "end": 2005,
+                                      "loc": {
+                                        "start": {
+                                          "line": 81,
+                                          "column": 19
+                                        },
+                                        "end": {
+                                          "line": 81,
+                                          "column": 26
+                                        },
+                                        "identifierName": "resolve"
+                                      },
+                                      "name": "resolve"
+                                    },
+                                    "computed": false
+                                  },
+                                  "arguments": [
+                                    {
+                                      "type": "MemberExpression",
+                                      "start": 2006,
+                                      "end": 2014,
+                                      "loc": {
+                                        "start": {
+                                          "line": 81,
+                                          "column": 27
+                                        },
+                                        "end": {
+                                          "line": 81,
+                                          "column": 35
+                                        }
+                                      },
+                                      "object": {
+                                        "type": "Identifier",
+                                        "start": 2006,
+                                        "end": 2009,
+                                        "loc": {
+                                          "start": {
+                                            "line": 81,
+                                            "column": 27
+                                          },
+                                          "end": {
+                                            "line": 81,
+                                            "column": 30
+                                          },
+                                          "identifierName": "res"
+                                        },
+                                        "name": "res"
+                                      },
+                                      "property": {
+                                        "type": "Identifier",
+                                        "start": 2010,
+                                        "end": 2014,
+                                        "loc": {
+                                          "start": {
+                                            "line": 81,
+                                            "column": 31
+                                          },
+                                          "end": {
+                                            "line": 81,
+                                            "column": 35
+                                          },
+                                          "identifierName": "data"
+                                        },
+                                        "name": "data"
+                                      },
+                                      "computed": false
+                                    }
+                                  ]
+                                }
+                              }
+                            ],
+                            "directives": []
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ],
+                "directives": []
+              }
+            },
+            "leadingComments": null
+          }
+        ],
+        "kind": "const",
+        "leadingComments": [
+          {
+            "type": "CommentBlock",
+            "value": "*\n  * Get a single part fzp from the core parts\n  *\n  * @param  {String} src\n  * @param  {String} url - The base URL of the parts api\n  * @return {Promise} the fetch promise returns xml\n  ",
+            "start": 1644,
+            "end": 1836,
+            "loc": {
+              "start": {
+                "line": 71,
+                "column": 1
+              },
+              "end": {
+                "line": 77,
+                "column": 4
+              }
+            }
+          }
+        ],
+        "trailingComments": [
+          {
+            "type": "CommentBlock",
+            "value": "*\n * Get a single part fzp from the obsolete parts, this is for old sketches only!\n *\n * @param  {String} src\n * @param  {String} url - The base URL of the parts api\n * @return {Promise} the fetch promise returns xml\n ",
+            "start": 2027,
+            "end": 2249,
+            "loc": {
+              "start": {
+                "line": 85,
+                "column": 0
+              },
+              "end": {
+                "line": 91,
+                "column": 3
+              }
+            }
+          }
+        ]
+      },
+      {
+        "type": "VariableDeclaration",
+        "start": 2250,
+        "end": 2446,
+        "loc": {
+          "start": {
+            "line": 92,
+            "column": 0
+          },
+          "end": {
+            "line": 97,
+            "column": 2
+          }
+        },
+        "declarations": [
+          {
+            "type": "VariableDeclarator",
+            "start": 2256,
+            "end": 2445,
+            "loc": {
+              "start": {
+                "line": 92,
+                "column": 6
+              },
+              "end": {
+                "line": 97,
+                "column": 1
+              }
+            },
+            "id": {
+              "type": "Identifier",
+              "start": 2256,
+              "end": 2270,
+              "loc": {
+                "start": {
+                  "line": 92,
+                  "column": 6
+                },
+                "end": {
+                  "line": 92,
+                  "column": 20
+                },
+                "identifierName": "getFzpObsolete"
+              },
+              "name": "getFzpObsolete",
+              "leadingComments": null
+            },
+            "init": {
+              "type": "FunctionExpression",
+              "start": 2273,
+              "end": 2445,
+              "loc": {
+                "start": {
+                  "line": 92,
+                  "column": 23
+                },
+                "end": {
+                  "line": 97,
+                  "column": 1
+                }
+              },
+              "id": {
+                "type": "Identifier",
+                "start": 2256,
+                "end": 2270,
+                "loc": {
+                  "start": {
+                    "line": 92,
+                    "column": 6
+                  },
+                  "end": {
+                    "line": 92,
+                    "column": 20
+                  },
+                  "identifierName": "getFzpObsolete"
+                },
+                "name": "getFzpObsolete",
+                "leadingComments": null
+              },
+              "generator": false,
+              "expression": false,
+              "async": false,
+              "params": [
+                {
+                  "type": "Identifier",
+                  "start": 2282,
+                  "end": 2285,
+                  "loc": {
+                    "start": {
+                      "line": 92,
+                      "column": 32
+                    },
+                    "end": {
+                      "line": 92,
+                      "column": 35
+                    },
+                    "identifierName": "src"
+                  },
+                  "name": "src"
+                },
+                {
+                  "type": "AssignmentPattern",
+                  "start": 2287,
+                  "end": 2309,
+                  "loc": {
+                    "start": {
+                      "line": 92,
+                      "column": 37
+                    },
+                    "end": {
+                      "line": 92,
+                      "column": 59
+                    }
+                  },
+                  "left": {
+                    "type": "Identifier",
+                    "start": 2287,
+                    "end": 2290,
+                    "loc": {
+                      "start": {
+                        "line": 92,
+                        "column": 37
+                      },
+                      "end": {
+                        "line": 92,
+                        "column": 40
+                      },
+                      "identifierName": "url"
+                    },
+                    "name": "url"
+                  },
+                  "right": {
+                    "type": "Identifier",
+                    "start": 2293,
+                    "end": 2309,
+                    "loc": {
+                      "start": {
+                        "line": 92,
+                        "column": 43
+                      },
+                      "end": {
+                        "line": 92,
+                        "column": 59
+                      },
+                      "identifierName": "FritzingPartsAPI"
+                    },
+                    "name": "FritzingPartsAPI"
+                  }
+                }
+              ],
+              "body": {
+                "type": "BlockStatement",
+                "start": 2311,
+                "end": 2445,
+                "loc": {
+                  "start": {
+                    "line": 92,
+                    "column": 61
+                  },
+                  "end": {
+                    "line": 97,
+                    "column": 1
+                  }
+                },
+                "body": [
+                  {
+                    "type": "ReturnStatement",
+                    "start": 2315,
+                    "end": 2443,
+                    "loc": {
+                      "start": {
+                        "line": 93,
+                        "column": 2
+                      },
+                      "end": {
+                        "line": 96,
+                        "column": 5
+                      }
+                    },
+                    "argument": {
+                      "type": "CallExpression",
+                      "start": 2322,
+                      "end": 2442,
+                      "loc": {
+                        "start": {
+                          "line": 93,
+                          "column": 9
+                        },
+                        "end": {
+                          "line": 96,
+                          "column": 4
+                        }
+                      },
+                      "callee": {
+                        "type": "MemberExpression",
+                        "start": 2322,
+                        "end": 2388,
+                        "loc": {
+                          "start": {
+                            "line": 93,
+                            "column": 9
+                          },
+                          "end": {
+                            "line": 94,
+                            "column": 7
+                          }
+                        },
+                        "object": {
+                          "type": "CallExpression",
+                          "start": 2322,
+                          "end": 2380,
+                          "loc": {
+                            "start": {
+                              "line": 93,
+                              "column": 9
+                            },
+                            "end": {
+                              "line": 93,
+                              "column": 67
+                            }
+                          },
+                          "callee": {
+                            "type": "MemberExpression",
+                            "start": 2322,
+                            "end": 2331,
+                            "loc": {
+                              "start": {
+                                "line": 93,
+                                "column": 9
+                              },
+                              "end": {
+                                "line": 93,
+                                "column": 18
+                              }
+                            },
+                            "object": {
+                              "type": "Identifier",
+                              "start": 2322,
+                              "end": 2327,
+                              "loc": {
+                                "start": {
+                                  "line": 93,
+                                  "column": 9
+                                },
+                                "end": {
+                                  "line": 93,
+                                  "column": 14
+                                },
+                                "identifierName": "axios"
+                              },
+                              "name": "axios"
+                            },
+                            "property": {
+                              "type": "Identifier",
+                              "start": 2328,
+                              "end": 2331,
+                              "loc": {
+                                "start": {
+                                  "line": 93,
+                                  "column": 15
+                                },
+                                "end": {
+                                  "line": 93,
+                                  "column": 18
+                                },
+                                "identifierName": "get"
+                              },
+                              "name": "get"
+                            },
+                            "computed": false
+                          },
+                          "arguments": [
+                            {
+                              "type": "TemplateLiteral",
+                              "start": 2332,
+                              "end": 2356,
+                              "loc": {
+                                "start": {
+                                  "line": 93,
+                                  "column": 19
+                                },
+                                "end": {
+                                  "line": 93,
+                                  "column": 43
+                                }
+                              },
+                              "expressions": [
+                                {
+                                  "type": "Identifier",
+                                  "start": 2335,
+                                  "end": 2338,
+                                  "loc": {
+                                    "start": {
+                                      "line": 93,
+                                      "column": 22
+                                    },
+                                    "end": {
+                                      "line": 93,
+                                      "column": 25
+                                    },
+                                    "identifierName": "url"
+                                  },
+                                  "name": "url"
+                                },
+                                {
+                                  "type": "Identifier",
+                                  "start": 2351,
+                                  "end": 2354,
+                                  "loc": {
+                                    "start": {
+                                      "line": 93,
+                                      "column": 38
+                                    },
+                                    "end": {
+                                      "line": 93,
+                                      "column": 41
+                                    },
+                                    "identifierName": "src"
+                                  },
+                                  "name": "src"
+                                }
+                              ],
+                              "quasis": [
+                                {
+                                  "type": "TemplateElement",
+                                  "start": 2333,
+                                  "end": 2333,
+                                  "loc": {
+                                    "start": {
+                                      "line": 93,
+                                      "column": 20
+                                    },
+                                    "end": {
+                                      "line": 93,
+                                      "column": 20
+                                    }
+                                  },
+                                  "value": {
+                                    "raw": "",
+                                    "cooked": ""
+                                  },
+                                  "tail": false
+                                },
+                                {
+                                  "type": "TemplateElement",
+                                  "start": 2339,
+                                  "end": 2349,
+                                  "loc": {
+                                    "start": {
+                                      "line": 93,
+                                      "column": 26
+                                    },
+                                    "end": {
+                                      "line": 93,
+                                      "column": 36
+                                    }
+                                  },
+                                  "value": {
+                                    "raw": "/obsolete/",
+                                    "cooked": "/obsolete/"
+                                  },
+                                  "tail": false
+                                },
+                                {
+                                  "type": "TemplateElement",
+                                  "start": 2355,
+                                  "end": 2355,
+                                  "loc": {
+                                    "start": {
+                                      "line": 93,
+                                      "column": 42
+                                    },
+                                    "end": {
+                                      "line": 93,
+                                      "column": 42
+                                    }
+                                  },
+                                  "value": {
+                                    "raw": "",
+                                    "cooked": ""
+                                  },
+                                  "tail": true
+                                }
+                              ]
+                            },
+                            {
+                              "type": "ObjectExpression",
+                              "start": 2358,
+                              "end": 2379,
+                              "loc": {
+                                "start": {
+                                  "line": 93,
+                                  "column": 45
+                                },
+                                "end": {
+                                  "line": 93,
+                                  "column": 66
+                                }
+                              },
+                              "properties": [
+                                {
+                                  "type": "ObjectProperty",
+                                  "start": 2359,
+                                  "end": 2378,
+                                  "loc": {
+                                    "start": {
+                                      "line": 93,
+                                      "column": 46
+                                    },
+                                    "end": {
+                                      "line": 93,
+                                      "column": 65
+                                    }
+                                  },
+                                  "method": false,
+                                  "shorthand": false,
+                                  "computed": false,
+                                  "key": {
+                                    "type": "Identifier",
+                                    "start": 2359,
+                                    "end": 2371,
+                                    "loc": {
+                                      "start": {
+                                        "line": 93,
+                                        "column": 46
+                                      },
+                                      "end": {
+                                        "line": 93,
+                                        "column": 58
+                                      },
+                                      "identifierName": "responseType"
+                                    },
+                                    "name": "responseType"
+                                  },
+                                  "value": {
+                                    "type": "StringLiteral",
+                                    "start": 2373,
+                                    "end": 2378,
+                                    "loc": {
+                                      "start": {
+                                        "line": 93,
+                                        "column": 60
+                                      },
+                                      "end": {
+                                        "line": 93,
+                                        "column": 65
+                                      }
+                                    },
+                                    "extra": {
+                                      "rawValue": "xml",
+                                      "raw": "'xml'"
+                                    },
+                                    "value": "xml"
+                                  }
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        "property": {
+                          "type": "Identifier",
+                          "start": 2384,
+                          "end": 2388,
+                          "loc": {
+                            "start": {
+                              "line": 94,
+                              "column": 3
+                            },
+                            "end": {
+                              "line": 94,
+                              "column": 7
+                            },
+                            "identifierName": "then"
+                          },
+                          "name": "then"
+                        },
+                        "computed": false
+                      },
+                      "arguments": [
+                        {
+                          "type": "ArrowFunctionExpression",
+                          "start": 2389,
+                          "end": 2441,
+                          "loc": {
+                            "start": {
+                              "line": 94,
+                              "column": 8
+                            },
+                            "end": {
+                              "line": 96,
+                              "column": 3
+                            }
+                          },
+                          "id": null,
+                          "generator": false,
+                          "expression": false,
+                          "async": false,
+                          "params": [
+                            {
+                              "type": "Identifier",
+                              "start": 2390,
+                              "end": 2393,
+                              "loc": {
+                                "start": {
+                                  "line": 94,
+                                  "column": 9
+                                },
+                                "end": {
+                                  "line": 94,
+                                  "column": 12
+                                },
+                                "identifierName": "res"
+                              },
+                              "name": "res"
+                            }
+                          ],
+                          "body": {
+                            "type": "BlockStatement",
+                            "start": 2398,
+                            "end": 2441,
+                            "loc": {
+                              "start": {
+                                "line": 94,
+                                "column": 17
+                              },
+                              "end": {
+                                "line": 96,
+                                "column": 3
+                              }
+                            },
+                            "body": [
+                              {
+                                "type": "ReturnStatement",
+                                "start": 2404,
+                                "end": 2437,
+                                "loc": {
+                                  "start": {
+                                    "line": 95,
+                                    "column": 4
+                                  },
+                                  "end": {
+                                    "line": 95,
+                                    "column": 37
+                                  }
+                                },
+                                "argument": {
+                                  "type": "CallExpression",
+                                  "start": 2411,
+                                  "end": 2436,
+                                  "loc": {
+                                    "start": {
+                                      "line": 95,
+                                      "column": 11
+                                    },
+                                    "end": {
+                                      "line": 95,
+                                      "column": 36
+                                    }
+                                  },
+                                  "callee": {
+                                    "type": "MemberExpression",
+                                    "start": 2411,
+                                    "end": 2426,
+                                    "loc": {
+                                      "start": {
+                                        "line": 95,
+                                        "column": 11
+                                      },
+                                      "end": {
+                                        "line": 95,
+                                        "column": 26
+                                      }
+                                    },
+                                    "object": {
+                                      "type": "Identifier",
+                                      "start": 2411,
+                                      "end": 2418,
+                                      "loc": {
+                                        "start": {
+                                          "line": 95,
+                                          "column": 11
+                                        },
+                                        "end": {
+                                          "line": 95,
+                                          "column": 18
+                                        },
+                                        "identifierName": "Promise"
+                                      },
+                                      "name": "Promise"
+                                    },
+                                    "property": {
+                                      "type": "Identifier",
+                                      "start": 2419,
+                                      "end": 2426,
+                                      "loc": {
+                                        "start": {
+                                          "line": 95,
+                                          "column": 19
+                                        },
+                                        "end": {
+                                          "line": 95,
+                                          "column": 26
+                                        },
+                                        "identifierName": "resolve"
+                                      },
+                                      "name": "resolve"
+                                    },
+                                    "computed": false
+                                  },
+                                  "arguments": [
+                                    {
+                                      "type": "MemberExpression",
+                                      "start": 2427,
+                                      "end": 2435,
+                                      "loc": {
+                                        "start": {
+                                          "line": 95,
+                                          "column": 27
+                                        },
+                                        "end": {
+                                          "line": 95,
+                                          "column": 35
+                                        }
+                                      },
+                                      "object": {
+                                        "type": "Identifier",
+                                        "start": 2427,
+                                        "end": 2430,
+                                        "loc": {
+                                          "start": {
+                                            "line": 95,
+                                            "column": 27
+                                          },
+                                          "end": {
+                                            "line": 95,
+                                            "column": 30
+                                          },
+                                          "identifierName": "res"
+                                        },
+                                        "name": "res"
+                                      },
+                                      "property": {
+                                        "type": "Identifier",
+                                        "start": 2431,
+                                        "end": 2435,
+                                        "loc": {
+                                          "start": {
+                                            "line": 95,
+                                            "column": 31
+                                          },
+                                          "end": {
+                                            "line": 95,
+                                            "column": 35
+                                          },
+                                          "identifierName": "data"
+                                        },
+                                        "name": "data"
+                                      },
+                                      "computed": false
+                                    }
+                                  ]
+                                }
+                              }
+                            ],
+                            "directives": []
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ],
+                "directives": []
+              }
+            },
+            "leadingComments": null
+          }
+        ],
+        "kind": "const",
+        "leadingComments": [
+          {
+            "type": "CommentBlock",
+            "value": "*\n * Get a single part fzp from the obsolete parts, this is for old sketches only!\n *\n * @param  {String} src\n * @param  {String} url - The base URL of the parts api\n * @return {Promise} the fetch promise returns xml\n ",
+            "start": 2027,
+            "end": 2249,
+            "loc": {
+              "start": {
+                "line": 85,
+                "column": 0
+              },
+              "end": {
+                "line": 91,
+                "column": 3
+              }
+            }
+          }
+        ],
+        "trailingComments": [
+          {
+            "type": "CommentBlock",
+            "value": "*\n * Get a single part svg and response the svg as a string\n *\n * @param  {String} src\n * @param  {String} url - The base URL of the parts api\n * @return {Promise} the fetch promise\n ",
+            "start": 2448,
+            "end": 2635,
+            "loc": {
+              "start": {
+                "line": 99,
+                "column": 0
+              },
+              "end": {
+                "line": 105,
+                "column": 3
+              }
+            }
+          }
+        ]
+      },
+      {
+        "type": "VariableDeclaration",
+        "start": 2637,
+        "end": 2825,
+        "loc": {
+          "start": {
+            "line": 106,
+            "column": 1
+          },
+          "end": {
+            "line": 111,
+            "column": 3
+          }
+        },
+        "declarations": [
+          {
+            "type": "VariableDeclarator",
+            "start": 2643,
+            "end": 2824,
+            "loc": {
+              "start": {
+                "line": 106,
+                "column": 7
+              },
+              "end": {
+                "line": 111,
+                "column": 2
+              }
+            },
+            "id": {
+              "type": "Identifier",
+              "start": 2643,
+              "end": 2649,
+              "loc": {
+                "start": {
+                  "line": 106,
+                  "column": 7
+                },
+                "end": {
+                  "line": 106,
+                  "column": 13
+                },
+                "identifierName": "getSvg"
+              },
+              "name": "getSvg",
+              "leadingComments": null
+            },
+            "init": {
+              "type": "FunctionExpression",
+              "start": 2652,
+              "end": 2824,
+              "loc": {
+                "start": {
+                  "line": 106,
+                  "column": 16
+                },
+                "end": {
+                  "line": 111,
+                  "column": 2
+                }
+              },
+              "id": {
+                "type": "Identifier",
+                "start": 2643,
+                "end": 2649,
+                "loc": {
+                  "start": {
+                    "line": 106,
+                    "column": 7
+                  },
+                  "end": {
+                    "line": 106,
+                    "column": 13
+                  },
+                  "identifierName": "getSvg"
+                },
+                "name": "getSvg",
+                "leadingComments": null
+              },
+              "generator": false,
+              "expression": false,
+              "async": false,
+              "params": [
+                {
+                  "type": "Identifier",
+                  "start": 2661,
+                  "end": 2664,
+                  "loc": {
+                    "start": {
+                      "line": 106,
+                      "column": 25
+                    },
+                    "end": {
+                      "line": 106,
+                      "column": 28
+                    },
+                    "identifierName": "src"
+                  },
+                  "name": "src"
+                },
+                {
+                  "type": "AssignmentPattern",
+                  "start": 2666,
+                  "end": 2688,
+                  "loc": {
+                    "start": {
+                      "line": 106,
+                      "column": 30
+                    },
+                    "end": {
+                      "line": 106,
+                      "column": 52
+                    }
+                  },
+                  "left": {
+                    "type": "Identifier",
+                    "start": 2666,
+                    "end": 2669,
+                    "loc": {
+                      "start": {
+                        "line": 106,
+                        "column": 30
+                      },
+                      "end": {
+                        "line": 106,
+                        "column": 33
+                      },
+                      "identifierName": "url"
+                    },
+                    "name": "url"
+                  },
+                  "right": {
+                    "type": "Identifier",
+                    "start": 2672,
+                    "end": 2688,
+                    "loc": {
+                      "start": {
+                        "line": 106,
+                        "column": 36
+                      },
+                      "end": {
+                        "line": 106,
+                        "column": 52
+                      },
+                      "identifierName": "FritzingPartsAPI"
+                    },
+                    "name": "FritzingPartsAPI"
+                  }
+                }
+              ],
+              "body": {
+                "type": "BlockStatement",
+                "start": 2690,
+                "end": 2824,
+                "loc": {
+                  "start": {
+                    "line": 106,
+                    "column": 54
+                  },
+                  "end": {
+                    "line": 111,
+                    "column": 2
+                  }
+                },
+                "body": [
+                  {
+                    "type": "ReturnStatement",
+                    "start": 2695,
+                    "end": 2821,
+                    "loc": {
+                      "start": {
+                        "line": 107,
+                        "column": 3
+                      },
+                      "end": {
+                        "line": 110,
+                        "column": 6
+                      }
+                    },
+                    "argument": {
+                      "type": "CallExpression",
+                      "start": 2702,
+                      "end": 2820,
+                      "loc": {
+                        "start": {
+                          "line": 107,
+                          "column": 10
+                        },
+                        "end": {
+                          "line": 110,
+                          "column": 5
+                        }
+                      },
+                      "callee": {
+                        "type": "MemberExpression",
+                        "start": 2702,
+                        "end": 2764,
+                        "loc": {
+                          "start": {
+                            "line": 107,
+                            "column": 10
+                          },
+                          "end": {
+                            "line": 108,
+                            "column": 8
+                          }
+                        },
+                        "object": {
+                          "type": "CallExpression",
+                          "start": 2702,
+                          "end": 2755,
+                          "loc": {
+                            "start": {
+                              "line": 107,
+                              "column": 10
+                            },
+                            "end": {
+                              "line": 107,
+                              "column": 63
+                            }
+                          },
+                          "callee": {
+                            "type": "MemberExpression",
+                            "start": 2702,
+                            "end": 2711,
+                            "loc": {
+                              "start": {
+                                "line": 107,
+                                "column": 10
+                              },
+                              "end": {
+                                "line": 107,
+                                "column": 19
+                              }
+                            },
+                            "object": {
+                              "type": "Identifier",
+                              "start": 2702,
+                              "end": 2707,
+                              "loc": {
+                                "start": {
+                                  "line": 107,
+                                  "column": 10
+                                },
+                                "end": {
+                                  "line": 107,
+                                  "column": 15
+                                },
+                                "identifierName": "axios"
+                              },
+                              "name": "axios"
+                            },
+                            "property": {
+                              "type": "Identifier",
+                              "start": 2708,
+                              "end": 2711,
+                              "loc": {
+                                "start": {
+                                  "line": 107,
+                                  "column": 16
+                                },
+                                "end": {
+                                  "line": 107,
+                                  "column": 19
+                                },
+                                "identifierName": "get"
+                              },
+                              "name": "get"
+                            },
+                            "computed": false
+                          },
+                          "arguments": [
+                            {
+                              "type": "TemplateLiteral",
+                              "start": 2712,
+                              "end": 2731,
+                              "loc": {
+                                "start": {
+                                  "line": 107,
+                                  "column": 20
+                                },
+                                "end": {
+                                  "line": 107,
+                                  "column": 39
+                                }
+                              },
+                              "expressions": [
+                                {
+                                  "type": "Identifier",
+                                  "start": 2715,
+                                  "end": 2718,
+                                  "loc": {
+                                    "start": {
+                                      "line": 107,
+                                      "column": 23
+                                    },
+                                    "end": {
+                                      "line": 107,
+                                      "column": 26
+                                    },
+                                    "identifierName": "url"
+                                  },
+                                  "name": "url"
+                                },
+                                {
+                                  "type": "Identifier",
+                                  "start": 2726,
+                                  "end": 2729,
+                                  "loc": {
+                                    "start": {
+                                      "line": 107,
+                                      "column": 34
+                                    },
+                                    "end": {
+                                      "line": 107,
+                                      "column": 37
+                                    },
+                                    "identifierName": "src"
+                                  },
+                                  "name": "src"
+                                }
+                              ],
+                              "quasis": [
+                                {
+                                  "type": "TemplateElement",
+                                  "start": 2713,
+                                  "end": 2713,
+                                  "loc": {
+                                    "start": {
+                                      "line": 107,
+                                      "column": 21
+                                    },
+                                    "end": {
+                                      "line": 107,
+                                      "column": 21
+                                    }
+                                  },
+                                  "value": {
+                                    "raw": "",
+                                    "cooked": ""
+                                  },
+                                  "tail": false
+                                },
+                                {
+                                  "type": "TemplateElement",
+                                  "start": 2719,
+                                  "end": 2724,
+                                  "loc": {
+                                    "start": {
+                                      "line": 107,
+                                      "column": 27
+                                    },
+                                    "end": {
+                                      "line": 107,
+                                      "column": 32
+                                    }
+                                  },
+                                  "value": {
+                                    "raw": "/svg/",
+                                    "cooked": "/svg/"
+                                  },
+                                  "tail": false
+                                },
+                                {
+                                  "type": "TemplateElement",
+                                  "start": 2730,
+                                  "end": 2730,
+                                  "loc": {
+                                    "start": {
+                                      "line": 107,
+                                      "column": 38
+                                    },
+                                    "end": {
+                                      "line": 107,
+                                      "column": 38
+                                    }
+                                  },
+                                  "value": {
+                                    "raw": "",
+                                    "cooked": ""
+                                  },
+                                  "tail": true
+                                }
+                              ]
+                            },
+                            {
+                              "type": "ObjectExpression",
+                              "start": 2733,
+                              "end": 2754,
+                              "loc": {
+                                "start": {
+                                  "line": 107,
+                                  "column": 41
+                                },
+                                "end": {
+                                  "line": 107,
+                                  "column": 62
+                                }
+                              },
+                              "properties": [
+                                {
+                                  "type": "ObjectProperty",
+                                  "start": 2734,
+                                  "end": 2753,
+                                  "loc": {
+                                    "start": {
+                                      "line": 107,
+                                      "column": 42
+                                    },
+                                    "end": {
+                                      "line": 107,
+                                      "column": 61
+                                    }
+                                  },
+                                  "method": false,
+                                  "shorthand": false,
+                                  "computed": false,
+                                  "key": {
+                                    "type": "Identifier",
+                                    "start": 2734,
+                                    "end": 2746,
+                                    "loc": {
+                                      "start": {
+                                        "line": 107,
+                                        "column": 42
+                                      },
+                                      "end": {
+                                        "line": 107,
+                                        "column": 54
+                                      },
+                                      "identifierName": "responseType"
+                                    },
+                                    "name": "responseType"
+                                  },
+                                  "value": {
+                                    "type": "StringLiteral",
+                                    "start": 2748,
+                                    "end": 2753,
+                                    "loc": {
+                                      "start": {
+                                        "line": 107,
+                                        "column": 56
+                                      },
+                                      "end": {
+                                        "line": 107,
+                                        "column": 61
+                                      }
+                                    },
+                                    "extra": {
+                                      "rawValue": "xml",
+                                      "raw": "'xml'"
+                                    },
+                                    "value": "xml"
+                                  }
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        "property": {
+                          "type": "Identifier",
+                          "start": 2760,
+                          "end": 2764,
+                          "loc": {
+                            "start": {
+                              "line": 108,
+                              "column": 4
+                            },
+                            "end": {
+                              "line": 108,
+                              "column": 8
+                            },
+                            "identifierName": "then"
+                          },
+                          "name": "then"
+                        },
+                        "computed": false
+                      },
+                      "arguments": [
+                        {
+                          "type": "ArrowFunctionExpression",
+                          "start": 2765,
+                          "end": 2819,
+                          "loc": {
+                            "start": {
+                              "line": 108,
+                              "column": 9
+                            },
+                            "end": {
+                              "line": 110,
+                              "column": 4
+                            }
+                          },
+                          "id": null,
+                          "generator": false,
+                          "expression": false,
+                          "async": false,
+                          "params": [
+                            {
+                              "type": "Identifier",
+                              "start": 2766,
+                              "end": 2769,
+                              "loc": {
+                                "start": {
+                                  "line": 108,
+                                  "column": 10
+                                },
+                                "end": {
+                                  "line": 108,
+                                  "column": 13
+                                },
+                                "identifierName": "res"
+                              },
+                              "name": "res"
+                            }
+                          ],
+                          "body": {
+                            "type": "BlockStatement",
+                            "start": 2774,
+                            "end": 2819,
+                            "loc": {
+                              "start": {
+                                "line": 108,
+                                "column": 18
+                              },
+                              "end": {
+                                "line": 110,
+                                "column": 4
+                              }
+                            },
+                            "body": [
+                              {
+                                "type": "ReturnStatement",
+                                "start": 2781,
+                                "end": 2814,
+                                "loc": {
+                                  "start": {
+                                    "line": 109,
+                                    "column": 5
+                                  },
+                                  "end": {
+                                    "line": 109,
+                                    "column": 38
+                                  }
+                                },
+                                "argument": {
+                                  "type": "CallExpression",
+                                  "start": 2788,
+                                  "end": 2813,
+                                  "loc": {
+                                    "start": {
+                                      "line": 109,
+                                      "column": 12
+                                    },
+                                    "end": {
+                                      "line": 109,
+                                      "column": 37
+                                    }
+                                  },
+                                  "callee": {
+                                    "type": "MemberExpression",
+                                    "start": 2788,
+                                    "end": 2803,
+                                    "loc": {
+                                      "start": {
+                                        "line": 109,
+                                        "column": 12
+                                      },
+                                      "end": {
+                                        "line": 109,
+                                        "column": 27
+                                      }
+                                    },
+                                    "object": {
+                                      "type": "Identifier",
+                                      "start": 2788,
+                                      "end": 2795,
+                                      "loc": {
+                                        "start": {
+                                          "line": 109,
+                                          "column": 12
+                                        },
+                                        "end": {
+                                          "line": 109,
+                                          "column": 19
+                                        },
+                                        "identifierName": "Promise"
+                                      },
+                                      "name": "Promise"
+                                    },
+                                    "property": {
+                                      "type": "Identifier",
+                                      "start": 2796,
+                                      "end": 2803,
+                                      "loc": {
+                                        "start": {
+                                          "line": 109,
+                                          "column": 20
+                                        },
+                                        "end": {
+                                          "line": 109,
+                                          "column": 27
+                                        },
+                                        "identifierName": "resolve"
+                                      },
+                                      "name": "resolve"
+                                    },
+                                    "computed": false
+                                  },
+                                  "arguments": [
+                                    {
+                                      "type": "MemberExpression",
+                                      "start": 2804,
+                                      "end": 2812,
+                                      "loc": {
+                                        "start": {
+                                          "line": 109,
+                                          "column": 28
+                                        },
+                                        "end": {
+                                          "line": 109,
+                                          "column": 36
+                                        }
+                                      },
+                                      "object": {
+                                        "type": "Identifier",
+                                        "start": 2804,
+                                        "end": 2807,
+                                        "loc": {
+                                          "start": {
+                                            "line": 109,
+                                            "column": 28
+                                          },
+                                          "end": {
+                                            "line": 109,
+                                            "column": 31
+                                          },
+                                          "identifierName": "res"
+                                        },
+                                        "name": "res"
+                                      },
+                                      "property": {
+                                        "type": "Identifier",
+                                        "start": 2808,
+                                        "end": 2812,
+                                        "loc": {
+                                          "start": {
+                                            "line": 109,
+                                            "column": 32
+                                          },
+                                          "end": {
+                                            "line": 109,
+                                            "column": 36
+                                          },
+                                          "identifierName": "data"
+                                        },
+                                        "name": "data"
+                                      },
+                                      "computed": false
+                                    }
+                                  ]
+                                }
+                              }
+                            ],
+                            "directives": []
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ],
+                "directives": []
+              }
+            },
+            "leadingComments": null
+          }
+        ],
+        "kind": "const",
+        "leadingComments": [
+          {
+            "type": "CommentBlock",
+            "value": "*\n * Get a single part svg and response the svg as a string\n *\n * @param  {String} src\n * @param  {String} url - The base URL of the parts api\n * @return {Promise} the fetch promise\n ",
+            "start": 2448,
+            "end": 2635,
+            "loc": {
+              "start": {
+                "line": 99,
+                "column": 0
+              },
+              "end": {
+                "line": 105,
+                "column": 3
+              }
+            }
+          }
+        ],
+        "trailingComments": [
+          {
+            "type": "CommentBlock",
+            "value": "*\n  * Get a single part svg from the core parts as svg-string\n  *\n  * @param  {String} src\n  * @param  {String} url - The base URL of the parts api\n  * @return {Promise} the fetch promise returns xml\n  ",
+            "start": 2828,
+            "end": 3034,
+            "loc": {
+              "start": {
+                "line": 113,
+                "column": 1
+              },
+              "end": {
+                "line": 119,
+                "column": 4
+              }
+            }
+          }
+        ]
+      },
+      {
+        "type": "VariableDeclaration",
+        "start": 3035,
+        "end": 3227,
+        "loc": {
+          "start": {
+            "line": 120,
+            "column": 0
+          },
+          "end": {
+            "line": 125,
+            "column": 2
+          }
+        },
+        "declarations": [
+          {
+            "type": "VariableDeclarator",
+            "start": 3041,
+            "end": 3226,
+            "loc": {
+              "start": {
+                "line": 120,
+                "column": 6
+              },
+              "end": {
+                "line": 125,
+                "column": 1
+              }
+            },
+            "id": {
+              "type": "Identifier",
+              "start": 3041,
+              "end": 3051,
+              "loc": {
+                "start": {
+                  "line": 120,
+                  "column": 6
+                },
+                "end": {
+                  "line": 120,
+                  "column": 16
+                },
+                "identifierName": "getSvgCore"
+              },
+              "name": "getSvgCore",
+              "leadingComments": null
+            },
+            "init": {
+              "type": "FunctionExpression",
+              "start": 3054,
+              "end": 3226,
+              "loc": {
+                "start": {
+                  "line": 120,
+                  "column": 19
+                },
+                "end": {
+                  "line": 125,
+                  "column": 1
+                }
+              },
+              "id": {
+                "type": "Identifier",
+                "start": 3041,
+                "end": 3051,
+                "loc": {
+                  "start": {
+                    "line": 120,
+                    "column": 6
+                  },
+                  "end": {
+                    "line": 120,
+                    "column": 16
+                  },
+                  "identifierName": "getSvgCore"
+                },
+                "name": "getSvgCore",
+                "leadingComments": null
+              },
+              "generator": false,
+              "expression": false,
+              "async": false,
+              "params": [
+                {
+                  "type": "Identifier",
+                  "start": 3063,
+                  "end": 3066,
+                  "loc": {
+                    "start": {
+                      "line": 120,
+                      "column": 28
+                    },
+                    "end": {
+                      "line": 120,
+                      "column": 31
+                    },
+                    "identifierName": "src"
+                  },
+                  "name": "src"
+                },
+                {
+                  "type": "AssignmentPattern",
+                  "start": 3068,
+                  "end": 3090,
+                  "loc": {
+                    "start": {
+                      "line": 120,
+                      "column": 33
+                    },
+                    "end": {
+                      "line": 120,
+                      "column": 55
+                    }
+                  },
+                  "left": {
+                    "type": "Identifier",
+                    "start": 3068,
+                    "end": 3071,
+                    "loc": {
+                      "start": {
+                        "line": 120,
+                        "column": 33
+                      },
+                      "end": {
+                        "line": 120,
+                        "column": 36
+                      },
+                      "identifierName": "url"
+                    },
+                    "name": "url"
+                  },
+                  "right": {
+                    "type": "Identifier",
+                    "start": 3074,
+                    "end": 3090,
+                    "loc": {
+                      "start": {
+                        "line": 120,
+                        "column": 39
+                      },
+                      "end": {
+                        "line": 120,
+                        "column": 55
+                      },
+                      "identifierName": "FritzingPartsAPI"
+                    },
+                    "name": "FritzingPartsAPI"
+                  }
+                }
+              ],
+              "body": {
+                "type": "BlockStatement",
+                "start": 3092,
+                "end": 3226,
+                "loc": {
+                  "start": {
+                    "line": 120,
+                    "column": 57
+                  },
+                  "end": {
+                    "line": 125,
+                    "column": 1
+                  }
+                },
+                "body": [
+                  {
+                    "type": "ReturnStatement",
+                    "start": 3096,
+                    "end": 3224,
+                    "loc": {
+                      "start": {
+                        "line": 121,
+                        "column": 2
+                      },
+                      "end": {
+                        "line": 124,
+                        "column": 5
+                      }
+                    },
+                    "argument": {
+                      "type": "CallExpression",
+                      "start": 3103,
+                      "end": 3223,
+                      "loc": {
+                        "start": {
+                          "line": 121,
+                          "column": 9
+                        },
+                        "end": {
+                          "line": 124,
+                          "column": 4
+                        }
+                      },
+                      "callee": {
+                        "type": "MemberExpression",
+                        "start": 3103,
+                        "end": 3169,
+                        "loc": {
+                          "start": {
+                            "line": 121,
+                            "column": 9
+                          },
+                          "end": {
+                            "line": 122,
+                            "column": 7
+                          }
+                        },
+                        "object": {
+                          "type": "CallExpression",
+                          "start": 3103,
+                          "end": 3161,
+                          "loc": {
+                            "start": {
+                              "line": 121,
+                              "column": 9
+                            },
+                            "end": {
+                              "line": 121,
+                              "column": 67
+                            }
+                          },
+                          "callee": {
+                            "type": "MemberExpression",
+                            "start": 3103,
+                            "end": 3112,
+                            "loc": {
+                              "start": {
+                                "line": 121,
+                                "column": 9
+                              },
+                              "end": {
+                                "line": 121,
+                                "column": 18
+                              }
+                            },
+                            "object": {
+                              "type": "Identifier",
+                              "start": 3103,
+                              "end": 3108,
+                              "loc": {
+                                "start": {
+                                  "line": 121,
+                                  "column": 9
+                                },
+                                "end": {
+                                  "line": 121,
+                                  "column": 14
+                                },
+                                "identifierName": "axios"
+                              },
+                              "name": "axios"
+                            },
+                            "property": {
+                              "type": "Identifier",
+                              "start": 3109,
+                              "end": 3112,
+                              "loc": {
+                                "start": {
+                                  "line": 121,
+                                  "column": 15
+                                },
+                                "end": {
+                                  "line": 121,
+                                  "column": 18
+                                },
+                                "identifierName": "get"
+                              },
+                              "name": "get"
+                            },
+                            "computed": false
+                          },
+                          "arguments": [
+                            {
+                              "type": "TemplateLiteral",
+                              "start": 3113,
+                              "end": 3137,
+                              "loc": {
+                                "start": {
+                                  "line": 121,
+                                  "column": 19
+                                },
+                                "end": {
+                                  "line": 121,
+                                  "column": 43
+                                }
+                              },
+                              "expressions": [
+                                {
+                                  "type": "Identifier",
+                                  "start": 3116,
+                                  "end": 3119,
+                                  "loc": {
+                                    "start": {
+                                      "line": 121,
+                                      "column": 22
+                                    },
+                                    "end": {
+                                      "line": 121,
+                                      "column": 25
+                                    },
+                                    "identifierName": "url"
+                                  },
+                                  "name": "url"
+                                },
+                                {
+                                  "type": "Identifier",
+                                  "start": 3132,
+                                  "end": 3135,
+                                  "loc": {
+                                    "start": {
+                                      "line": 121,
+                                      "column": 38
+                                    },
+                                    "end": {
+                                      "line": 121,
+                                      "column": 41
+                                    },
+                                    "identifierName": "src"
+                                  },
+                                  "name": "src"
+                                }
+                              ],
+                              "quasis": [
+                                {
+                                  "type": "TemplateElement",
+                                  "start": 3114,
+                                  "end": 3114,
+                                  "loc": {
+                                    "start": {
+                                      "line": 121,
+                                      "column": 20
+                                    },
+                                    "end": {
+                                      "line": 121,
+                                      "column": 20
+                                    }
+                                  },
+                                  "value": {
+                                    "raw": "",
+                                    "cooked": ""
+                                  },
+                                  "tail": false
+                                },
+                                {
+                                  "type": "TemplateElement",
+                                  "start": 3120,
+                                  "end": 3130,
+                                  "loc": {
+                                    "start": {
+                                      "line": 121,
+                                      "column": 26
+                                    },
+                                    "end": {
+                                      "line": 121,
+                                      "column": 36
+                                    }
+                                  },
+                                  "value": {
+                                    "raw": "/svg/core/",
+                                    "cooked": "/svg/core/"
+                                  },
+                                  "tail": false
+                                },
+                                {
+                                  "type": "TemplateElement",
+                                  "start": 3136,
+                                  "end": 3136,
+                                  "loc": {
+                                    "start": {
+                                      "line": 121,
+                                      "column": 42
+                                    },
+                                    "end": {
+                                      "line": 121,
+                                      "column": 42
+                                    }
+                                  },
+                                  "value": {
+                                    "raw": "",
+                                    "cooked": ""
+                                  },
+                                  "tail": true
+                                }
+                              ]
+                            },
+                            {
+                              "type": "ObjectExpression",
+                              "start": 3139,
+                              "end": 3160,
+                              "loc": {
+                                "start": {
+                                  "line": 121,
+                                  "column": 45
+                                },
+                                "end": {
+                                  "line": 121,
+                                  "column": 66
+                                }
+                              },
+                              "properties": [
+                                {
+                                  "type": "ObjectProperty",
+                                  "start": 3140,
+                                  "end": 3159,
+                                  "loc": {
+                                    "start": {
+                                      "line": 121,
+                                      "column": 46
+                                    },
+                                    "end": {
+                                      "line": 121,
+                                      "column": 65
+                                    }
+                                  },
+                                  "method": false,
+                                  "shorthand": false,
+                                  "computed": false,
+                                  "key": {
+                                    "type": "Identifier",
+                                    "start": 3140,
+                                    "end": 3152,
+                                    "loc": {
+                                      "start": {
+                                        "line": 121,
+                                        "column": 46
+                                      },
+                                      "end": {
+                                        "line": 121,
+                                        "column": 58
+                                      },
+                                      "identifierName": "responseType"
+                                    },
+                                    "name": "responseType"
+                                  },
+                                  "value": {
+                                    "type": "StringLiteral",
+                                    "start": 3154,
+                                    "end": 3159,
+                                    "loc": {
+                                      "start": {
+                                        "line": 121,
+                                        "column": 60
+                                      },
+                                      "end": {
+                                        "line": 121,
+                                        "column": 65
+                                      }
+                                    },
+                                    "extra": {
+                                      "rawValue": "xml",
+                                      "raw": "'xml'"
+                                    },
+                                    "value": "xml"
+                                  }
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        "property": {
+                          "type": "Identifier",
+                          "start": 3165,
+                          "end": 3169,
+                          "loc": {
+                            "start": {
+                              "line": 122,
+                              "column": 3
+                            },
+                            "end": {
+                              "line": 122,
+                              "column": 7
+                            },
+                            "identifierName": "then"
+                          },
+                          "name": "then"
+                        },
+                        "computed": false
+                      },
+                      "arguments": [
+                        {
+                          "type": "ArrowFunctionExpression",
+                          "start": 3170,
+                          "end": 3222,
+                          "loc": {
+                            "start": {
+                              "line": 122,
+                              "column": 8
+                            },
+                            "end": {
+                              "line": 124,
+                              "column": 3
+                            }
+                          },
+                          "id": null,
+                          "generator": false,
+                          "expression": false,
+                          "async": false,
+                          "params": [
+                            {
+                              "type": "Identifier",
+                              "start": 3171,
+                              "end": 3174,
+                              "loc": {
+                                "start": {
+                                  "line": 122,
+                                  "column": 9
+                                },
+                                "end": {
+                                  "line": 122,
+                                  "column": 12
+                                },
+                                "identifierName": "res"
+                              },
+                              "name": "res"
+                            }
+                          ],
+                          "body": {
+                            "type": "BlockStatement",
+                            "start": 3179,
+                            "end": 3222,
+                            "loc": {
+                              "start": {
+                                "line": 122,
+                                "column": 17
+                              },
+                              "end": {
+                                "line": 124,
+                                "column": 3
+                              }
+                            },
+                            "body": [
+                              {
+                                "type": "ReturnStatement",
+                                "start": 3185,
+                                "end": 3218,
+                                "loc": {
+                                  "start": {
+                                    "line": 123,
+                                    "column": 4
+                                  },
+                                  "end": {
+                                    "line": 123,
+                                    "column": 37
+                                  }
+                                },
+                                "argument": {
+                                  "type": "CallExpression",
+                                  "start": 3192,
+                                  "end": 3217,
+                                  "loc": {
+                                    "start": {
+                                      "line": 123,
+                                      "column": 11
+                                    },
+                                    "end": {
+                                      "line": 123,
+                                      "column": 36
+                                    }
+                                  },
+                                  "callee": {
+                                    "type": "MemberExpression",
+                                    "start": 3192,
+                                    "end": 3207,
+                                    "loc": {
+                                      "start": {
+                                        "line": 123,
+                                        "column": 11
+                                      },
+                                      "end": {
+                                        "line": 123,
+                                        "column": 26
+                                      }
+                                    },
+                                    "object": {
+                                      "type": "Identifier",
+                                      "start": 3192,
+                                      "end": 3199,
+                                      "loc": {
+                                        "start": {
+                                          "line": 123,
+                                          "column": 11
+                                        },
+                                        "end": {
+                                          "line": 123,
+                                          "column": 18
+                                        },
+                                        "identifierName": "Promise"
+                                      },
+                                      "name": "Promise"
+                                    },
+                                    "property": {
+                                      "type": "Identifier",
+                                      "start": 3200,
+                                      "end": 3207,
+                                      "loc": {
+                                        "start": {
+                                          "line": 123,
+                                          "column": 19
+                                        },
+                                        "end": {
+                                          "line": 123,
+                                          "column": 26
+                                        },
+                                        "identifierName": "resolve"
+                                      },
+                                      "name": "resolve"
+                                    },
+                                    "computed": false
+                                  },
+                                  "arguments": [
+                                    {
+                                      "type": "MemberExpression",
+                                      "start": 3208,
+                                      "end": 3216,
+                                      "loc": {
+                                        "start": {
+                                          "line": 123,
+                                          "column": 27
+                                        },
+                                        "end": {
+                                          "line": 123,
+                                          "column": 35
+                                        }
+                                      },
+                                      "object": {
+                                        "type": "Identifier",
+                                        "start": 3208,
+                                        "end": 3211,
+                                        "loc": {
+                                          "start": {
+                                            "line": 123,
+                                            "column": 27
+                                          },
+                                          "end": {
+                                            "line": 123,
+                                            "column": 30
+                                          },
+                                          "identifierName": "res"
+                                        },
+                                        "name": "res"
+                                      },
+                                      "property": {
+                                        "type": "Identifier",
+                                        "start": 3212,
+                                        "end": 3216,
+                                        "loc": {
+                                          "start": {
+                                            "line": 123,
+                                            "column": 31
+                                          },
+                                          "end": {
+                                            "line": 123,
+                                            "column": 35
+                                          },
+                                          "identifierName": "data"
+                                        },
+                                        "name": "data"
+                                      },
+                                      "computed": false
+                                    }
+                                  ]
+                                }
+                              }
+                            ],
+                            "directives": []
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ],
+                "directives": []
+              }
+            },
+            "leadingComments": null
+          }
+        ],
+        "kind": "const",
+        "leadingComments": [
+          {
+            "type": "CommentBlock",
+            "value": "*\n  * Get a single part svg from the core parts as svg-string\n  *\n  * @param  {String} src\n  * @param  {String} url - The base URL of the parts api\n  * @return {Promise} the fetch promise returns xml\n  ",
+            "start": 2828,
+            "end": 3034,
+            "loc": {
+              "start": {
+                "line": 113,
+                "column": 1
+              },
+              "end": {
+                "line": 119,
+                "column": 4
+              }
+            }
+          }
+        ],
+        "trailingComments": [
+          {
+            "type": "CommentBlock",
+            "value": "*\n * Get a single part svg from the obsolete svgs, this is for old-sketches only! the response is a svg-string\n *\n * @param  {String} src\n * @param  {String} url - The base URL of the parts api\n * @return {Promise} the fetch promise\n ",
+            "start": 3229,
+            "end": 3467,
+            "loc": {
+              "start": {
+                "line": 127,
+                "column": 0
+              },
+              "end": {
+                "line": 133,
+                "column": 3
+              }
+            }
+          }
+        ]
+      },
+      {
+        "type": "VariableDeclaration",
+        "start": 3468,
+        "end": 3668,
+        "loc": {
+          "start": {
+            "line": 134,
+            "column": 0
+          },
+          "end": {
+            "line": 139,
+            "column": 2
+          }
+        },
+        "declarations": [
+          {
+            "type": "VariableDeclarator",
+            "start": 3474,
+            "end": 3667,
+            "loc": {
+              "start": {
+                "line": 134,
+                "column": 6
+              },
+              "end": {
+                "line": 139,
+                "column": 1
+              }
+            },
+            "id": {
+              "type": "Identifier",
+              "start": 3474,
+              "end": 3488,
+              "loc": {
+                "start": {
+                  "line": 134,
+                  "column": 6
+                },
+                "end": {
+                  "line": 134,
+                  "column": 20
+                },
+                "identifierName": "getSvgObsolete"
+              },
+              "name": "getSvgObsolete",
+              "leadingComments": null
+            },
+            "init": {
+              "type": "FunctionExpression",
+              "start": 3491,
+              "end": 3667,
+              "loc": {
+                "start": {
+                  "line": 134,
+                  "column": 23
+                },
+                "end": {
+                  "line": 139,
+                  "column": 1
+                }
+              },
+              "id": {
+                "type": "Identifier",
+                "start": 3474,
+                "end": 3488,
+                "loc": {
+                  "start": {
+                    "line": 134,
+                    "column": 6
+                  },
+                  "end": {
+                    "line": 134,
+                    "column": 20
+                  },
+                  "identifierName": "getSvgObsolete"
+                },
+                "name": "getSvgObsolete",
+                "leadingComments": null
+              },
+              "generator": false,
+              "expression": false,
+              "async": false,
+              "params": [
+                {
+                  "type": "Identifier",
+                  "start": 3500,
+                  "end": 3503,
+                  "loc": {
+                    "start": {
+                      "line": 134,
+                      "column": 32
+                    },
+                    "end": {
+                      "line": 134,
+                      "column": 35
+                    },
+                    "identifierName": "src"
+                  },
+                  "name": "src"
+                },
+                {
+                  "type": "AssignmentPattern",
+                  "start": 3505,
+                  "end": 3527,
+                  "loc": {
+                    "start": {
+                      "line": 134,
+                      "column": 37
+                    },
+                    "end": {
+                      "line": 134,
+                      "column": 59
+                    }
+                  },
+                  "left": {
+                    "type": "Identifier",
+                    "start": 3505,
+                    "end": 3508,
+                    "loc": {
+                      "start": {
+                        "line": 134,
+                        "column": 37
+                      },
+                      "end": {
+                        "line": 134,
+                        "column": 40
+                      },
+                      "identifierName": "url"
+                    },
+                    "name": "url"
+                  },
+                  "right": {
+                    "type": "Identifier",
+                    "start": 3511,
+                    "end": 3527,
+                    "loc": {
+                      "start": {
+                        "line": 134,
+                        "column": 43
+                      },
+                      "end": {
+                        "line": 134,
+                        "column": 59
+                      },
+                      "identifierName": "FritzingPartsAPI"
+                    },
+                    "name": "FritzingPartsAPI"
+                  }
+                }
+              ],
+              "body": {
+                "type": "BlockStatement",
+                "start": 3529,
+                "end": 3667,
+                "loc": {
+                  "start": {
+                    "line": 134,
+                    "column": 61
+                  },
+                  "end": {
+                    "line": 139,
+                    "column": 1
+                  }
+                },
+                "body": [
+                  {
+                    "type": "ReturnStatement",
+                    "start": 3533,
+                    "end": 3665,
+                    "loc": {
+                      "start": {
+                        "line": 135,
+                        "column": 2
+                      },
+                      "end": {
+                        "line": 138,
+                        "column": 5
+                      }
+                    },
+                    "argument": {
+                      "type": "CallExpression",
+                      "start": 3540,
+                      "end": 3664,
+                      "loc": {
+                        "start": {
+                          "line": 135,
+                          "column": 9
+                        },
+                        "end": {
+                          "line": 138,
+                          "column": 4
+                        }
+                      },
+                      "callee": {
+                        "type": "MemberExpression",
+                        "start": 3540,
+                        "end": 3610,
+                        "loc": {
+                          "start": {
+                            "line": 135,
+                            "column": 9
+                          },
+                          "end": {
+                            "line": 136,
+                            "column": 7
+                          }
+                        },
+                        "object": {
+                          "type": "CallExpression",
+                          "start": 3540,
+                          "end": 3602,
+                          "loc": {
+                            "start": {
+                              "line": 135,
+                              "column": 9
+                            },
+                            "end": {
+                              "line": 135,
+                              "column": 71
+                            }
+                          },
+                          "callee": {
+                            "type": "MemberExpression",
+                            "start": 3540,
+                            "end": 3549,
+                            "loc": {
+                              "start": {
+                                "line": 135,
+                                "column": 9
+                              },
+                              "end": {
+                                "line": 135,
+                                "column": 18
+                              }
+                            },
+                            "object": {
+                              "type": "Identifier",
+                              "start": 3540,
+                              "end": 3545,
+                              "loc": {
+                                "start": {
+                                  "line": 135,
+                                  "column": 9
+                                },
+                                "end": {
+                                  "line": 135,
+                                  "column": 14
+                                },
+                                "identifierName": "axios"
+                              },
+                              "name": "axios"
+                            },
+                            "property": {
+                              "type": "Identifier",
+                              "start": 3546,
+                              "end": 3549,
+                              "loc": {
+                                "start": {
+                                  "line": 135,
+                                  "column": 15
+                                },
+                                "end": {
+                                  "line": 135,
+                                  "column": 18
+                                },
+                                "identifierName": "get"
+                              },
+                              "name": "get"
+                            },
+                            "computed": false
+                          },
+                          "arguments": [
+                            {
+                              "type": "TemplateLiteral",
+                              "start": 3550,
+                              "end": 3578,
+                              "loc": {
+                                "start": {
+                                  "line": 135,
+                                  "column": 19
+                                },
+                                "end": {
+                                  "line": 135,
+                                  "column": 47
+                                }
+                              },
+                              "expressions": [
+                                {
+                                  "type": "Identifier",
+                                  "start": 3553,
+                                  "end": 3556,
+                                  "loc": {
+                                    "start": {
+                                      "line": 135,
+                                      "column": 22
+                                    },
+                                    "end": {
+                                      "line": 135,
+                                      "column": 25
+                                    },
+                                    "identifierName": "url"
+                                  },
+                                  "name": "url"
+                                },
+                                {
+                                  "type": "Identifier",
+                                  "start": 3573,
+                                  "end": 3576,
+                                  "loc": {
+                                    "start": {
+                                      "line": 135,
+                                      "column": 42
+                                    },
+                                    "end": {
+                                      "line": 135,
+                                      "column": 45
+                                    },
+                                    "identifierName": "src"
+                                  },
+                                  "name": "src"
+                                }
+                              ],
+                              "quasis": [
+                                {
+                                  "type": "TemplateElement",
+                                  "start": 3551,
+                                  "end": 3551,
+                                  "loc": {
+                                    "start": {
+                                      "line": 135,
+                                      "column": 20
+                                    },
+                                    "end": {
+                                      "line": 135,
+                                      "column": 20
+                                    }
+                                  },
+                                  "value": {
+                                    "raw": "",
+                                    "cooked": ""
+                                  },
+                                  "tail": false
+                                },
+                                {
+                                  "type": "TemplateElement",
+                                  "start": 3557,
+                                  "end": 3571,
+                                  "loc": {
+                                    "start": {
+                                      "line": 135,
+                                      "column": 26
+                                    },
+                                    "end": {
+                                      "line": 135,
+                                      "column": 40
+                                    }
+                                  },
+                                  "value": {
+                                    "raw": "/svg/obsolete/",
+                                    "cooked": "/svg/obsolete/"
+                                  },
+                                  "tail": false
+                                },
+                                {
+                                  "type": "TemplateElement",
+                                  "start": 3577,
+                                  "end": 3577,
+                                  "loc": {
+                                    "start": {
+                                      "line": 135,
+                                      "column": 46
+                                    },
+                                    "end": {
+                                      "line": 135,
+                                      "column": 46
+                                    }
+                                  },
+                                  "value": {
+                                    "raw": "",
+                                    "cooked": ""
+                                  },
+                                  "tail": true
+                                }
+                              ]
+                            },
+                            {
+                              "type": "ObjectExpression",
+                              "start": 3580,
+                              "end": 3601,
+                              "loc": {
+                                "start": {
+                                  "line": 135,
+                                  "column": 49
+                                },
+                                "end": {
+                                  "line": 135,
+                                  "column": 70
+                                }
+                              },
+                              "properties": [
+                                {
+                                  "type": "ObjectProperty",
+                                  "start": 3581,
+                                  "end": 3600,
+                                  "loc": {
+                                    "start": {
+                                      "line": 135,
+                                      "column": 50
+                                    },
+                                    "end": {
+                                      "line": 135,
+                                      "column": 69
+                                    }
+                                  },
+                                  "method": false,
+                                  "shorthand": false,
+                                  "computed": false,
+                                  "key": {
+                                    "type": "Identifier",
+                                    "start": 3581,
+                                    "end": 3593,
+                                    "loc": {
+                                      "start": {
+                                        "line": 135,
+                                        "column": 50
+                                      },
+                                      "end": {
+                                        "line": 135,
+                                        "column": 62
+                                      },
+                                      "identifierName": "responseType"
+                                    },
+                                    "name": "responseType"
+                                  },
+                                  "value": {
+                                    "type": "StringLiteral",
+                                    "start": 3595,
+                                    "end": 3600,
+                                    "loc": {
+                                      "start": {
+                                        "line": 135,
+                                        "column": 64
+                                      },
+                                      "end": {
+                                        "line": 135,
+                                        "column": 69
+                                      }
+                                    },
+                                    "extra": {
+                                      "rawValue": "xml",
+                                      "raw": "'xml'"
+                                    },
+                                    "value": "xml"
+                                  }
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        "property": {
+                          "type": "Identifier",
+                          "start": 3606,
+                          "end": 3610,
+                          "loc": {
+                            "start": {
+                              "line": 136,
+                              "column": 3
+                            },
+                            "end": {
+                              "line": 136,
+                              "column": 7
+                            },
+                            "identifierName": "then"
+                          },
+                          "name": "then"
+                        },
+                        "computed": false
+                      },
+                      "arguments": [
+                        {
+                          "type": "ArrowFunctionExpression",
+                          "start": 3611,
+                          "end": 3663,
+                          "loc": {
+                            "start": {
+                              "line": 136,
+                              "column": 8
+                            },
+                            "end": {
+                              "line": 138,
+                              "column": 3
+                            }
+                          },
+                          "id": null,
+                          "generator": false,
+                          "expression": false,
+                          "async": false,
+                          "params": [
+                            {
+                              "type": "Identifier",
+                              "start": 3612,
+                              "end": 3615,
+                              "loc": {
+                                "start": {
+                                  "line": 136,
+                                  "column": 9
+                                },
+                                "end": {
+                                  "line": 136,
+                                  "column": 12
+                                },
+                                "identifierName": "res"
+                              },
+                              "name": "res"
+                            }
+                          ],
+                          "body": {
+                            "type": "BlockStatement",
+                            "start": 3620,
+                            "end": 3663,
+                            "loc": {
+                              "start": {
+                                "line": 136,
+                                "column": 17
+                              },
+                              "end": {
+                                "line": 138,
+                                "column": 3
+                              }
+                            },
+                            "body": [
+                              {
+                                "type": "ReturnStatement",
+                                "start": 3626,
+                                "end": 3659,
+                                "loc": {
+                                  "start": {
+                                    "line": 137,
+                                    "column": 4
+                                  },
+                                  "end": {
+                                    "line": 137,
+                                    "column": 37
+                                  }
+                                },
+                                "argument": {
+                                  "type": "CallExpression",
+                                  "start": 3633,
+                                  "end": 3658,
+                                  "loc": {
+                                    "start": {
+                                      "line": 137,
+                                      "column": 11
+                                    },
+                                    "end": {
+                                      "line": 137,
+                                      "column": 36
+                                    }
+                                  },
+                                  "callee": {
+                                    "type": "MemberExpression",
+                                    "start": 3633,
+                                    "end": 3648,
+                                    "loc": {
+                                      "start": {
+                                        "line": 137,
+                                        "column": 11
+                                      },
+                                      "end": {
+                                        "line": 137,
+                                        "column": 26
+                                      }
+                                    },
+                                    "object": {
+                                      "type": "Identifier",
+                                      "start": 3633,
+                                      "end": 3640,
+                                      "loc": {
+                                        "start": {
+                                          "line": 137,
+                                          "column": 11
+                                        },
+                                        "end": {
+                                          "line": 137,
+                                          "column": 18
+                                        },
+                                        "identifierName": "Promise"
+                                      },
+                                      "name": "Promise"
+                                    },
+                                    "property": {
+                                      "type": "Identifier",
+                                      "start": 3641,
+                                      "end": 3648,
+                                      "loc": {
+                                        "start": {
+                                          "line": 137,
+                                          "column": 19
+                                        },
+                                        "end": {
+                                          "line": 137,
+                                          "column": 26
+                                        },
+                                        "identifierName": "resolve"
+                                      },
+                                      "name": "resolve"
+                                    },
+                                    "computed": false
+                                  },
+                                  "arguments": [
+                                    {
+                                      "type": "MemberExpression",
+                                      "start": 3649,
+                                      "end": 3657,
+                                      "loc": {
+                                        "start": {
+                                          "line": 137,
+                                          "column": 27
+                                        },
+                                        "end": {
+                                          "line": 137,
+                                          "column": 35
+                                        }
+                                      },
+                                      "object": {
+                                        "type": "Identifier",
+                                        "start": 3649,
+                                        "end": 3652,
+                                        "loc": {
+                                          "start": {
+                                            "line": 137,
+                                            "column": 27
+                                          },
+                                          "end": {
+                                            "line": 137,
+                                            "column": 30
+                                          },
+                                          "identifierName": "res"
+                                        },
+                                        "name": "res"
+                                      },
+                                      "property": {
+                                        "type": "Identifier",
+                                        "start": 3653,
+                                        "end": 3657,
+                                        "loc": {
+                                          "start": {
+                                            "line": 137,
+                                            "column": 31
+                                          },
+                                          "end": {
+                                            "line": 137,
+                                            "column": 35
+                                          },
+                                          "identifierName": "data"
+                                        },
+                                        "name": "data"
+                                      },
+                                      "computed": false
+                                    }
+                                  ]
+                                }
+                              }
+                            ],
+                            "directives": []
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ],
+                "directives": []
+              }
+            },
+            "leadingComments": null
+          }
+        ],
+        "kind": "const",
+        "leadingComments": [
+          {
+            "type": "CommentBlock",
+            "value": "*\n * Get a single part svg from the obsolete svgs, this is for old-sketches only! the response is a svg-string\n *\n * @param  {String} src\n * @param  {String} url - The base URL of the parts api\n * @return {Promise} the fetch promise\n ",
+            "start": 3229,
+            "end": 3467,
+            "loc": {
+              "start": {
+                "line": 127,
+                "column": 0
+              },
+              "end": {
+                "line": 133,
+                "column": 3
+              }
+            }
+          }
+        ],
+        "trailingComments": [
+          {
+            "type": "CommentBlock",
+            "value": "*\n * Get a list of all FZB files\n *\n * @param  {String} url - The base URL of the parts api\n * @return {Promise}\n ",
+            "start": 3670,
+            "end": 3788,
+            "loc": {
+              "start": {
+                "line": 141,
+                "column": 0
+              },
+              "end": {
+                "line": 146,
+                "column": 3
+              }
+            }
+          }
+        ]
+      },
+      {
+        "type": "VariableDeclaration",
+        "start": 3789,
+        "end": 3962,
+        "loc": {
+          "start": {
+            "line": 147,
+            "column": 0
+          },
+          "end": {
+            "line": 152,
+            "column": 2
+          }
+        },
+        "declarations": [
+          {
+            "type": "VariableDeclarator",
+            "start": 3795,
+            "end": 3961,
+            "loc": {
+              "start": {
+                "line": 147,
+                "column": 6
+              },
+              "end": {
+                "line": 152,
+                "column": 1
+              }
+            },
+            "id": {
+              "type": "Identifier",
+              "start": 3795,
+              "end": 3802,
+              "loc": {
+                "start": {
+                  "line": 147,
+                  "column": 6
+                },
+                "end": {
+                  "line": 147,
+                  "column": 13
+                },
+                "identifierName": "getFzbs"
+              },
+              "name": "getFzbs",
+              "leadingComments": null
+            },
+            "init": {
+              "type": "FunctionExpression",
+              "start": 3805,
+              "end": 3961,
+              "loc": {
+                "start": {
+                  "line": 147,
+                  "column": 16
+                },
+                "end": {
+                  "line": 152,
+                  "column": 1
+                }
+              },
+              "id": {
+                "type": "Identifier",
+                "start": 3795,
+                "end": 3802,
+                "loc": {
+                  "start": {
+                    "line": 147,
+                    "column": 6
+                  },
+                  "end": {
+                    "line": 147,
+                    "column": 13
+                  },
+                  "identifierName": "getFzbs"
+                },
+                "name": "getFzbs",
+                "leadingComments": null
+              },
+              "generator": false,
+              "expression": false,
+              "async": false,
+              "params": [
+                {
+                  "type": "AssignmentPattern",
+                  "start": 3814,
+                  "end": 3845,
+                  "loc": {
+                    "start": {
+                      "line": 147,
+                      "column": 25
+                    },
+                    "end": {
+                      "line": 147,
+                      "column": 56
+                    }
+                  },
+                  "left": {
+                    "type": "Identifier",
+                    "start": 3814,
+                    "end": 3817,
+                    "loc": {
+                      "start": {
+                        "line": 147,
+                        "column": 25
+                      },
+                      "end": {
+                        "line": 147,
+                        "column": 28
+                      },
+                      "identifierName": "url"
+                    },
+                    "name": "url"
+                  },
+                  "right": {
+                    "type": "TemplateLiteral",
+                    "start": 3820,
+                    "end": 3845,
+                    "loc": {
+                      "start": {
+                        "line": 147,
+                        "column": 31
+                      },
+                      "end": {
+                        "line": 147,
+                        "column": 56
+                      }
+                    },
+                    "expressions": [
+                      {
+                        "type": "Identifier",
+                        "start": 3823,
+                        "end": 3839,
+                        "loc": {
+                          "start": {
+                            "line": 147,
+                            "column": 34
+                          },
+                          "end": {
+                            "line": 147,
+                            "column": 50
+                          },
+                          "identifierName": "FritzingPartsAPI"
+                        },
+                        "name": "FritzingPartsAPI"
+                      }
+                    ],
+                    "quasis": [
+                      {
+                        "type": "TemplateElement",
+                        "start": 3821,
+                        "end": 3821,
+                        "loc": {
+                          "start": {
+                            "line": 147,
+                            "column": 32
+                          },
+                          "end": {
+                            "line": 147,
+                            "column": 32
+                          }
+                        },
+                        "value": {
+                          "raw": "",
+                          "cooked": ""
+                        },
+                        "tail": false
+                      },
+                      {
+                        "type": "TemplateElement",
+                        "start": 3840,
+                        "end": 3844,
+                        "loc": {
+                          "start": {
+                            "line": 147,
+                            "column": 51
+                          },
+                          "end": {
+                            "line": 147,
+                            "column": 55
+                          }
+                        },
+                        "value": {
+                          "raw": "/fzb",
+                          "cooked": "/fzb"
+                        },
+                        "tail": true
+                      }
+                    ]
+                  }
+                }
+              ],
+              "body": {
+                "type": "BlockStatement",
+                "start": 3847,
+                "end": 3961,
+                "loc": {
+                  "start": {
+                    "line": 147,
+                    "column": 58
+                  },
+                  "end": {
+                    "line": 152,
+                    "column": 1
+                  }
+                },
+                "body": [
+                  {
+                    "type": "ReturnStatement",
+                    "start": 3851,
+                    "end": 3959,
+                    "loc": {
+                      "start": {
+                        "line": 148,
+                        "column": 2
+                      },
+                      "end": {
+                        "line": 151,
+                        "column": 5
+                      }
+                    },
+                    "argument": {
+                      "type": "CallExpression",
+                      "start": 3858,
+                      "end": 3958,
+                      "loc": {
+                        "start": {
+                          "line": 148,
+                          "column": 9
+                        },
+                        "end": {
+                          "line": 151,
+                          "column": 4
+                        }
+                      },
+                      "callee": {
+                        "type": "MemberExpression",
+                        "start": 3858,
+                        "end": 3904,
+                        "loc": {
+                          "start": {
+                            "line": 148,
+                            "column": 9
+                          },
+                          "end": {
+                            "line": 149,
+                            "column": 7
+                          }
+                        },
+                        "object": {
+                          "type": "CallExpression",
+                          "start": 3858,
+                          "end": 3896,
+                          "loc": {
+                            "start": {
+                              "line": 148,
+                              "column": 9
+                            },
+                            "end": {
+                              "line": 148,
+                              "column": 47
+                            }
+                          },
+                          "callee": {
+                            "type": "MemberExpression",
+                            "start": 3858,
+                            "end": 3867,
+                            "loc": {
+                              "start": {
+                                "line": 148,
+                                "column": 9
+                              },
+                              "end": {
+                                "line": 148,
+                                "column": 18
+                              }
+                            },
+                            "object": {
+                              "type": "Identifier",
+                              "start": 3858,
+                              "end": 3863,
+                              "loc": {
+                                "start": {
+                                  "line": 148,
+                                  "column": 9
+                                },
+                                "end": {
+                                  "line": 148,
+                                  "column": 14
+                                },
+                                "identifierName": "axios"
+                              },
+                              "name": "axios"
+                            },
+                            "property": {
+                              "type": "Identifier",
+                              "start": 3864,
+                              "end": 3867,
+                              "loc": {
+                                "start": {
+                                  "line": 148,
+                                  "column": 15
+                                },
+                                "end": {
+                                  "line": 148,
+                                  "column": 18
+                                },
+                                "identifierName": "get"
+                              },
+                              "name": "get"
+                            },
+                            "computed": false
+                          },
+                          "arguments": [
+                            {
+                              "type": "Identifier",
+                              "start": 3868,
+                              "end": 3871,
+                              "loc": {
+                                "start": {
+                                  "line": 148,
+                                  "column": 19
+                                },
+                                "end": {
+                                  "line": 148,
+                                  "column": 22
+                                },
+                                "identifierName": "url"
+                              },
+                              "name": "url"
+                            },
+                            {
+                              "type": "ObjectExpression",
+                              "start": 3873,
+                              "end": 3895,
+                              "loc": {
+                                "start": {
+                                  "line": 148,
+                                  "column": 24
+                                },
+                                "end": {
+                                  "line": 148,
+                                  "column": 46
+                                }
+                              },
+                              "properties": [
+                                {
+                                  "type": "ObjectProperty",
+                                  "start": 3874,
+                                  "end": 3894,
+                                  "loc": {
+                                    "start": {
+                                      "line": 148,
+                                      "column": 25
+                                    },
+                                    "end": {
+                                      "line": 148,
+                                      "column": 45
+                                    }
+                                  },
+                                  "method": false,
+                                  "shorthand": false,
+                                  "computed": false,
+                                  "key": {
+                                    "type": "Identifier",
+                                    "start": 3874,
+                                    "end": 3886,
+                                    "loc": {
+                                      "start": {
+                                        "line": 148,
+                                        "column": 25
+                                      },
+                                      "end": {
+                                        "line": 148,
+                                        "column": 37
+                                      },
+                                      "identifierName": "responseType"
+                                    },
+                                    "name": "responseType"
+                                  },
+                                  "value": {
+                                    "type": "StringLiteral",
+                                    "start": 3888,
+                                    "end": 3894,
+                                    "loc": {
+                                      "start": {
+                                        "line": 148,
+                                        "column": 39
+                                      },
+                                      "end": {
+                                        "line": 148,
+                                        "column": 45
+                                      }
+                                    },
+                                    "extra": {
+                                      "rawValue": "json",
+                                      "raw": "'json'"
+                                    },
+                                    "value": "json"
+                                  }
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        "property": {
+                          "type": "Identifier",
+                          "start": 3900,
+                          "end": 3904,
+                          "loc": {
+                            "start": {
+                              "line": 149,
+                              "column": 3
+                            },
+                            "end": {
+                              "line": 149,
+                              "column": 7
+                            },
+                            "identifierName": "then"
+                          },
+                          "name": "then"
+                        },
+                        "computed": false
+                      },
+                      "arguments": [
+                        {
+                          "type": "ArrowFunctionExpression",
+                          "start": 3905,
+                          "end": 3957,
+                          "loc": {
+                            "start": {
+                              "line": 149,
+                              "column": 8
+                            },
+                            "end": {
+                              "line": 151,
+                              "column": 3
+                            }
+                          },
+                          "id": null,
+                          "generator": false,
+                          "expression": false,
+                          "async": false,
+                          "params": [
+                            {
+                              "type": "Identifier",
+                              "start": 3906,
+                              "end": 3909,
+                              "loc": {
+                                "start": {
+                                  "line": 149,
+                                  "column": 9
+                                },
+                                "end": {
+                                  "line": 149,
+                                  "column": 12
+                                },
+                                "identifierName": "res"
+                              },
+                              "name": "res"
+                            }
+                          ],
+                          "body": {
+                            "type": "BlockStatement",
+                            "start": 3914,
+                            "end": 3957,
+                            "loc": {
+                              "start": {
+                                "line": 149,
+                                "column": 17
+                              },
+                              "end": {
+                                "line": 151,
+                                "column": 3
+                              }
+                            },
+                            "body": [
+                              {
+                                "type": "ReturnStatement",
+                                "start": 3920,
+                                "end": 3953,
+                                "loc": {
+                                  "start": {
+                                    "line": 150,
+                                    "column": 4
+                                  },
+                                  "end": {
+                                    "line": 150,
+                                    "column": 37
+                                  }
+                                },
+                                "argument": {
+                                  "type": "CallExpression",
+                                  "start": 3927,
+                                  "end": 3952,
+                                  "loc": {
+                                    "start": {
+                                      "line": 150,
+                                      "column": 11
+                                    },
+                                    "end": {
+                                      "line": 150,
+                                      "column": 36
+                                    }
+                                  },
+                                  "callee": {
+                                    "type": "MemberExpression",
+                                    "start": 3927,
+                                    "end": 3942,
+                                    "loc": {
+                                      "start": {
+                                        "line": 150,
+                                        "column": 11
+                                      },
+                                      "end": {
+                                        "line": 150,
+                                        "column": 26
+                                      }
+                                    },
+                                    "object": {
+                                      "type": "Identifier",
+                                      "start": 3927,
+                                      "end": 3934,
+                                      "loc": {
+                                        "start": {
+                                          "line": 150,
+                                          "column": 11
+                                        },
+                                        "end": {
+                                          "line": 150,
+                                          "column": 18
+                                        },
+                                        "identifierName": "Promise"
+                                      },
+                                      "name": "Promise"
+                                    },
+                                    "property": {
+                                      "type": "Identifier",
+                                      "start": 3935,
+                                      "end": 3942,
+                                      "loc": {
+                                        "start": {
+                                          "line": 150,
+                                          "column": 19
+                                        },
+                                        "end": {
+                                          "line": 150,
+                                          "column": 26
+                                        },
+                                        "identifierName": "resolve"
+                                      },
+                                      "name": "resolve"
+                                    },
+                                    "computed": false
+                                  },
+                                  "arguments": [
+                                    {
+                                      "type": "MemberExpression",
+                                      "start": 3943,
+                                      "end": 3951,
+                                      "loc": {
+                                        "start": {
+                                          "line": 150,
+                                          "column": 27
+                                        },
+                                        "end": {
+                                          "line": 150,
+                                          "column": 35
+                                        }
+                                      },
+                                      "object": {
+                                        "type": "Identifier",
+                                        "start": 3943,
+                                        "end": 3946,
+                                        "loc": {
+                                          "start": {
+                                            "line": 150,
+                                            "column": 27
+                                          },
+                                          "end": {
+                                            "line": 150,
+                                            "column": 30
+                                          },
+                                          "identifierName": "res"
+                                        },
+                                        "name": "res"
+                                      },
+                                      "property": {
+                                        "type": "Identifier",
+                                        "start": 3947,
+                                        "end": 3951,
+                                        "loc": {
+                                          "start": {
+                                            "line": 150,
+                                            "column": 31
+                                          },
+                                          "end": {
+                                            "line": 150,
+                                            "column": 35
+                                          },
+                                          "identifierName": "data"
+                                        },
+                                        "name": "data"
+                                      },
+                                      "computed": false
+                                    }
+                                  ]
+                                }
+                              }
+                            ],
+                            "directives": []
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ],
+                "directives": []
+              }
+            },
+            "leadingComments": null
+          }
+        ],
+        "kind": "const",
+        "leadingComments": [
+          {
+            "type": "CommentBlock",
+            "value": "*\n * Get a list of all FZB files\n *\n * @param  {String} url - The base URL of the parts api\n * @return {Promise}\n ",
+            "start": 3670,
+            "end": 3788,
+            "loc": {
+              "start": {
+                "line": 141,
+                "column": 0
+              },
+              "end": {
+                "line": 146,
+                "column": 3
+              }
+            }
+          }
+        ],
+        "trailingComments": [
+          {
+            "type": "CommentBlock",
+            "value": "*\n* Fritzing Parts API Client\n*\n* @example\n* const {FritzingPartsAPIClient} = require('fritzing-parts-api-client-js')\n*\n* FritzingPartsAPIClient.getFzps()\n* .then((fzpz) => {\n*   console.log(fzps)\n* })\n* .catch((err) => {\n*   console.error(err)\n* })\n",
+            "start": 3965,
+            "end": 4219,
+            "loc": {
+              "start": {
+                "line": 155,
+                "column": 0
+              },
+              "end": {
+                "line": 168,
+                "column": 2
+              }
+            }
+          }
+        ]
+      },
+      {
+        "type": "VariableDeclaration",
+        "start": 4220,
+        "end": 4395,
+        "loc": {
+          "start": {
+            "line": 169,
+            "column": 0
+          },
+          "end": {
+            "line": 180,
+            "column": 2
+          }
+        },
+        "declarations": [
+          {
+            "type": "VariableDeclarator",
+            "start": 4226,
+            "end": 4394,
+            "loc": {
+              "start": {
+                "line": 169,
+                "column": 6
+              },
+              "end": {
+                "line": 180,
+                "column": 1
+              }
+            },
+            "id": {
+              "type": "Identifier",
+              "start": 4226,
+              "end": 4248,
+              "loc": {
+                "start": {
+                  "line": 169,
+                  "column": 6
+                },
+                "end": {
+                  "line": 169,
+                  "column": 28
+                },
+                "identifierName": "FritzingPartsAPIClient"
+              },
+              "name": "FritzingPartsAPIClient",
+              "leadingComments": null
+            },
+            "init": {
+              "type": "ObjectExpression",
+              "start": 4251,
+              "end": 4394,
+              "loc": {
+                "start": {
+                  "line": 169,
+                  "column": 31
+                },
+                "end": {
+                  "line": 180,
+                  "column": 1
+                }
+              },
+              "properties": [
+                {
+                  "type": "ObjectProperty",
+                  "start": 4255,
+                  "end": 4262,
+                  "loc": {
+                    "start": {
+                      "line": 170,
+                      "column": 2
+                    },
+                    "end": {
+                      "line": 170,
+                      "column": 9
+                    }
+                  },
+                  "method": false,
+                  "shorthand": true,
+                  "computed": false,
+                  "key": {
+                    "type": "Identifier",
+                    "start": 4255,
+                    "end": 4262,
+                    "loc": {
+                      "start": {
+                        "line": 170,
+                        "column": 2
+                      },
+                      "end": {
+                        "line": 170,
+                        "column": 9
+                      },
+                      "identifierName": "getFzps"
+                    },
+                    "name": "getFzps"
+                  },
+                  "value": {
+                    "type": "Identifier",
+                    "start": 4255,
+                    "end": 4262,
+                    "loc": {
+                      "start": {
+                        "line": 170,
+                        "column": 2
+                      },
+                      "end": {
+                        "line": 170,
+                        "column": 9
+                      },
+                      "identifierName": "getFzps"
+                    },
+                    "name": "getFzps"
+                  },
+                  "extra": {
+                    "shorthand": true
+                  }
+                },
+                {
+                  "type": "ObjectProperty",
+                  "start": 4266,
+                  "end": 4277,
+                  "loc": {
+                    "start": {
+                      "line": 171,
+                      "column": 2
+                    },
+                    "end": {
+                      "line": 171,
+                      "column": 13
+                    }
+                  },
+                  "method": false,
+                  "shorthand": true,
+                  "computed": false,
+                  "key": {
+                    "type": "Identifier",
+                    "start": 4266,
+                    "end": 4277,
+                    "loc": {
+                      "start": {
+                        "line": 171,
+                        "column": 2
+                      },
+                      "end": {
+                        "line": 171,
+                        "column": 13
+                      },
+                      "identifierName": "getFzpsCore"
+                    },
+                    "name": "getFzpsCore"
+                  },
+                  "value": {
+                    "type": "Identifier",
+                    "start": 4266,
+                    "end": 4277,
+                    "loc": {
+                      "start": {
+                        "line": 171,
+                        "column": 2
+                      },
+                      "end": {
+                        "line": 171,
+                        "column": 13
+                      },
+                      "identifierName": "getFzpsCore"
+                    },
+                    "name": "getFzpsCore"
+                  },
+                  "extra": {
+                    "shorthand": true
+                  }
+                },
+                {
+                  "type": "ObjectProperty",
+                  "start": 4281,
+                  "end": 4296,
+                  "loc": {
+                    "start": {
+                      "line": 172,
+                      "column": 2
+                    },
+                    "end": {
+                      "line": 172,
+                      "column": 17
+                    }
+                  },
+                  "method": false,
+                  "shorthand": true,
+                  "computed": false,
+                  "key": {
+                    "type": "Identifier",
+                    "start": 4281,
+                    "end": 4296,
+                    "loc": {
+                      "start": {
+                        "line": 172,
+                        "column": 2
+                      },
+                      "end": {
+                        "line": 172,
+                        "column": 17
+                      },
+                      "identifierName": "getFzpsObsolete"
+                    },
+                    "name": "getFzpsObsolete"
+                  },
+                  "value": {
+                    "type": "Identifier",
+                    "start": 4281,
+                    "end": 4296,
+                    "loc": {
+                      "start": {
+                        "line": 172,
+                        "column": 2
+                      },
+                      "end": {
+                        "line": 172,
+                        "column": 17
+                      },
+                      "identifierName": "getFzpsObsolete"
+                    },
+                    "name": "getFzpsObsolete"
+                  },
+                  "extra": {
+                    "shorthand": true
+                  }
+                },
+                {
+                  "type": "ObjectProperty",
+                  "start": 4300,
+                  "end": 4306,
+                  "loc": {
+                    "start": {
+                      "line": 173,
+                      "column": 2
+                    },
+                    "end": {
+                      "line": 173,
+                      "column": 8
+                    }
+                  },
+                  "method": false,
+                  "shorthand": true,
+                  "computed": false,
+                  "key": {
+                    "type": "Identifier",
+                    "start": 4300,
+                    "end": 4306,
+                    "loc": {
+                      "start": {
+                        "line": 173,
+                        "column": 2
+                      },
+                      "end": {
+                        "line": 173,
+                        "column": 8
+                      },
+                      "identifierName": "getFzp"
+                    },
+                    "name": "getFzp"
+                  },
+                  "value": {
+                    "type": "Identifier",
+                    "start": 4300,
+                    "end": 4306,
+                    "loc": {
+                      "start": {
+                        "line": 173,
+                        "column": 2
+                      },
+                      "end": {
+                        "line": 173,
+                        "column": 8
+                      },
+                      "identifierName": "getFzp"
+                    },
+                    "name": "getFzp"
+                  },
+                  "extra": {
+                    "shorthand": true
+                  }
+                },
+                {
+                  "type": "ObjectProperty",
+                  "start": 4310,
+                  "end": 4320,
+                  "loc": {
+                    "start": {
+                      "line": 174,
+                      "column": 2
+                    },
+                    "end": {
+                      "line": 174,
+                      "column": 12
+                    }
+                  },
+                  "method": false,
+                  "shorthand": true,
+                  "computed": false,
+                  "key": {
+                    "type": "Identifier",
+                    "start": 4310,
+                    "end": 4320,
+                    "loc": {
+                      "start": {
+                        "line": 174,
+                        "column": 2
+                      },
+                      "end": {
+                        "line": 174,
+                        "column": 12
+                      },
+                      "identifierName": "getFzpCore"
+                    },
+                    "name": "getFzpCore"
+                  },
+                  "value": {
+                    "type": "Identifier",
+                    "start": 4310,
+                    "end": 4320,
+                    "loc": {
+                      "start": {
+                        "line": 174,
+                        "column": 2
+                      },
+                      "end": {
+                        "line": 174,
+                        "column": 12
+                      },
+                      "identifierName": "getFzpCore"
+                    },
+                    "name": "getFzpCore"
+                  },
+                  "extra": {
+                    "shorthand": true
+                  }
+                },
+                {
+                  "type": "ObjectProperty",
+                  "start": 4324,
+                  "end": 4338,
+                  "loc": {
+                    "start": {
+                      "line": 175,
+                      "column": 2
+                    },
+                    "end": {
+                      "line": 175,
+                      "column": 16
+                    }
+                  },
+                  "method": false,
+                  "shorthand": true,
+                  "computed": false,
+                  "key": {
+                    "type": "Identifier",
+                    "start": 4324,
+                    "end": 4338,
+                    "loc": {
+                      "start": {
+                        "line": 175,
+                        "column": 2
+                      },
+                      "end": {
+                        "line": 175,
+                        "column": 16
+                      },
+                      "identifierName": "getFzpObsolete"
+                    },
+                    "name": "getFzpObsolete"
+                  },
+                  "value": {
+                    "type": "Identifier",
+                    "start": 4324,
+                    "end": 4338,
+                    "loc": {
+                      "start": {
+                        "line": 175,
+                        "column": 2
+                      },
+                      "end": {
+                        "line": 175,
+                        "column": 16
+                      },
+                      "identifierName": "getFzpObsolete"
+                    },
+                    "name": "getFzpObsolete"
+                  },
+                  "extra": {
+                    "shorthand": true
+                  }
+                },
+                {
+                  "type": "ObjectProperty",
+                  "start": 4342,
+                  "end": 4348,
+                  "loc": {
+                    "start": {
+                      "line": 176,
+                      "column": 2
+                    },
+                    "end": {
+                      "line": 176,
+                      "column": 8
+                    }
+                  },
+                  "method": false,
+                  "shorthand": true,
+                  "computed": false,
+                  "key": {
+                    "type": "Identifier",
+                    "start": 4342,
+                    "end": 4348,
+                    "loc": {
+                      "start": {
+                        "line": 176,
+                        "column": 2
+                      },
+                      "end": {
+                        "line": 176,
+                        "column": 8
+                      },
+                      "identifierName": "getSvg"
+                    },
+                    "name": "getSvg"
+                  },
+                  "value": {
+                    "type": "Identifier",
+                    "start": 4342,
+                    "end": 4348,
+                    "loc": {
+                      "start": {
+                        "line": 176,
+                        "column": 2
+                      },
+                      "end": {
+                        "line": 176,
+                        "column": 8
+                      },
+                      "identifierName": "getSvg"
+                    },
+                    "name": "getSvg"
+                  },
+                  "extra": {
+                    "shorthand": true
+                  }
+                },
+                {
+                  "type": "ObjectProperty",
+                  "start": 4352,
+                  "end": 4362,
+                  "loc": {
+                    "start": {
+                      "line": 177,
+                      "column": 2
+                    },
+                    "end": {
+                      "line": 177,
+                      "column": 12
+                    }
+                  },
+                  "method": false,
+                  "shorthand": true,
+                  "computed": false,
+                  "key": {
+                    "type": "Identifier",
+                    "start": 4352,
+                    "end": 4362,
+                    "loc": {
+                      "start": {
+                        "line": 177,
+                        "column": 2
+                      },
+                      "end": {
+                        "line": 177,
+                        "column": 12
+                      },
+                      "identifierName": "getSvgCore"
+                    },
+                    "name": "getSvgCore"
+                  },
+                  "value": {
+                    "type": "Identifier",
+                    "start": 4352,
+                    "end": 4362,
+                    "loc": {
+                      "start": {
+                        "line": 177,
+                        "column": 2
+                      },
+                      "end": {
+                        "line": 177,
+                        "column": 12
+                      },
+                      "identifierName": "getSvgCore"
+                    },
+                    "name": "getSvgCore"
+                  },
+                  "extra": {
+                    "shorthand": true
+                  }
+                },
+                {
+                  "type": "ObjectProperty",
+                  "start": 4366,
+                  "end": 4380,
+                  "loc": {
+                    "start": {
+                      "line": 178,
+                      "column": 2
+                    },
+                    "end": {
+                      "line": 178,
+                      "column": 16
+                    }
+                  },
+                  "method": false,
+                  "shorthand": true,
+                  "computed": false,
+                  "key": {
+                    "type": "Identifier",
+                    "start": 4366,
+                    "end": 4380,
+                    "loc": {
+                      "start": {
+                        "line": 178,
+                        "column": 2
+                      },
+                      "end": {
+                        "line": 178,
+                        "column": 16
+                      },
+                      "identifierName": "getSvgObsolete"
+                    },
+                    "name": "getSvgObsolete"
+                  },
+                  "value": {
+                    "type": "Identifier",
+                    "start": 4366,
+                    "end": 4380,
+                    "loc": {
+                      "start": {
+                        "line": 178,
+                        "column": 2
+                      },
+                      "end": {
+                        "line": 178,
+                        "column": 16
+                      },
+                      "identifierName": "getSvgObsolete"
+                    },
+                    "name": "getSvgObsolete"
+                  },
+                  "extra": {
+                    "shorthand": true
+                  }
+                },
+                {
+                  "type": "ObjectProperty",
+                  "start": 4384,
+                  "end": 4391,
+                  "loc": {
+                    "start": {
+                      "line": 179,
+                      "column": 2
+                    },
+                    "end": {
+                      "line": 179,
+                      "column": 9
+                    }
+                  },
+                  "method": false,
+                  "shorthand": true,
+                  "computed": false,
+                  "key": {
+                    "type": "Identifier",
+                    "start": 4384,
+                    "end": 4391,
+                    "loc": {
+                      "start": {
+                        "line": 179,
+                        "column": 2
+                      },
+                      "end": {
+                        "line": 179,
+                        "column": 9
+                      },
+                      "identifierName": "getFzbs"
+                    },
+                    "name": "getFzbs"
+                  },
+                  "value": {
+                    "type": "Identifier",
+                    "start": 4384,
+                    "end": 4391,
+                    "loc": {
+                      "start": {
+                        "line": 179,
+                        "column": 2
+                      },
+                      "end": {
+                        "line": 179,
+                        "column": 9
+                      },
+                      "identifierName": "getFzbs"
+                    },
+                    "name": "getFzbs"
+                  },
+                  "extra": {
+                    "shorthand": true
+                  }
+                }
+              ]
+            },
+            "leadingComments": null
+          }
+        ],
+        "kind": "const",
+        "leadingComments": [
+          {
+            "type": "CommentBlock",
+            "value": "*\n* Fritzing Parts API Client\n*\n* @example\n* const {FritzingPartsAPIClient} = require('fritzing-parts-api-client-js')\n*\n* FritzingPartsAPIClient.getFzps()\n* .then((fzpz) => {\n*   console.log(fzps)\n* })\n* .catch((err) => {\n*   console.error(err)\n* })\n",
+            "start": 3965,
+            "end": 4219,
+            "loc": {
+              "start": {
+                "line": 155,
+                "column": 0
+              },
+              "end": {
+                "line": 168,
+                "column": 2
+              }
+            }
+          }
+        ]
+      },
+      {
+        "type": "ExpressionStatement",
+        "start": 4397,
+        "end": 4464,
+        "loc": {
+          "start": {
+            "line": 182,
+            "column": 0
+          },
+          "end": {
+            "line": 185,
+            "column": 2
           }
         },
         "expression": {
           "type": "AssignmentExpression",
-          "start": 2916,
-          "end": 2942,
+          "start": 4397,
+          "end": 4463,
           "loc": {
             "start": {
-              "line": 129,
+              "line": 182,
               "column": 0
             },
             "end": {
-              "line": 129,
-              "column": 26
+              "line": 185,
+              "column": 1
             }
           },
           "operator": "=",
           "left": {
             "type": "MemberExpression",
-            "start": 2916,
-            "end": 2930,
+            "start": 4397,
+            "end": 4411,
             "loc": {
               "start": {
-                "line": 129,
+                "line": 182,
                 "column": 0
               },
               "end": {
-                "line": 129,
+                "line": 182,
                 "column": 14
               }
             },
             "object": {
               "type": "Identifier",
-              "start": 2916,
-              "end": 2922,
+              "start": 4397,
+              "end": 4403,
               "loc": {
                 "start": {
-                  "line": 129,
+                  "line": 182,
                   "column": 0
                 },
                 "end": {
-                  "line": 129,
+                  "line": 182,
                   "column": 6
                 },
                 "identifierName": "module"
@@ -5813,15 +7891,15 @@
             },
             "property": {
               "type": "Identifier",
-              "start": 2923,
-              "end": 2930,
+              "start": 4404,
+              "end": 4411,
               "loc": {
                 "start": {
-                  "line": 129,
+                  "line": 182,
                   "column": 7
                 },
                 "end": {
-                  "line": 129,
+                  "line": 182,
                   "column": 14
                 },
                 "identifierName": "exports"
@@ -5831,21 +7909,131 @@
             "computed": false
           },
           "right": {
-            "type": "Identifier",
-            "start": 2933,
-            "end": 2942,
+            "type": "ObjectExpression",
+            "start": 4414,
+            "end": 4463,
             "loc": {
               "start": {
-                "line": 129,
+                "line": 182,
                 "column": 17
               },
               "end": {
-                "line": 129,
-                "column": 26
-              },
-              "identifierName": "ApiClient"
+                "line": 185,
+                "column": 1
+              }
             },
-            "name": "ApiClient"
+            "properties": [
+              {
+                "type": "ObjectProperty",
+                "start": 4418,
+                "end": 4434,
+                "loc": {
+                  "start": {
+                    "line": 183,
+                    "column": 2
+                  },
+                  "end": {
+                    "line": 183,
+                    "column": 18
+                  }
+                },
+                "method": false,
+                "shorthand": true,
+                "computed": false,
+                "key": {
+                  "type": "Identifier",
+                  "start": 4418,
+                  "end": 4434,
+                  "loc": {
+                    "start": {
+                      "line": 183,
+                      "column": 2
+                    },
+                    "end": {
+                      "line": 183,
+                      "column": 18
+                    },
+                    "identifierName": "FritzingPartsAPI"
+                  },
+                  "name": "FritzingPartsAPI"
+                },
+                "value": {
+                  "type": "Identifier",
+                  "start": 4418,
+                  "end": 4434,
+                  "loc": {
+                    "start": {
+                      "line": 183,
+                      "column": 2
+                    },
+                    "end": {
+                      "line": 183,
+                      "column": 18
+                    },
+                    "identifierName": "FritzingPartsAPI"
+                  },
+                  "name": "FritzingPartsAPI"
+                },
+                "extra": {
+                  "shorthand": true
+                }
+              },
+              {
+                "type": "ObjectProperty",
+                "start": 4438,
+                "end": 4460,
+                "loc": {
+                  "start": {
+                    "line": 184,
+                    "column": 2
+                  },
+                  "end": {
+                    "line": 184,
+                    "column": 24
+                  }
+                },
+                "method": false,
+                "shorthand": true,
+                "computed": false,
+                "key": {
+                  "type": "Identifier",
+                  "start": 4438,
+                  "end": 4460,
+                  "loc": {
+                    "start": {
+                      "line": 184,
+                      "column": 2
+                    },
+                    "end": {
+                      "line": 184,
+                      "column": 24
+                    },
+                    "identifierName": "FritzingPartsAPIClient"
+                  },
+                  "name": "FritzingPartsAPIClient"
+                },
+                "value": {
+                  "type": "Identifier",
+                  "start": 4438,
+                  "end": 4460,
+                  "loc": {
+                    "start": {
+                      "line": 184,
+                      "column": 2
+                    },
+                    "end": {
+                      "line": 184,
+                      "column": 24
+                    },
+                    "identifierName": "FritzingPartsAPIClient"
+                  },
+                  "name": "FritzingPartsAPIClient"
+                },
+                "extra": {
+                  "shorthand": true
+                }
+              }
+            ]
           }
         }
       }
@@ -5891,193 +8079,193 @@
   "comments": [
     {
       "type": "CommentBlock",
-      "value": "*\n * Fritzing Parts API Client\n ",
+      "value": "*\n * The base url of the fritzing parts api\n *\n * @example\n * const {FritzingPartsAPI} = require('fritzing-parts-api-client-js')\n *\n * console.log(FritzingPartsAPI)\n *\n * @type {String}\n ",
       "start": 48,
-      "end": 84,
+      "end": 239,
       "loc": {
         "start": {
           "line": 5,
           "column": 0
         },
         "end": {
-          "line": 7,
+          "line": 14,
           "column": 3
         }
       }
     },
     {
       "type": "CommentBlock",
-      "value": "*\n   * Construct the ApiClient\n   ",
-      "start": 105,
-      "end": 143,
+      "value": "*\n * Get a list of all FZP files\n *\n * @type   {Function}\n * @param  {String} url - The base URL of the parts api\n * @return {Promise}\n ",
+      "start": 311,
+      "end": 451,
       "loc": {
         "start": {
-          "line": 9,
-          "column": 2
+          "line": 17,
+          "column": 0
         },
         "end": {
-          "line": 11,
-          "column": 5
+          "line": 23,
+          "column": 3
         }
       }
     },
     {
       "type": "CommentBlock",
-      "value": "*\n   * Get a list of all FZP files\n   * @return {Promise}\n   ",
-      "start": 229,
-      "end": 294,
+      "value": "*\n * Get a list of all Core-FZP files\n *\n * @param  {String} url - The base URL of the parts api\n * @return {Promise}\n ",
+      "start": 627,
+      "end": 750,
       "loc": {
         "start": {
-          "line": 16,
-          "column": 2
+          "line": 31,
+          "column": 0
         },
         "end": {
-          "line": 19,
-          "column": 5
-        }
-      }
-    },
-    {
-      "type": "CommentBlock",
-      "value": "*\n   * Get a list of all Core-FZP files\n   * @return {Promise}\n   ",
-      "start": 429,
-      "end": 499,
-      "loc": {
-        "start": {
-          "line": 26,
-          "column": 2
-        },
-        "end": {
-          "line": 29,
-          "column": 5
-        }
-      }
-    },
-    {
-      "type": "CommentBlock",
-      "value": "*\n   * Get a list of all Obsolete-FZP files. for old sketches only!\n   * @return {Promise}\n   ",
-      "start": 643,
-      "end": 741,
-      "loc": {
-        "start": {
           "line": 36,
-          "column": 2
-        },
-        "end": {
-          "line": 39,
-          "column": 5
-        }
-      }
-    },
-    {
-      "type": "CommentBlock",
-      "value": "*\n   * Get a single FZP and response the xml as a string\n   * @param  {String} src\n   * @return {Promise} the fetch promise\n   ",
-      "start": 894,
-      "end": 1025,
-      "loc": {
-        "start": {
-          "line": 47,
-          "column": 2
-        },
-        "end": {
-          "line": 51,
-          "column": 5
-        }
-      }
-    },
-    {
-      "type": "CommentBlock",
-      "value": "*\n    * Get a single part fzp from the core parts\n    * @param  {String} src\n    * @return {Promise} the fetch promise returns xml\n    ",
-      "start": 1170,
-      "end": 1309,
-      "loc": {
-        "start": {
-          "line": 59,
           "column": 3
+        }
+      }
+    },
+    {
+      "type": "CommentBlock",
+      "value": "*\n * Get a list of all Obsolete-FZP files. for old sketches only!\n *\n * @param  {String} url - The base URL of the parts api\n * @return {Promise}\n ",
+      "start": 935,
+      "end": 1086,
+      "loc": {
+        "start": {
+          "line": 44,
+          "column": 0
+        },
+        "end": {
+          "line": 49,
+          "column": 3
+        }
+      }
+    },
+    {
+      "type": "CommentBlock",
+      "value": "*\n * Get a single FZP and response the xml as a string\n *\n * @param  {String} src\n * @param  {String} url - The base URL of the parts api\n * @return {Promise} the fetch promise\n ",
+      "start": 1279,
+      "end": 1461,
+      "loc": {
+        "start": {
+          "line": 57,
+          "column": 0
         },
         "end": {
           "line": 63,
-          "column": 6
-        }
-      }
-    },
-    {
-      "type": "CommentBlock",
-      "value": "*\n   * Get a single part fzp from the obsolete parts, this is for old sketches only!\n   * @param  {String} src\n   * @return {Promise} the fetch promise returns xml\n   ",
-      "start": 1455,
-      "end": 1626,
-      "loc": {
-        "start": {
-          "line": 70,
-          "column": 2
-        },
-        "end": {
-          "line": 74,
-          "column": 5
-        }
-      }
-    },
-    {
-      "type": "CommentBlock",
-      "value": "*\n   * Get a single part svg and response the svg as a string\n   * @param  {String} src\n   * @return {Promise} the fetch promise\n   ",
-      "start": 1782,
-      "end": 1918,
-      "loc": {
-        "start": {
-          "line": 83,
-          "column": 2
-        },
-        "end": {
-          "line": 87,
-          "column": 5
-        }
-      }
-    },
-    {
-      "type": "CommentBlock",
-      "value": "*\n    * Get a single part svg from the core parts as svg-string\n    * @param  {String} src\n    * @return {Promise} the fetch promise returns xml\n    ",
-      "start": 2066,
-      "end": 2219,
-      "loc": {
-        "start": {
-          "line": 94,
           "column": 3
-        },
-        "end": {
-          "line": 98,
-          "column": 6
         }
       }
     },
     {
       "type": "CommentBlock",
-      "value": "*\n   * Get a single part svg from the obsolete svgs, this is for old-sketches only! the response is a svg-string\n   * @param  {String} src\n   * @return {Promise} the fetch promise\n   ",
-      "start": 2369,
-      "end": 2556,
+      "value": "*\n  * Get a single part fzp from the core parts\n  *\n  * @param  {String} src\n  * @param  {String} url - The base URL of the parts api\n  * @return {Promise} the fetch promise returns xml\n  ",
+      "start": 1644,
+      "end": 1836,
       "loc": {
         "start": {
+          "line": 71,
+          "column": 1
+        },
+        "end": {
+          "line": 77,
+          "column": 4
+        }
+      }
+    },
+    {
+      "type": "CommentBlock",
+      "value": "*\n * Get a single part fzp from the obsolete parts, this is for old sketches only!\n *\n * @param  {String} src\n * @param  {String} url - The base URL of the parts api\n * @return {Promise} the fetch promise returns xml\n ",
+      "start": 2027,
+      "end": 2249,
+      "loc": {
+        "start": {
+          "line": 85,
+          "column": 0
+        },
+        "end": {
+          "line": 91,
+          "column": 3
+        }
+      }
+    },
+    {
+      "type": "CommentBlock",
+      "value": "*\n * Get a single part svg and response the svg as a string\n *\n * @param  {String} src\n * @param  {String} url - The base URL of the parts api\n * @return {Promise} the fetch promise\n ",
+      "start": 2448,
+      "end": 2635,
+      "loc": {
+        "start": {
+          "line": 99,
+          "column": 0
+        },
+        "end": {
           "line": 105,
-          "column": 2
-        },
-        "end": {
-          "line": 109,
-          "column": 5
+          "column": 3
         }
       }
     },
     {
       "type": "CommentBlock",
-      "value": "*\n   * Get a list of all FZB files\n   * @return {Promise}\n   ",
-      "start": 2715,
-      "end": 2780,
+      "value": "*\n  * Get a single part svg from the core parts as svg-string\n  *\n  * @param  {String} src\n  * @param  {String} url - The base URL of the parts api\n  * @return {Promise} the fetch promise returns xml\n  ",
+      "start": 2828,
+      "end": 3034,
       "loc": {
         "start": {
-          "line": 117,
-          "column": 2
+          "line": 113,
+          "column": 1
         },
         "end": {
-          "line": 120,
-          "column": 5
+          "line": 119,
+          "column": 4
+        }
+      }
+    },
+    {
+      "type": "CommentBlock",
+      "value": "*\n * Get a single part svg from the obsolete svgs, this is for old-sketches only! the response is a svg-string\n *\n * @param  {String} src\n * @param  {String} url - The base URL of the parts api\n * @return {Promise} the fetch promise\n ",
+      "start": 3229,
+      "end": 3467,
+      "loc": {
+        "start": {
+          "line": 127,
+          "column": 0
+        },
+        "end": {
+          "line": 133,
+          "column": 3
+        }
+      }
+    },
+    {
+      "type": "CommentBlock",
+      "value": "*\n * Get a list of all FZB files\n *\n * @param  {String} url - The base URL of the parts api\n * @return {Promise}\n ",
+      "start": 3670,
+      "end": 3788,
+      "loc": {
+        "start": {
+          "line": 141,
+          "column": 0
+        },
+        "end": {
+          "line": 146,
+          "column": 3
+        }
+      }
+    },
+    {
+      "type": "CommentBlock",
+      "value": "*\n* Fritzing Parts API Client\n*\n* @example\n* const {FritzingPartsAPIClient} = require('fritzing-parts-api-client-js')\n*\n* FritzingPartsAPIClient.getFzps()\n* .then((fzpz) => {\n*   console.log(fzps)\n* })\n* .catch((err) => {\n*   console.error(err)\n* })\n",
+      "start": 3965,
+      "end": 4219,
+      "loc": {
+        "start": {
+          "line": 155,
+          "column": 0
+        },
+        "end": {
+          "line": 168,
+          "column": 2
         }
       }
     }
@@ -6348,24 +8536,24 @@
     },
     {
       "type": "CommentBlock",
-      "value": "*\n * Fritzing Parts API Client\n ",
+      "value": "*\n * The base url of the fritzing parts api\n *\n * @example\n * const {FritzingPartsAPI} = require('fritzing-parts-api-client-js')\n *\n * console.log(FritzingPartsAPI)\n *\n * @type {String}\n ",
       "start": 48,
-      "end": 84,
+      "end": 239,
       "loc": {
         "start": {
           "line": 5,
           "column": 0
         },
         "end": {
-          "line": 7,
+          "line": 14,
           "column": 3
         }
       }
     },
     {
       "type": {
-        "label": "class",
-        "keyword": "class",
+        "label": "const",
+        "keyword": "const",
         "beforeExpr": false,
         "startsExpr": false,
         "rightAssociative": false,
@@ -6376,16 +8564,16 @@
         "binop": null,
         "updateContext": null
       },
-      "value": "class",
-      "start": 85,
-      "end": 90,
+      "value": "const",
+      "start": 240,
+      "end": 245,
       "loc": {
         "start": {
-          "line": 8,
+          "line": 15,
           "column": 0
         },
         "end": {
-          "line": 8,
+          "line": 15,
           "column": 5
         }
       }
@@ -6402,64 +8590,201 @@
         "postfix": false,
         "binop": null
       },
-      "value": "ApiClient",
-      "start": 91,
-      "end": 100,
+      "value": "FritzingPartsAPI",
+      "start": 246,
+      "end": 262,
       "loc": {
         "start": {
-          "line": 8,
+          "line": 15,
           "column": 6
         },
         "end": {
-          "line": 8,
+          "line": 15,
+          "column": 22
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "=",
+        "beforeExpr": true,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": true,
+        "prefix": false,
+        "postfix": false,
+        "binop": null,
+        "updateContext": null
+      },
+      "value": "=",
+      "start": 263,
+      "end": 264,
+      "loc": {
+        "start": {
+          "line": 15,
+          "column": 23
+        },
+        "end": {
+          "line": 15,
+          "column": 24
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "string",
+        "beforeExpr": false,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null,
+        "updateContext": null
+      },
+      "value": "https://fritzing.github.io/fritzing-parts",
+      "start": 265,
+      "end": 308,
+      "loc": {
+        "start": {
+          "line": 15,
+          "column": 25
+        },
+        "end": {
+          "line": 15,
+          "column": 68
+        }
+      }
+    },
+    {
+      "type": {
+        "label": ";",
+        "beforeExpr": true,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null,
+        "updateContext": null
+      },
+      "start": 308,
+      "end": 309,
+      "loc": {
+        "start": {
+          "line": 15,
+          "column": 68
+        },
+        "end": {
+          "line": 15,
+          "column": 69
+        }
+      }
+    },
+    {
+      "type": "CommentBlock",
+      "value": "*\n * Get a list of all FZP files\n *\n * @type   {Function}\n * @param  {String} url - The base URL of the parts api\n * @return {Promise}\n ",
+      "start": 311,
+      "end": 451,
+      "loc": {
+        "start": {
+          "line": 17,
+          "column": 0
+        },
+        "end": {
+          "line": 23,
+          "column": 3
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "const",
+        "keyword": "const",
+        "beforeExpr": false,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null,
+        "updateContext": null
+      },
+      "value": "const",
+      "start": 452,
+      "end": 457,
+      "loc": {
+        "start": {
+          "line": 24,
+          "column": 0
+        },
+        "end": {
+          "line": 24,
+          "column": 5
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "name",
+        "beforeExpr": false,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "value": "getFzps",
+      "start": 458,
+      "end": 465,
+      "loc": {
+        "start": {
+          "line": 24,
+          "column": 6
+        },
+        "end": {
+          "line": 24,
+          "column": 13
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "=",
+        "beforeExpr": true,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": true,
+        "prefix": false,
+        "postfix": false,
+        "binop": null,
+        "updateContext": null
+      },
+      "value": "=",
+      "start": 466,
+      "end": 467,
+      "loc": {
+        "start": {
+          "line": 24,
+          "column": 14
+        },
+        "end": {
+          "line": 24,
           "column": 15
         }
       }
     },
     {
       "type": {
-        "label": "{",
-        "beforeExpr": true,
-        "startsExpr": true,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null
-      },
-      "start": 101,
-      "end": 102,
-      "loc": {
-        "start": {
-          "line": 8,
-          "column": 16
-        },
-        "end": {
-          "line": 8,
-          "column": 17
-        }
-      }
-    },
-    {
-      "type": "CommentBlock",
-      "value": "*\n   * Construct the ApiClient\n   ",
-      "start": 105,
-      "end": 143,
-      "loc": {
-        "start": {
-          "line": 9,
-          "column": 2
-        },
-        "end": {
-          "line": 11,
-          "column": 5
-        }
-      }
-    },
-    {
-      "type": {
-        "label": "name",
+        "label": "function",
+        "keyword": "function",
         "beforeExpr": false,
         "startsExpr": true,
         "rightAssociative": false,
@@ -6469,17 +8794,17 @@
         "postfix": false,
         "binop": null
       },
-      "value": "constructor",
-      "start": 146,
-      "end": 157,
+      "value": "function",
+      "start": 468,
+      "end": 476,
       "loc": {
         "start": {
-          "line": 12,
-          "column": 2
+          "line": 24,
+          "column": 16
         },
         "end": {
-          "line": 12,
-          "column": 13
+          "line": 24,
+          "column": 24
         }
       }
     },
@@ -6495,120 +8820,16 @@
         "postfix": false,
         "binop": null
       },
-      "start": 157,
-      "end": 158,
+      "start": 476,
+      "end": 477,
       "loc": {
         "start": {
-          "line": 12,
-          "column": 13
+          "line": 24,
+          "column": 24
         },
         "end": {
-          "line": 12,
-          "column": 14
-        }
-      }
-    },
-    {
-      "type": {
-        "label": ")",
-        "beforeExpr": false,
-        "startsExpr": false,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null
-      },
-      "start": 158,
-      "end": 159,
-      "loc": {
-        "start": {
-          "line": 12,
-          "column": 14
-        },
-        "end": {
-          "line": 12,
-          "column": 15
-        }
-      }
-    },
-    {
-      "type": {
-        "label": "{",
-        "beforeExpr": true,
-        "startsExpr": true,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null
-      },
-      "start": 160,
-      "end": 161,
-      "loc": {
-        "start": {
-          "line": 12,
-          "column": 16
-        },
-        "end": {
-          "line": 12,
-          "column": 17
-        }
-      }
-    },
-    {
-      "type": {
-        "label": "this",
-        "keyword": "this",
-        "beforeExpr": false,
-        "startsExpr": true,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null,
-        "updateContext": null
-      },
-      "value": "this",
-      "start": 166,
-      "end": 170,
-      "loc": {
-        "start": {
-          "line": 13,
-          "column": 4
-        },
-        "end": {
-          "line": 13,
-          "column": 8
-        }
-      }
-    },
-    {
-      "type": {
-        "label": ".",
-        "beforeExpr": false,
-        "startsExpr": false,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null,
-        "updateContext": null
-      },
-      "start": 170,
-      "end": 171,
-      "loc": {
-        "start": {
-          "line": 13,
-          "column": 8
-        },
-        "end": {
-          "line": 13,
-          "column": 9
+          "line": 24,
+          "column": 25
         }
       }
     },
@@ -6625,15 +8846,3990 @@
         "binop": null
       },
       "value": "url",
-      "start": 171,
-      "end": 174,
+      "start": 477,
+      "end": 480,
       "loc": {
         "start": {
-          "line": 13,
+          "line": 24,
+          "column": 25
+        },
+        "end": {
+          "line": 24,
+          "column": 28
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "=",
+        "beforeExpr": true,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": true,
+        "prefix": false,
+        "postfix": false,
+        "binop": null,
+        "updateContext": null
+      },
+      "value": "=",
+      "start": 481,
+      "end": 482,
+      "loc": {
+        "start": {
+          "line": 24,
+          "column": 29
+        },
+        "end": {
+          "line": 24,
+          "column": 30
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "`",
+        "beforeExpr": false,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "start": 483,
+      "end": 484,
+      "loc": {
+        "start": {
+          "line": 24,
+          "column": 31
+        },
+        "end": {
+          "line": 24,
+          "column": 32
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "template",
+        "beforeExpr": false,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null,
+        "updateContext": null
+      },
+      "value": "",
+      "start": 484,
+      "end": 484,
+      "loc": {
+        "start": {
+          "line": 24,
+          "column": 32
+        },
+        "end": {
+          "line": 24,
+          "column": 32
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "${",
+        "beforeExpr": true,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "start": 484,
+      "end": 486,
+      "loc": {
+        "start": {
+          "line": 24,
+          "column": 32
+        },
+        "end": {
+          "line": 24,
+          "column": 34
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "name",
+        "beforeExpr": false,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "value": "FritzingPartsAPI",
+      "start": 486,
+      "end": 502,
+      "loc": {
+        "start": {
+          "line": 24,
+          "column": 34
+        },
+        "end": {
+          "line": 24,
+          "column": 50
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "}",
+        "beforeExpr": false,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "start": 502,
+      "end": 503,
+      "loc": {
+        "start": {
+          "line": 24,
+          "column": 50
+        },
+        "end": {
+          "line": 24,
+          "column": 51
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "template",
+        "beforeExpr": false,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null,
+        "updateContext": null
+      },
+      "value": "/fzp",
+      "start": 503,
+      "end": 507,
+      "loc": {
+        "start": {
+          "line": 24,
+          "column": 51
+        },
+        "end": {
+          "line": 24,
+          "column": 55
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "`",
+        "beforeExpr": false,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "start": 507,
+      "end": 508,
+      "loc": {
+        "start": {
+          "line": 24,
+          "column": 55
+        },
+        "end": {
+          "line": 24,
+          "column": 56
+        }
+      }
+    },
+    {
+      "type": {
+        "label": ")",
+        "beforeExpr": false,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "start": 508,
+      "end": 509,
+      "loc": {
+        "start": {
+          "line": 24,
+          "column": 56
+        },
+        "end": {
+          "line": 24,
+          "column": 57
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "{",
+        "beforeExpr": true,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "start": 510,
+      "end": 511,
+      "loc": {
+        "start": {
+          "line": 24,
+          "column": 58
+        },
+        "end": {
+          "line": 24,
+          "column": 59
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "return",
+        "keyword": "return",
+        "beforeExpr": true,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null,
+        "updateContext": null
+      },
+      "value": "return",
+      "start": 514,
+      "end": 520,
+      "loc": {
+        "start": {
+          "line": 25,
+          "column": 2
+        },
+        "end": {
+          "line": 25,
+          "column": 8
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "name",
+        "beforeExpr": false,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "value": "axios",
+      "start": 521,
+      "end": 526,
+      "loc": {
+        "start": {
+          "line": 25,
           "column": 9
         },
         "end": {
-          "line": 13,
+          "line": 25,
+          "column": 14
+        }
+      }
+    },
+    {
+      "type": {
+        "label": ".",
+        "beforeExpr": false,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null,
+        "updateContext": null
+      },
+      "start": 526,
+      "end": 527,
+      "loc": {
+        "start": {
+          "line": 25,
+          "column": 14
+        },
+        "end": {
+          "line": 25,
+          "column": 15
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "name",
+        "beforeExpr": false,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "value": "get",
+      "start": 527,
+      "end": 530,
+      "loc": {
+        "start": {
+          "line": 25,
+          "column": 15
+        },
+        "end": {
+          "line": 25,
+          "column": 18
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "(",
+        "beforeExpr": true,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "start": 530,
+      "end": 531,
+      "loc": {
+        "start": {
+          "line": 25,
+          "column": 18
+        },
+        "end": {
+          "line": 25,
+          "column": 19
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "name",
+        "beforeExpr": false,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "value": "url",
+      "start": 531,
+      "end": 534,
+      "loc": {
+        "start": {
+          "line": 25,
+          "column": 19
+        },
+        "end": {
+          "line": 25,
+          "column": 22
+        }
+      }
+    },
+    {
+      "type": {
+        "label": ",",
+        "beforeExpr": true,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null,
+        "updateContext": null
+      },
+      "start": 534,
+      "end": 535,
+      "loc": {
+        "start": {
+          "line": 25,
+          "column": 22
+        },
+        "end": {
+          "line": 25,
+          "column": 23
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "{",
+        "beforeExpr": true,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "start": 536,
+      "end": 537,
+      "loc": {
+        "start": {
+          "line": 25,
+          "column": 24
+        },
+        "end": {
+          "line": 25,
+          "column": 25
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "name",
+        "beforeExpr": false,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "value": "responseType",
+      "start": 537,
+      "end": 549,
+      "loc": {
+        "start": {
+          "line": 25,
+          "column": 25
+        },
+        "end": {
+          "line": 25,
+          "column": 37
+        }
+      }
+    },
+    {
+      "type": {
+        "label": ":",
+        "beforeExpr": true,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null,
+        "updateContext": null
+      },
+      "start": 549,
+      "end": 550,
+      "loc": {
+        "start": {
+          "line": 25,
+          "column": 37
+        },
+        "end": {
+          "line": 25,
+          "column": 38
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "string",
+        "beforeExpr": false,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null,
+        "updateContext": null
+      },
+      "value": "json",
+      "start": 551,
+      "end": 557,
+      "loc": {
+        "start": {
+          "line": 25,
+          "column": 39
+        },
+        "end": {
+          "line": 25,
+          "column": 45
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "}",
+        "beforeExpr": false,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "start": 557,
+      "end": 558,
+      "loc": {
+        "start": {
+          "line": 25,
+          "column": 45
+        },
+        "end": {
+          "line": 25,
+          "column": 46
+        }
+      }
+    },
+    {
+      "type": {
+        "label": ")",
+        "beforeExpr": false,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "start": 558,
+      "end": 559,
+      "loc": {
+        "start": {
+          "line": 25,
+          "column": 46
+        },
+        "end": {
+          "line": 25,
+          "column": 47
+        }
+      }
+    },
+    {
+      "type": {
+        "label": ".",
+        "beforeExpr": false,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null,
+        "updateContext": null
+      },
+      "start": 562,
+      "end": 563,
+      "loc": {
+        "start": {
+          "line": 26,
+          "column": 2
+        },
+        "end": {
+          "line": 26,
+          "column": 3
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "name",
+        "beforeExpr": false,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "value": "then",
+      "start": 563,
+      "end": 567,
+      "loc": {
+        "start": {
+          "line": 26,
+          "column": 3
+        },
+        "end": {
+          "line": 26,
+          "column": 7
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "(",
+        "beforeExpr": true,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "start": 567,
+      "end": 568,
+      "loc": {
+        "start": {
+          "line": 26,
+          "column": 7
+        },
+        "end": {
+          "line": 26,
+          "column": 8
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "(",
+        "beforeExpr": true,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "start": 568,
+      "end": 569,
+      "loc": {
+        "start": {
+          "line": 26,
+          "column": 8
+        },
+        "end": {
+          "line": 26,
+          "column": 9
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "name",
+        "beforeExpr": false,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "value": "res",
+      "start": 569,
+      "end": 572,
+      "loc": {
+        "start": {
+          "line": 26,
+          "column": 9
+        },
+        "end": {
+          "line": 26,
+          "column": 12
+        }
+      }
+    },
+    {
+      "type": {
+        "label": ")",
+        "beforeExpr": false,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "start": 572,
+      "end": 573,
+      "loc": {
+        "start": {
+          "line": 26,
+          "column": 12
+        },
+        "end": {
+          "line": 26,
+          "column": 13
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "=>",
+        "beforeExpr": true,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null,
+        "updateContext": null
+      },
+      "start": 574,
+      "end": 576,
+      "loc": {
+        "start": {
+          "line": 26,
+          "column": 14
+        },
+        "end": {
+          "line": 26,
+          "column": 16
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "{",
+        "beforeExpr": true,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "start": 577,
+      "end": 578,
+      "loc": {
+        "start": {
+          "line": 26,
+          "column": 17
+        },
+        "end": {
+          "line": 26,
+          "column": 18
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "return",
+        "keyword": "return",
+        "beforeExpr": true,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null,
+        "updateContext": null
+      },
+      "value": "return",
+      "start": 583,
+      "end": 589,
+      "loc": {
+        "start": {
+          "line": 27,
+          "column": 4
+        },
+        "end": {
+          "line": 27,
+          "column": 10
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "name",
+        "beforeExpr": false,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "value": "Promise",
+      "start": 590,
+      "end": 597,
+      "loc": {
+        "start": {
+          "line": 27,
+          "column": 11
+        },
+        "end": {
+          "line": 27,
+          "column": 18
+        }
+      }
+    },
+    {
+      "type": {
+        "label": ".",
+        "beforeExpr": false,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null,
+        "updateContext": null
+      },
+      "start": 597,
+      "end": 598,
+      "loc": {
+        "start": {
+          "line": 27,
+          "column": 18
+        },
+        "end": {
+          "line": 27,
+          "column": 19
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "name",
+        "beforeExpr": false,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "value": "resolve",
+      "start": 598,
+      "end": 605,
+      "loc": {
+        "start": {
+          "line": 27,
+          "column": 19
+        },
+        "end": {
+          "line": 27,
+          "column": 26
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "(",
+        "beforeExpr": true,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "start": 605,
+      "end": 606,
+      "loc": {
+        "start": {
+          "line": 27,
+          "column": 26
+        },
+        "end": {
+          "line": 27,
+          "column": 27
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "name",
+        "beforeExpr": false,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "value": "res",
+      "start": 606,
+      "end": 609,
+      "loc": {
+        "start": {
+          "line": 27,
+          "column": 27
+        },
+        "end": {
+          "line": 27,
+          "column": 30
+        }
+      }
+    },
+    {
+      "type": {
+        "label": ".",
+        "beforeExpr": false,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null,
+        "updateContext": null
+      },
+      "start": 609,
+      "end": 610,
+      "loc": {
+        "start": {
+          "line": 27,
+          "column": 30
+        },
+        "end": {
+          "line": 27,
+          "column": 31
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "name",
+        "beforeExpr": false,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "value": "data",
+      "start": 610,
+      "end": 614,
+      "loc": {
+        "start": {
+          "line": 27,
+          "column": 31
+        },
+        "end": {
+          "line": 27,
+          "column": 35
+        }
+      }
+    },
+    {
+      "type": {
+        "label": ")",
+        "beforeExpr": false,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "start": 614,
+      "end": 615,
+      "loc": {
+        "start": {
+          "line": 27,
+          "column": 35
+        },
+        "end": {
+          "line": 27,
+          "column": 36
+        }
+      }
+    },
+    {
+      "type": {
+        "label": ";",
+        "beforeExpr": true,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null,
+        "updateContext": null
+      },
+      "start": 615,
+      "end": 616,
+      "loc": {
+        "start": {
+          "line": 27,
+          "column": 36
+        },
+        "end": {
+          "line": 27,
+          "column": 37
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "}",
+        "beforeExpr": false,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "start": 619,
+      "end": 620,
+      "loc": {
+        "start": {
+          "line": 28,
+          "column": 2
+        },
+        "end": {
+          "line": 28,
+          "column": 3
+        }
+      }
+    },
+    {
+      "type": {
+        "label": ")",
+        "beforeExpr": false,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "start": 620,
+      "end": 621,
+      "loc": {
+        "start": {
+          "line": 28,
+          "column": 3
+        },
+        "end": {
+          "line": 28,
+          "column": 4
+        }
+      }
+    },
+    {
+      "type": {
+        "label": ";",
+        "beforeExpr": true,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null,
+        "updateContext": null
+      },
+      "start": 621,
+      "end": 622,
+      "loc": {
+        "start": {
+          "line": 28,
+          "column": 4
+        },
+        "end": {
+          "line": 28,
+          "column": 5
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "}",
+        "beforeExpr": false,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "start": 623,
+      "end": 624,
+      "loc": {
+        "start": {
+          "line": 29,
+          "column": 0
+        },
+        "end": {
+          "line": 29,
+          "column": 1
+        }
+      }
+    },
+    {
+      "type": {
+        "label": ";",
+        "beforeExpr": true,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null,
+        "updateContext": null
+      },
+      "start": 624,
+      "end": 625,
+      "loc": {
+        "start": {
+          "line": 29,
+          "column": 1
+        },
+        "end": {
+          "line": 29,
+          "column": 2
+        }
+      }
+    },
+    {
+      "type": "CommentBlock",
+      "value": "*\n * Get a list of all Core-FZP files\n *\n * @param  {String} url - The base URL of the parts api\n * @return {Promise}\n ",
+      "start": 627,
+      "end": 750,
+      "loc": {
+        "start": {
+          "line": 31,
+          "column": 0
+        },
+        "end": {
+          "line": 36,
+          "column": 3
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "const",
+        "keyword": "const",
+        "beforeExpr": false,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null,
+        "updateContext": null
+      },
+      "value": "const",
+      "start": 751,
+      "end": 756,
+      "loc": {
+        "start": {
+          "line": 37,
+          "column": 0
+        },
+        "end": {
+          "line": 37,
+          "column": 5
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "name",
+        "beforeExpr": false,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "value": "getFzpsCore",
+      "start": 757,
+      "end": 768,
+      "loc": {
+        "start": {
+          "line": 37,
+          "column": 6
+        },
+        "end": {
+          "line": 37,
+          "column": 17
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "=",
+        "beforeExpr": true,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": true,
+        "prefix": false,
+        "postfix": false,
+        "binop": null,
+        "updateContext": null
+      },
+      "value": "=",
+      "start": 769,
+      "end": 770,
+      "loc": {
+        "start": {
+          "line": 37,
+          "column": 18
+        },
+        "end": {
+          "line": 37,
+          "column": 19
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "function",
+        "keyword": "function",
+        "beforeExpr": false,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "value": "function",
+      "start": 771,
+      "end": 779,
+      "loc": {
+        "start": {
+          "line": 37,
+          "column": 20
+        },
+        "end": {
+          "line": 37,
+          "column": 28
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "(",
+        "beforeExpr": true,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "start": 779,
+      "end": 780,
+      "loc": {
+        "start": {
+          "line": 37,
+          "column": 28
+        },
+        "end": {
+          "line": 37,
+          "column": 29
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "name",
+        "beforeExpr": false,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "value": "url",
+      "start": 780,
+      "end": 783,
+      "loc": {
+        "start": {
+          "line": 37,
+          "column": 29
+        },
+        "end": {
+          "line": 37,
+          "column": 32
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "=",
+        "beforeExpr": true,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": true,
+        "prefix": false,
+        "postfix": false,
+        "binop": null,
+        "updateContext": null
+      },
+      "value": "=",
+      "start": 784,
+      "end": 785,
+      "loc": {
+        "start": {
+          "line": 37,
+          "column": 33
+        },
+        "end": {
+          "line": 37,
+          "column": 34
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "`",
+        "beforeExpr": false,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "start": 786,
+      "end": 787,
+      "loc": {
+        "start": {
+          "line": 37,
+          "column": 35
+        },
+        "end": {
+          "line": 37,
+          "column": 36
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "template",
+        "beforeExpr": false,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null,
+        "updateContext": null
+      },
+      "value": "",
+      "start": 787,
+      "end": 787,
+      "loc": {
+        "start": {
+          "line": 37,
+          "column": 36
+        },
+        "end": {
+          "line": 37,
+          "column": 36
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "${",
+        "beforeExpr": true,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "start": 787,
+      "end": 789,
+      "loc": {
+        "start": {
+          "line": 37,
+          "column": 36
+        },
+        "end": {
+          "line": 37,
+          "column": 38
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "name",
+        "beforeExpr": false,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "value": "FritzingPartsAPI",
+      "start": 789,
+      "end": 805,
+      "loc": {
+        "start": {
+          "line": 37,
+          "column": 38
+        },
+        "end": {
+          "line": 37,
+          "column": 54
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "}",
+        "beforeExpr": false,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "start": 805,
+      "end": 806,
+      "loc": {
+        "start": {
+          "line": 37,
+          "column": 54
+        },
+        "end": {
+          "line": 37,
+          "column": 55
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "template",
+        "beforeExpr": false,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null,
+        "updateContext": null
+      },
+      "value": "/fzp/core",
+      "start": 806,
+      "end": 815,
+      "loc": {
+        "start": {
+          "line": 37,
+          "column": 55
+        },
+        "end": {
+          "line": 37,
+          "column": 64
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "`",
+        "beforeExpr": false,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "start": 815,
+      "end": 816,
+      "loc": {
+        "start": {
+          "line": 37,
+          "column": 64
+        },
+        "end": {
+          "line": 37,
+          "column": 65
+        }
+      }
+    },
+    {
+      "type": {
+        "label": ")",
+        "beforeExpr": false,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "start": 816,
+      "end": 817,
+      "loc": {
+        "start": {
+          "line": 37,
+          "column": 65
+        },
+        "end": {
+          "line": 37,
+          "column": 66
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "{",
+        "beforeExpr": true,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "start": 818,
+      "end": 819,
+      "loc": {
+        "start": {
+          "line": 37,
+          "column": 67
+        },
+        "end": {
+          "line": 37,
+          "column": 68
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "return",
+        "keyword": "return",
+        "beforeExpr": true,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null,
+        "updateContext": null
+      },
+      "value": "return",
+      "start": 822,
+      "end": 828,
+      "loc": {
+        "start": {
+          "line": 38,
+          "column": 2
+        },
+        "end": {
+          "line": 38,
+          "column": 8
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "name",
+        "beforeExpr": false,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "value": "axios",
+      "start": 829,
+      "end": 834,
+      "loc": {
+        "start": {
+          "line": 38,
+          "column": 9
+        },
+        "end": {
+          "line": 38,
+          "column": 14
+        }
+      }
+    },
+    {
+      "type": {
+        "label": ".",
+        "beforeExpr": false,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null,
+        "updateContext": null
+      },
+      "start": 834,
+      "end": 835,
+      "loc": {
+        "start": {
+          "line": 38,
+          "column": 14
+        },
+        "end": {
+          "line": 38,
+          "column": 15
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "name",
+        "beforeExpr": false,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "value": "get",
+      "start": 835,
+      "end": 838,
+      "loc": {
+        "start": {
+          "line": 38,
+          "column": 15
+        },
+        "end": {
+          "line": 38,
+          "column": 18
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "(",
+        "beforeExpr": true,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "start": 838,
+      "end": 839,
+      "loc": {
+        "start": {
+          "line": 38,
+          "column": 18
+        },
+        "end": {
+          "line": 38,
+          "column": 19
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "name",
+        "beforeExpr": false,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "value": "url",
+      "start": 839,
+      "end": 842,
+      "loc": {
+        "start": {
+          "line": 38,
+          "column": 19
+        },
+        "end": {
+          "line": 38,
+          "column": 22
+        }
+      }
+    },
+    {
+      "type": {
+        "label": ",",
+        "beforeExpr": true,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null,
+        "updateContext": null
+      },
+      "start": 842,
+      "end": 843,
+      "loc": {
+        "start": {
+          "line": 38,
+          "column": 22
+        },
+        "end": {
+          "line": 38,
+          "column": 23
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "{",
+        "beforeExpr": true,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "start": 844,
+      "end": 845,
+      "loc": {
+        "start": {
+          "line": 38,
+          "column": 24
+        },
+        "end": {
+          "line": 38,
+          "column": 25
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "name",
+        "beforeExpr": false,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "value": "responseType",
+      "start": 845,
+      "end": 857,
+      "loc": {
+        "start": {
+          "line": 38,
+          "column": 25
+        },
+        "end": {
+          "line": 38,
+          "column": 37
+        }
+      }
+    },
+    {
+      "type": {
+        "label": ":",
+        "beforeExpr": true,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null,
+        "updateContext": null
+      },
+      "start": 857,
+      "end": 858,
+      "loc": {
+        "start": {
+          "line": 38,
+          "column": 37
+        },
+        "end": {
+          "line": 38,
+          "column": 38
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "string",
+        "beforeExpr": false,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null,
+        "updateContext": null
+      },
+      "value": "json",
+      "start": 859,
+      "end": 865,
+      "loc": {
+        "start": {
+          "line": 38,
+          "column": 39
+        },
+        "end": {
+          "line": 38,
+          "column": 45
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "}",
+        "beforeExpr": false,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "start": 865,
+      "end": 866,
+      "loc": {
+        "start": {
+          "line": 38,
+          "column": 45
+        },
+        "end": {
+          "line": 38,
+          "column": 46
+        }
+      }
+    },
+    {
+      "type": {
+        "label": ")",
+        "beforeExpr": false,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "start": 866,
+      "end": 867,
+      "loc": {
+        "start": {
+          "line": 38,
+          "column": 46
+        },
+        "end": {
+          "line": 38,
+          "column": 47
+        }
+      }
+    },
+    {
+      "type": {
+        "label": ".",
+        "beforeExpr": false,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null,
+        "updateContext": null
+      },
+      "start": 870,
+      "end": 871,
+      "loc": {
+        "start": {
+          "line": 39,
+          "column": 2
+        },
+        "end": {
+          "line": 39,
+          "column": 3
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "name",
+        "beforeExpr": false,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "value": "then",
+      "start": 871,
+      "end": 875,
+      "loc": {
+        "start": {
+          "line": 39,
+          "column": 3
+        },
+        "end": {
+          "line": 39,
+          "column": 7
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "(",
+        "beforeExpr": true,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "start": 875,
+      "end": 876,
+      "loc": {
+        "start": {
+          "line": 39,
+          "column": 7
+        },
+        "end": {
+          "line": 39,
+          "column": 8
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "(",
+        "beforeExpr": true,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "start": 876,
+      "end": 877,
+      "loc": {
+        "start": {
+          "line": 39,
+          "column": 8
+        },
+        "end": {
+          "line": 39,
+          "column": 9
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "name",
+        "beforeExpr": false,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "value": "res",
+      "start": 877,
+      "end": 880,
+      "loc": {
+        "start": {
+          "line": 39,
+          "column": 9
+        },
+        "end": {
+          "line": 39,
+          "column": 12
+        }
+      }
+    },
+    {
+      "type": {
+        "label": ")",
+        "beforeExpr": false,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "start": 880,
+      "end": 881,
+      "loc": {
+        "start": {
+          "line": 39,
+          "column": 12
+        },
+        "end": {
+          "line": 39,
+          "column": 13
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "=>",
+        "beforeExpr": true,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null,
+        "updateContext": null
+      },
+      "start": 882,
+      "end": 884,
+      "loc": {
+        "start": {
+          "line": 39,
+          "column": 14
+        },
+        "end": {
+          "line": 39,
+          "column": 16
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "{",
+        "beforeExpr": true,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "start": 885,
+      "end": 886,
+      "loc": {
+        "start": {
+          "line": 39,
+          "column": 17
+        },
+        "end": {
+          "line": 39,
+          "column": 18
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "return",
+        "keyword": "return",
+        "beforeExpr": true,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null,
+        "updateContext": null
+      },
+      "value": "return",
+      "start": 891,
+      "end": 897,
+      "loc": {
+        "start": {
+          "line": 40,
+          "column": 4
+        },
+        "end": {
+          "line": 40,
+          "column": 10
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "name",
+        "beforeExpr": false,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "value": "Promise",
+      "start": 898,
+      "end": 905,
+      "loc": {
+        "start": {
+          "line": 40,
+          "column": 11
+        },
+        "end": {
+          "line": 40,
+          "column": 18
+        }
+      }
+    },
+    {
+      "type": {
+        "label": ".",
+        "beforeExpr": false,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null,
+        "updateContext": null
+      },
+      "start": 905,
+      "end": 906,
+      "loc": {
+        "start": {
+          "line": 40,
+          "column": 18
+        },
+        "end": {
+          "line": 40,
+          "column": 19
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "name",
+        "beforeExpr": false,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "value": "resolve",
+      "start": 906,
+      "end": 913,
+      "loc": {
+        "start": {
+          "line": 40,
+          "column": 19
+        },
+        "end": {
+          "line": 40,
+          "column": 26
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "(",
+        "beforeExpr": true,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "start": 913,
+      "end": 914,
+      "loc": {
+        "start": {
+          "line": 40,
+          "column": 26
+        },
+        "end": {
+          "line": 40,
+          "column": 27
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "name",
+        "beforeExpr": false,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "value": "res",
+      "start": 914,
+      "end": 917,
+      "loc": {
+        "start": {
+          "line": 40,
+          "column": 27
+        },
+        "end": {
+          "line": 40,
+          "column": 30
+        }
+      }
+    },
+    {
+      "type": {
+        "label": ".",
+        "beforeExpr": false,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null,
+        "updateContext": null
+      },
+      "start": 917,
+      "end": 918,
+      "loc": {
+        "start": {
+          "line": 40,
+          "column": 30
+        },
+        "end": {
+          "line": 40,
+          "column": 31
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "name",
+        "beforeExpr": false,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "value": "data",
+      "start": 918,
+      "end": 922,
+      "loc": {
+        "start": {
+          "line": 40,
+          "column": 31
+        },
+        "end": {
+          "line": 40,
+          "column": 35
+        }
+      }
+    },
+    {
+      "type": {
+        "label": ")",
+        "beforeExpr": false,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "start": 922,
+      "end": 923,
+      "loc": {
+        "start": {
+          "line": 40,
+          "column": 35
+        },
+        "end": {
+          "line": 40,
+          "column": 36
+        }
+      }
+    },
+    {
+      "type": {
+        "label": ";",
+        "beforeExpr": true,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null,
+        "updateContext": null
+      },
+      "start": 923,
+      "end": 924,
+      "loc": {
+        "start": {
+          "line": 40,
+          "column": 36
+        },
+        "end": {
+          "line": 40,
+          "column": 37
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "}",
+        "beforeExpr": false,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "start": 927,
+      "end": 928,
+      "loc": {
+        "start": {
+          "line": 41,
+          "column": 2
+        },
+        "end": {
+          "line": 41,
+          "column": 3
+        }
+      }
+    },
+    {
+      "type": {
+        "label": ")",
+        "beforeExpr": false,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "start": 928,
+      "end": 929,
+      "loc": {
+        "start": {
+          "line": 41,
+          "column": 3
+        },
+        "end": {
+          "line": 41,
+          "column": 4
+        }
+      }
+    },
+    {
+      "type": {
+        "label": ";",
+        "beforeExpr": true,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null,
+        "updateContext": null
+      },
+      "start": 929,
+      "end": 930,
+      "loc": {
+        "start": {
+          "line": 41,
+          "column": 4
+        },
+        "end": {
+          "line": 41,
+          "column": 5
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "}",
+        "beforeExpr": false,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "start": 931,
+      "end": 932,
+      "loc": {
+        "start": {
+          "line": 42,
+          "column": 0
+        },
+        "end": {
+          "line": 42,
+          "column": 1
+        }
+      }
+    },
+    {
+      "type": {
+        "label": ";",
+        "beforeExpr": true,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null,
+        "updateContext": null
+      },
+      "start": 932,
+      "end": 933,
+      "loc": {
+        "start": {
+          "line": 42,
+          "column": 1
+        },
+        "end": {
+          "line": 42,
+          "column": 2
+        }
+      }
+    },
+    {
+      "type": "CommentBlock",
+      "value": "*\n * Get a list of all Obsolete-FZP files. for old sketches only!\n *\n * @param  {String} url - The base URL of the parts api\n * @return {Promise}\n ",
+      "start": 935,
+      "end": 1086,
+      "loc": {
+        "start": {
+          "line": 44,
+          "column": 0
+        },
+        "end": {
+          "line": 49,
+          "column": 3
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "const",
+        "keyword": "const",
+        "beforeExpr": false,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null,
+        "updateContext": null
+      },
+      "value": "const",
+      "start": 1087,
+      "end": 1092,
+      "loc": {
+        "start": {
+          "line": 50,
+          "column": 0
+        },
+        "end": {
+          "line": 50,
+          "column": 5
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "name",
+        "beforeExpr": false,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "value": "getFzpsObsolete",
+      "start": 1093,
+      "end": 1108,
+      "loc": {
+        "start": {
+          "line": 50,
+          "column": 6
+        },
+        "end": {
+          "line": 50,
+          "column": 21
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "=",
+        "beforeExpr": true,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": true,
+        "prefix": false,
+        "postfix": false,
+        "binop": null,
+        "updateContext": null
+      },
+      "value": "=",
+      "start": 1109,
+      "end": 1110,
+      "loc": {
+        "start": {
+          "line": 50,
+          "column": 22
+        },
+        "end": {
+          "line": 50,
+          "column": 23
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "function",
+        "keyword": "function",
+        "beforeExpr": false,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "value": "function",
+      "start": 1111,
+      "end": 1119,
+      "loc": {
+        "start": {
+          "line": 50,
+          "column": 24
+        },
+        "end": {
+          "line": 50,
+          "column": 32
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "(",
+        "beforeExpr": true,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "start": 1119,
+      "end": 1120,
+      "loc": {
+        "start": {
+          "line": 50,
+          "column": 32
+        },
+        "end": {
+          "line": 50,
+          "column": 33
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "name",
+        "beforeExpr": false,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "value": "url",
+      "start": 1120,
+      "end": 1123,
+      "loc": {
+        "start": {
+          "line": 50,
+          "column": 33
+        },
+        "end": {
+          "line": 50,
+          "column": 36
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "=",
+        "beforeExpr": true,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": true,
+        "prefix": false,
+        "postfix": false,
+        "binop": null,
+        "updateContext": null
+      },
+      "value": "=",
+      "start": 1124,
+      "end": 1125,
+      "loc": {
+        "start": {
+          "line": 50,
+          "column": 37
+        },
+        "end": {
+          "line": 50,
+          "column": 38
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "`",
+        "beforeExpr": false,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "start": 1126,
+      "end": 1127,
+      "loc": {
+        "start": {
+          "line": 50,
+          "column": 39
+        },
+        "end": {
+          "line": 50,
+          "column": 40
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "template",
+        "beforeExpr": false,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null,
+        "updateContext": null
+      },
+      "value": "",
+      "start": 1127,
+      "end": 1127,
+      "loc": {
+        "start": {
+          "line": 50,
+          "column": 40
+        },
+        "end": {
+          "line": 50,
+          "column": 40
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "${",
+        "beforeExpr": true,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "start": 1127,
+      "end": 1129,
+      "loc": {
+        "start": {
+          "line": 50,
+          "column": 40
+        },
+        "end": {
+          "line": 50,
+          "column": 42
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "name",
+        "beforeExpr": false,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "value": "FritzingPartsAPI",
+      "start": 1129,
+      "end": 1145,
+      "loc": {
+        "start": {
+          "line": 50,
+          "column": 42
+        },
+        "end": {
+          "line": 50,
+          "column": 58
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "}",
+        "beforeExpr": false,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "start": 1145,
+      "end": 1146,
+      "loc": {
+        "start": {
+          "line": 50,
+          "column": 58
+        },
+        "end": {
+          "line": 50,
+          "column": 59
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "template",
+        "beforeExpr": false,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null,
+        "updateContext": null
+      },
+      "value": "/fzp/obsolete",
+      "start": 1146,
+      "end": 1159,
+      "loc": {
+        "start": {
+          "line": 50,
+          "column": 59
+        },
+        "end": {
+          "line": 50,
+          "column": 72
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "`",
+        "beforeExpr": false,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "start": 1159,
+      "end": 1160,
+      "loc": {
+        "start": {
+          "line": 50,
+          "column": 72
+        },
+        "end": {
+          "line": 50,
+          "column": 73
+        }
+      }
+    },
+    {
+      "type": {
+        "label": ")",
+        "beforeExpr": false,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "start": 1160,
+      "end": 1161,
+      "loc": {
+        "start": {
+          "line": 50,
+          "column": 73
+        },
+        "end": {
+          "line": 50,
+          "column": 74
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "{",
+        "beforeExpr": true,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "start": 1162,
+      "end": 1163,
+      "loc": {
+        "start": {
+          "line": 50,
+          "column": 75
+        },
+        "end": {
+          "line": 50,
+          "column": 76
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "return",
+        "keyword": "return",
+        "beforeExpr": true,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null,
+        "updateContext": null
+      },
+      "value": "return",
+      "start": 1166,
+      "end": 1172,
+      "loc": {
+        "start": {
+          "line": 51,
+          "column": 2
+        },
+        "end": {
+          "line": 51,
+          "column": 8
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "name",
+        "beforeExpr": false,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "value": "axios",
+      "start": 1173,
+      "end": 1178,
+      "loc": {
+        "start": {
+          "line": 51,
+          "column": 9
+        },
+        "end": {
+          "line": 51,
+          "column": 14
+        }
+      }
+    },
+    {
+      "type": {
+        "label": ".",
+        "beforeExpr": false,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null,
+        "updateContext": null
+      },
+      "start": 1178,
+      "end": 1179,
+      "loc": {
+        "start": {
+          "line": 51,
+          "column": 14
+        },
+        "end": {
+          "line": 51,
+          "column": 15
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "name",
+        "beforeExpr": false,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "value": "get",
+      "start": 1179,
+      "end": 1182,
+      "loc": {
+        "start": {
+          "line": 51,
+          "column": 15
+        },
+        "end": {
+          "line": 51,
+          "column": 18
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "(",
+        "beforeExpr": true,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "start": 1182,
+      "end": 1183,
+      "loc": {
+        "start": {
+          "line": 51,
+          "column": 18
+        },
+        "end": {
+          "line": 51,
+          "column": 19
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "name",
+        "beforeExpr": false,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "value": "url",
+      "start": 1183,
+      "end": 1186,
+      "loc": {
+        "start": {
+          "line": 51,
+          "column": 19
+        },
+        "end": {
+          "line": 51,
+          "column": 22
+        }
+      }
+    },
+    {
+      "type": {
+        "label": ",",
+        "beforeExpr": true,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null,
+        "updateContext": null
+      },
+      "start": 1186,
+      "end": 1187,
+      "loc": {
+        "start": {
+          "line": 51,
+          "column": 22
+        },
+        "end": {
+          "line": 51,
+          "column": 23
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "{",
+        "beforeExpr": true,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "start": 1188,
+      "end": 1189,
+      "loc": {
+        "start": {
+          "line": 51,
+          "column": 24
+        },
+        "end": {
+          "line": 51,
+          "column": 25
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "name",
+        "beforeExpr": false,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "value": "responseType",
+      "start": 1189,
+      "end": 1201,
+      "loc": {
+        "start": {
+          "line": 51,
+          "column": 25
+        },
+        "end": {
+          "line": 51,
+          "column": 37
+        }
+      }
+    },
+    {
+      "type": {
+        "label": ":",
+        "beforeExpr": true,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null,
+        "updateContext": null
+      },
+      "start": 1201,
+      "end": 1202,
+      "loc": {
+        "start": {
+          "line": 51,
+          "column": 37
+        },
+        "end": {
+          "line": 51,
+          "column": 38
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "string",
+        "beforeExpr": false,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null,
+        "updateContext": null
+      },
+      "value": "json",
+      "start": 1203,
+      "end": 1209,
+      "loc": {
+        "start": {
+          "line": 51,
+          "column": 39
+        },
+        "end": {
+          "line": 51,
+          "column": 45
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "}",
+        "beforeExpr": false,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "start": 1209,
+      "end": 1210,
+      "loc": {
+        "start": {
+          "line": 51,
+          "column": 45
+        },
+        "end": {
+          "line": 51,
+          "column": 46
+        }
+      }
+    },
+    {
+      "type": {
+        "label": ")",
+        "beforeExpr": false,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "start": 1210,
+      "end": 1211,
+      "loc": {
+        "start": {
+          "line": 51,
+          "column": 46
+        },
+        "end": {
+          "line": 51,
+          "column": 47
+        }
+      }
+    },
+    {
+      "type": {
+        "label": ".",
+        "beforeExpr": false,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null,
+        "updateContext": null
+      },
+      "start": 1214,
+      "end": 1215,
+      "loc": {
+        "start": {
+          "line": 52,
+          "column": 2
+        },
+        "end": {
+          "line": 52,
+          "column": 3
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "name",
+        "beforeExpr": false,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "value": "then",
+      "start": 1215,
+      "end": 1219,
+      "loc": {
+        "start": {
+          "line": 52,
+          "column": 3
+        },
+        "end": {
+          "line": 52,
+          "column": 7
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "(",
+        "beforeExpr": true,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "start": 1219,
+      "end": 1220,
+      "loc": {
+        "start": {
+          "line": 52,
+          "column": 7
+        },
+        "end": {
+          "line": 52,
+          "column": 8
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "(",
+        "beforeExpr": true,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "start": 1220,
+      "end": 1221,
+      "loc": {
+        "start": {
+          "line": 52,
+          "column": 8
+        },
+        "end": {
+          "line": 52,
+          "column": 9
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "name",
+        "beforeExpr": false,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "value": "res",
+      "start": 1221,
+      "end": 1224,
+      "loc": {
+        "start": {
+          "line": 52,
+          "column": 9
+        },
+        "end": {
+          "line": 52,
+          "column": 12
+        }
+      }
+    },
+    {
+      "type": {
+        "label": ")",
+        "beforeExpr": false,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "start": 1224,
+      "end": 1225,
+      "loc": {
+        "start": {
+          "line": 52,
+          "column": 12
+        },
+        "end": {
+          "line": 52,
+          "column": 13
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "=>",
+        "beforeExpr": true,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null,
+        "updateContext": null
+      },
+      "start": 1226,
+      "end": 1228,
+      "loc": {
+        "start": {
+          "line": 52,
+          "column": 14
+        },
+        "end": {
+          "line": 52,
+          "column": 16
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "{",
+        "beforeExpr": true,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "start": 1229,
+      "end": 1230,
+      "loc": {
+        "start": {
+          "line": 52,
+          "column": 17
+        },
+        "end": {
+          "line": 52,
+          "column": 18
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "return",
+        "keyword": "return",
+        "beforeExpr": true,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null,
+        "updateContext": null
+      },
+      "value": "return",
+      "start": 1235,
+      "end": 1241,
+      "loc": {
+        "start": {
+          "line": 53,
+          "column": 4
+        },
+        "end": {
+          "line": 53,
+          "column": 10
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "name",
+        "beforeExpr": false,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "value": "Promise",
+      "start": 1242,
+      "end": 1249,
+      "loc": {
+        "start": {
+          "line": 53,
+          "column": 11
+        },
+        "end": {
+          "line": 53,
+          "column": 18
+        }
+      }
+    },
+    {
+      "type": {
+        "label": ".",
+        "beforeExpr": false,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null,
+        "updateContext": null
+      },
+      "start": 1249,
+      "end": 1250,
+      "loc": {
+        "start": {
+          "line": 53,
+          "column": 18
+        },
+        "end": {
+          "line": 53,
+          "column": 19
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "name",
+        "beforeExpr": false,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "value": "resolve",
+      "start": 1250,
+      "end": 1257,
+      "loc": {
+        "start": {
+          "line": 53,
+          "column": 19
+        },
+        "end": {
+          "line": 53,
+          "column": 26
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "(",
+        "beforeExpr": true,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "start": 1257,
+      "end": 1258,
+      "loc": {
+        "start": {
+          "line": 53,
+          "column": 26
+        },
+        "end": {
+          "line": 53,
+          "column": 27
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "name",
+        "beforeExpr": false,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "value": "res",
+      "start": 1258,
+      "end": 1261,
+      "loc": {
+        "start": {
+          "line": 53,
+          "column": 27
+        },
+        "end": {
+          "line": 53,
+          "column": 30
+        }
+      }
+    },
+    {
+      "type": {
+        "label": ".",
+        "beforeExpr": false,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null,
+        "updateContext": null
+      },
+      "start": 1261,
+      "end": 1262,
+      "loc": {
+        "start": {
+          "line": 53,
+          "column": 30
+        },
+        "end": {
+          "line": 53,
+          "column": 31
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "name",
+        "beforeExpr": false,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "value": "data",
+      "start": 1262,
+      "end": 1266,
+      "loc": {
+        "start": {
+          "line": 53,
+          "column": 31
+        },
+        "end": {
+          "line": 53,
+          "column": 35
+        }
+      }
+    },
+    {
+      "type": {
+        "label": ")",
+        "beforeExpr": false,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "start": 1266,
+      "end": 1267,
+      "loc": {
+        "start": {
+          "line": 53,
+          "column": 35
+        },
+        "end": {
+          "line": 53,
+          "column": 36
+        }
+      }
+    },
+    {
+      "type": {
+        "label": ";",
+        "beforeExpr": true,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null,
+        "updateContext": null
+      },
+      "start": 1267,
+      "end": 1268,
+      "loc": {
+        "start": {
+          "line": 53,
+          "column": 36
+        },
+        "end": {
+          "line": 53,
+          "column": 37
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "}",
+        "beforeExpr": false,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "start": 1271,
+      "end": 1272,
+      "loc": {
+        "start": {
+          "line": 54,
+          "column": 2
+        },
+        "end": {
+          "line": 54,
+          "column": 3
+        }
+      }
+    },
+    {
+      "type": {
+        "label": ")",
+        "beforeExpr": false,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "start": 1272,
+      "end": 1273,
+      "loc": {
+        "start": {
+          "line": 54,
+          "column": 3
+        },
+        "end": {
+          "line": 54,
+          "column": 4
+        }
+      }
+    },
+    {
+      "type": {
+        "label": ";",
+        "beforeExpr": true,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null,
+        "updateContext": null
+      },
+      "start": 1273,
+      "end": 1274,
+      "loc": {
+        "start": {
+          "line": 54,
+          "column": 4
+        },
+        "end": {
+          "line": 54,
+          "column": 5
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "}",
+        "beforeExpr": false,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "start": 1275,
+      "end": 1276,
+      "loc": {
+        "start": {
+          "line": 55,
+          "column": 0
+        },
+        "end": {
+          "line": 55,
+          "column": 1
+        }
+      }
+    },
+    {
+      "type": {
+        "label": ";",
+        "beforeExpr": true,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null,
+        "updateContext": null
+      },
+      "start": 1276,
+      "end": 1277,
+      "loc": {
+        "start": {
+          "line": 55,
+          "column": 1
+        },
+        "end": {
+          "line": 55,
+          "column": 2
+        }
+      }
+    },
+    {
+      "type": "CommentBlock",
+      "value": "*\n * Get a single FZP and response the xml as a string\n *\n * @param  {String} src\n * @param  {String} url - The base URL of the parts api\n * @return {Promise} the fetch promise\n ",
+      "start": 1279,
+      "end": 1461,
+      "loc": {
+        "start": {
+          "line": 57,
+          "column": 0
+        },
+        "end": {
+          "line": 63,
+          "column": 3
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "const",
+        "keyword": "const",
+        "beforeExpr": false,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null,
+        "updateContext": null
+      },
+      "value": "const",
+      "start": 1462,
+      "end": 1467,
+      "loc": {
+        "start": {
+          "line": 64,
+          "column": 0
+        },
+        "end": {
+          "line": 64,
+          "column": 5
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "name",
+        "beforeExpr": false,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "value": "getFzp",
+      "start": 1468,
+      "end": 1474,
+      "loc": {
+        "start": {
+          "line": 64,
+          "column": 6
+        },
+        "end": {
+          "line": 64,
           "column": 12
         }
       }
@@ -6652,22 +12848,23 @@
         "updateContext": null
       },
       "value": "=",
-      "start": 175,
-      "end": 176,
+      "start": 1475,
+      "end": 1476,
       "loc": {
         "start": {
-          "line": 13,
+          "line": 64,
           "column": 13
         },
         "end": {
-          "line": 13,
+          "line": 64,
           "column": 14
         }
       }
     },
     {
       "type": {
-        "label": "string",
+        "label": "function",
+        "keyword": "function",
         "beforeExpr": false,
         "startsExpr": true,
         "rightAssociative": false,
@@ -6675,113 +12872,19 @@
         "isAssign": false,
         "prefix": false,
         "postfix": false,
-        "binop": null,
-        "updateContext": null
+        "binop": null
       },
-      "value": "https://fritzing.github.io/fritzing-parts",
-      "start": 177,
-      "end": 220,
+      "value": "function",
+      "start": 1477,
+      "end": 1485,
       "loc": {
         "start": {
-          "line": 13,
+          "line": 64,
           "column": 15
         },
         "end": {
-          "line": 13,
-          "column": 58
-        }
-      }
-    },
-    {
-      "type": {
-        "label": ";",
-        "beforeExpr": true,
-        "startsExpr": false,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null,
-        "updateContext": null
-      },
-      "start": 220,
-      "end": 221,
-      "loc": {
-        "start": {
-          "line": 13,
-          "column": 58
-        },
-        "end": {
-          "line": 13,
-          "column": 59
-        }
-      }
-    },
-    {
-      "type": {
-        "label": "}",
-        "beforeExpr": false,
-        "startsExpr": false,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null
-      },
-      "start": 224,
-      "end": 225,
-      "loc": {
-        "start": {
-          "line": 14,
-          "column": 2
-        },
-        "end": {
-          "line": 14,
-          "column": 3
-        }
-      }
-    },
-    {
-      "type": "CommentBlock",
-      "value": "*\n   * Get a list of all FZP files\n   * @return {Promise}\n   ",
-      "start": 229,
-      "end": 294,
-      "loc": {
-        "start": {
-          "line": 16,
-          "column": 2
-        },
-        "end": {
-          "line": 19,
-          "column": 5
-        }
-      }
-    },
-    {
-      "type": {
-        "label": "name",
-        "beforeExpr": false,
-        "startsExpr": true,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null
-      },
-      "value": "getFzps",
-      "start": 297,
-      "end": 304,
-      "loc": {
-        "start": {
-          "line": 20,
-          "column": 2
-        },
-        "end": {
-          "line": 20,
-          "column": 9
+          "line": 64,
+          "column": 23
         }
       }
     },
@@ -6797,3013 +12900,16 @@
         "postfix": false,
         "binop": null
       },
-      "start": 304,
-      "end": 305,
+      "start": 1485,
+      "end": 1486,
       "loc": {
         "start": {
-          "line": 20,
-          "column": 9
+          "line": 64,
+          "column": 23
         },
         "end": {
-          "line": 20,
-          "column": 10
-        }
-      }
-    },
-    {
-      "type": {
-        "label": ")",
-        "beforeExpr": false,
-        "startsExpr": false,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null
-      },
-      "start": 305,
-      "end": 306,
-      "loc": {
-        "start": {
-          "line": 20,
-          "column": 10
-        },
-        "end": {
-          "line": 20,
-          "column": 11
-        }
-      }
-    },
-    {
-      "type": {
-        "label": "{",
-        "beforeExpr": true,
-        "startsExpr": true,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null
-      },
-      "start": 307,
-      "end": 308,
-      "loc": {
-        "start": {
-          "line": 20,
-          "column": 12
-        },
-        "end": {
-          "line": 20,
-          "column": 13
-        }
-      }
-    },
-    {
-      "type": {
-        "label": "return",
-        "keyword": "return",
-        "beforeExpr": true,
-        "startsExpr": false,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null,
-        "updateContext": null
-      },
-      "value": "return",
-      "start": 313,
-      "end": 319,
-      "loc": {
-        "start": {
-          "line": 21,
-          "column": 4
-        },
-        "end": {
-          "line": 21,
-          "column": 10
-        }
-      }
-    },
-    {
-      "type": {
-        "label": "name",
-        "beforeExpr": false,
-        "startsExpr": true,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null
-      },
-      "value": "axios",
-      "start": 320,
-      "end": 325,
-      "loc": {
-        "start": {
-          "line": 21,
-          "column": 11
-        },
-        "end": {
-          "line": 21,
-          "column": 16
-        }
-      }
-    },
-    {
-      "type": {
-        "label": ".",
-        "beforeExpr": false,
-        "startsExpr": false,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null,
-        "updateContext": null
-      },
-      "start": 325,
-      "end": 326,
-      "loc": {
-        "start": {
-          "line": 21,
-          "column": 16
-        },
-        "end": {
-          "line": 21,
-          "column": 17
-        }
-      }
-    },
-    {
-      "type": {
-        "label": "name",
-        "beforeExpr": false,
-        "startsExpr": true,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null
-      },
-      "value": "get",
-      "start": 326,
-      "end": 329,
-      "loc": {
-        "start": {
-          "line": 21,
-          "column": 17
-        },
-        "end": {
-          "line": 21,
-          "column": 20
-        }
-      }
-    },
-    {
-      "type": {
-        "label": "(",
-        "beforeExpr": true,
-        "startsExpr": true,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null
-      },
-      "start": 329,
-      "end": 330,
-      "loc": {
-        "start": {
-          "line": 21,
-          "column": 20
-        },
-        "end": {
-          "line": 21,
-          "column": 21
-        }
-      }
-    },
-    {
-      "type": {
-        "label": "this",
-        "keyword": "this",
-        "beforeExpr": false,
-        "startsExpr": true,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null,
-        "updateContext": null
-      },
-      "value": "this",
-      "start": 330,
-      "end": 334,
-      "loc": {
-        "start": {
-          "line": 21,
-          "column": 21
-        },
-        "end": {
-          "line": 21,
-          "column": 25
-        }
-      }
-    },
-    {
-      "type": {
-        "label": ".",
-        "beforeExpr": false,
-        "startsExpr": false,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null,
-        "updateContext": null
-      },
-      "start": 334,
-      "end": 335,
-      "loc": {
-        "start": {
-          "line": 21,
-          "column": 25
-        },
-        "end": {
-          "line": 21,
-          "column": 26
-        }
-      }
-    },
-    {
-      "type": {
-        "label": "name",
-        "beforeExpr": false,
-        "startsExpr": true,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null
-      },
-      "value": "url",
-      "start": 335,
-      "end": 338,
-      "loc": {
-        "start": {
-          "line": 21,
-          "column": 26
-        },
-        "end": {
-          "line": 21,
-          "column": 29
-        }
-      }
-    },
-    {
-      "type": {
-        "label": "+/-",
-        "beforeExpr": true,
-        "startsExpr": true,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": true,
-        "postfix": false,
-        "binop": 9,
-        "updateContext": null
-      },
-      "value": "+",
-      "start": 338,
-      "end": 339,
-      "loc": {
-        "start": {
-          "line": 21,
-          "column": 29
-        },
-        "end": {
-          "line": 21,
-          "column": 30
-        }
-      }
-    },
-    {
-      "type": {
-        "label": "string",
-        "beforeExpr": false,
-        "startsExpr": true,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null,
-        "updateContext": null
-      },
-      "value": "/fzp",
-      "start": 339,
-      "end": 345,
-      "loc": {
-        "start": {
-          "line": 21,
-          "column": 30
-        },
-        "end": {
-          "line": 21,
-          "column": 36
-        }
-      }
-    },
-    {
-      "type": {
-        "label": ",",
-        "beforeExpr": true,
-        "startsExpr": false,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null,
-        "updateContext": null
-      },
-      "start": 345,
-      "end": 346,
-      "loc": {
-        "start": {
-          "line": 21,
-          "column": 36
-        },
-        "end": {
-          "line": 21,
-          "column": 37
-        }
-      }
-    },
-    {
-      "type": {
-        "label": "{",
-        "beforeExpr": true,
-        "startsExpr": true,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null
-      },
-      "start": 347,
-      "end": 348,
-      "loc": {
-        "start": {
-          "line": 21,
-          "column": 38
-        },
-        "end": {
-          "line": 21,
-          "column": 39
-        }
-      }
-    },
-    {
-      "type": {
-        "label": "name",
-        "beforeExpr": false,
-        "startsExpr": true,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null
-      },
-      "value": "responseType",
-      "start": 348,
-      "end": 360,
-      "loc": {
-        "start": {
-          "line": 21,
-          "column": 39
-        },
-        "end": {
-          "line": 21,
-          "column": 51
-        }
-      }
-    },
-    {
-      "type": {
-        "label": ":",
-        "beforeExpr": true,
-        "startsExpr": false,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null,
-        "updateContext": null
-      },
-      "start": 360,
-      "end": 361,
-      "loc": {
-        "start": {
-          "line": 21,
-          "column": 51
-        },
-        "end": {
-          "line": 21,
-          "column": 52
-        }
-      }
-    },
-    {
-      "type": {
-        "label": "string",
-        "beforeExpr": false,
-        "startsExpr": true,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null,
-        "updateContext": null
-      },
-      "value": "json",
-      "start": 362,
-      "end": 368,
-      "loc": {
-        "start": {
-          "line": 21,
-          "column": 53
-        },
-        "end": {
-          "line": 21,
-          "column": 59
-        }
-      }
-    },
-    {
-      "type": {
-        "label": "}",
-        "beforeExpr": false,
-        "startsExpr": false,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null
-      },
-      "start": 368,
-      "end": 369,
-      "loc": {
-        "start": {
-          "line": 21,
-          "column": 59
-        },
-        "end": {
-          "line": 21,
-          "column": 60
-        }
-      }
-    },
-    {
-      "type": {
-        "label": ")",
-        "beforeExpr": false,
-        "startsExpr": false,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null
-      },
-      "start": 369,
-      "end": 370,
-      "loc": {
-        "start": {
-          "line": 21,
-          "column": 60
-        },
-        "end": {
-          "line": 21,
-          "column": 61
-        }
-      }
-    },
-    {
-      "type": {
-        "label": ".",
-        "beforeExpr": false,
-        "startsExpr": false,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null,
-        "updateContext": null
-      },
-      "start": 375,
-      "end": 376,
-      "loc": {
-        "start": {
-          "line": 22,
-          "column": 4
-        },
-        "end": {
-          "line": 22,
-          "column": 5
-        }
-      }
-    },
-    {
-      "type": {
-        "label": "name",
-        "beforeExpr": false,
-        "startsExpr": true,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null
-      },
-      "value": "then",
-      "start": 376,
-      "end": 380,
-      "loc": {
-        "start": {
-          "line": 22,
-          "column": 5
-        },
-        "end": {
-          "line": 22,
-          "column": 9
-        }
-      }
-    },
-    {
-      "type": {
-        "label": "(",
-        "beforeExpr": true,
-        "startsExpr": true,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null
-      },
-      "start": 380,
-      "end": 381,
-      "loc": {
-        "start": {
-          "line": 22,
-          "column": 9
-        },
-        "end": {
-          "line": 22,
-          "column": 10
-        }
-      }
-    },
-    {
-      "type": {
-        "label": "(",
-        "beforeExpr": true,
-        "startsExpr": true,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null
-      },
-      "start": 381,
-      "end": 382,
-      "loc": {
-        "start": {
-          "line": 22,
-          "column": 10
-        },
-        "end": {
-          "line": 22,
-          "column": 11
-        }
-      }
-    },
-    {
-      "type": {
-        "label": "name",
-        "beforeExpr": false,
-        "startsExpr": true,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null
-      },
-      "value": "res",
-      "start": 382,
-      "end": 385,
-      "loc": {
-        "start": {
-          "line": 22,
-          "column": 11
-        },
-        "end": {
-          "line": 22,
-          "column": 14
-        }
-      }
-    },
-    {
-      "type": {
-        "label": ")",
-        "beforeExpr": false,
-        "startsExpr": false,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null
-      },
-      "start": 385,
-      "end": 386,
-      "loc": {
-        "start": {
-          "line": 22,
-          "column": 14
-        },
-        "end": {
-          "line": 22,
-          "column": 15
-        }
-      }
-    },
-    {
-      "type": {
-        "label": "=>",
-        "beforeExpr": true,
-        "startsExpr": false,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null,
-        "updateContext": null
-      },
-      "start": 387,
-      "end": 389,
-      "loc": {
-        "start": {
-          "line": 22,
-          "column": 16
-        },
-        "end": {
-          "line": 22,
-          "column": 18
-        }
-      }
-    },
-    {
-      "type": {
-        "label": "{",
-        "beforeExpr": true,
-        "startsExpr": true,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null
-      },
-      "start": 390,
-      "end": 391,
-      "loc": {
-        "start": {
-          "line": 22,
-          "column": 19
-        },
-        "end": {
-          "line": 22,
-          "column": 20
-        }
-      }
-    },
-    {
-      "type": {
-        "label": "return",
-        "keyword": "return",
-        "beforeExpr": true,
-        "startsExpr": false,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null,
-        "updateContext": null
-      },
-      "value": "return",
-      "start": 398,
-      "end": 404,
-      "loc": {
-        "start": {
-          "line": 23,
-          "column": 6
-        },
-        "end": {
-          "line": 23,
-          "column": 12
-        }
-      }
-    },
-    {
-      "type": {
-        "label": "name",
-        "beforeExpr": false,
-        "startsExpr": true,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null
-      },
-      "value": "res",
-      "start": 405,
-      "end": 408,
-      "loc": {
-        "start": {
-          "line": 23,
-          "column": 13
-        },
-        "end": {
-          "line": 23,
-          "column": 16
-        }
-      }
-    },
-    {
-      "type": {
-        "label": ".",
-        "beforeExpr": false,
-        "startsExpr": false,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null,
-        "updateContext": null
-      },
-      "start": 408,
-      "end": 409,
-      "loc": {
-        "start": {
-          "line": 23,
-          "column": 16
-        },
-        "end": {
-          "line": 23,
-          "column": 17
-        }
-      }
-    },
-    {
-      "type": {
-        "label": "name",
-        "beforeExpr": false,
-        "startsExpr": true,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null
-      },
-      "value": "data",
-      "start": 409,
-      "end": 413,
-      "loc": {
-        "start": {
-          "line": 23,
-          "column": 17
-        },
-        "end": {
-          "line": 23,
-          "column": 21
-        }
-      }
-    },
-    {
-      "type": {
-        "label": ";",
-        "beforeExpr": true,
-        "startsExpr": false,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null,
-        "updateContext": null
-      },
-      "start": 413,
-      "end": 414,
-      "loc": {
-        "start": {
-          "line": 23,
-          "column": 21
-        },
-        "end": {
-          "line": 23,
-          "column": 22
-        }
-      }
-    },
-    {
-      "type": {
-        "label": "}",
-        "beforeExpr": false,
-        "startsExpr": false,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null
-      },
-      "start": 419,
-      "end": 420,
-      "loc": {
-        "start": {
-          "line": 24,
-          "column": 4
-        },
-        "end": {
-          "line": 24,
-          "column": 5
-        }
-      }
-    },
-    {
-      "type": {
-        "label": ")",
-        "beforeExpr": false,
-        "startsExpr": false,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null
-      },
-      "start": 420,
-      "end": 421,
-      "loc": {
-        "start": {
-          "line": 24,
-          "column": 5
-        },
-        "end": {
-          "line": 24,
-          "column": 6
-        }
-      }
-    },
-    {
-      "type": {
-        "label": ";",
-        "beforeExpr": true,
-        "startsExpr": false,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null,
-        "updateContext": null
-      },
-      "start": 421,
-      "end": 422,
-      "loc": {
-        "start": {
-          "line": 24,
-          "column": 6
-        },
-        "end": {
-          "line": 24,
-          "column": 7
-        }
-      }
-    },
-    {
-      "type": {
-        "label": "}",
-        "beforeExpr": false,
-        "startsExpr": false,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null
-      },
-      "start": 425,
-      "end": 426,
-      "loc": {
-        "start": {
-          "line": 25,
-          "column": 2
-        },
-        "end": {
-          "line": 25,
-          "column": 3
-        }
-      }
-    },
-    {
-      "type": "CommentBlock",
-      "value": "*\n   * Get a list of all Core-FZP files\n   * @return {Promise}\n   ",
-      "start": 429,
-      "end": 499,
-      "loc": {
-        "start": {
-          "line": 26,
-          "column": 2
-        },
-        "end": {
-          "line": 29,
-          "column": 5
-        }
-      }
-    },
-    {
-      "type": {
-        "label": "name",
-        "beforeExpr": false,
-        "startsExpr": true,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null
-      },
-      "value": "getFzpsCore",
-      "start": 502,
-      "end": 513,
-      "loc": {
-        "start": {
-          "line": 30,
-          "column": 2
-        },
-        "end": {
-          "line": 30,
-          "column": 13
-        }
-      }
-    },
-    {
-      "type": {
-        "label": "(",
-        "beforeExpr": true,
-        "startsExpr": true,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null
-      },
-      "start": 513,
-      "end": 514,
-      "loc": {
-        "start": {
-          "line": 30,
-          "column": 13
-        },
-        "end": {
-          "line": 30,
-          "column": 14
-        }
-      }
-    },
-    {
-      "type": {
-        "label": ")",
-        "beforeExpr": false,
-        "startsExpr": false,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null
-      },
-      "start": 514,
-      "end": 515,
-      "loc": {
-        "start": {
-          "line": 30,
-          "column": 14
-        },
-        "end": {
-          "line": 30,
-          "column": 15
-        }
-      }
-    },
-    {
-      "type": {
-        "label": "{",
-        "beforeExpr": true,
-        "startsExpr": true,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null
-      },
-      "start": 516,
-      "end": 517,
-      "loc": {
-        "start": {
-          "line": 30,
-          "column": 16
-        },
-        "end": {
-          "line": 30,
-          "column": 17
-        }
-      }
-    },
-    {
-      "type": {
-        "label": "return",
-        "keyword": "return",
-        "beforeExpr": true,
-        "startsExpr": false,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null,
-        "updateContext": null
-      },
-      "value": "return",
-      "start": 522,
-      "end": 528,
-      "loc": {
-        "start": {
-          "line": 31,
-          "column": 4
-        },
-        "end": {
-          "line": 31,
-          "column": 10
-        }
-      }
-    },
-    {
-      "type": {
-        "label": "name",
-        "beforeExpr": false,
-        "startsExpr": true,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null
-      },
-      "value": "axios",
-      "start": 529,
-      "end": 534,
-      "loc": {
-        "start": {
-          "line": 31,
-          "column": 11
-        },
-        "end": {
-          "line": 31,
-          "column": 16
-        }
-      }
-    },
-    {
-      "type": {
-        "label": ".",
-        "beforeExpr": false,
-        "startsExpr": false,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null,
-        "updateContext": null
-      },
-      "start": 534,
-      "end": 535,
-      "loc": {
-        "start": {
-          "line": 31,
-          "column": 16
-        },
-        "end": {
-          "line": 31,
-          "column": 17
-        }
-      }
-    },
-    {
-      "type": {
-        "label": "name",
-        "beforeExpr": false,
-        "startsExpr": true,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null
-      },
-      "value": "get",
-      "start": 535,
-      "end": 538,
-      "loc": {
-        "start": {
-          "line": 31,
-          "column": 17
-        },
-        "end": {
-          "line": 31,
-          "column": 20
-        }
-      }
-    },
-    {
-      "type": {
-        "label": "(",
-        "beforeExpr": true,
-        "startsExpr": true,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null
-      },
-      "start": 538,
-      "end": 539,
-      "loc": {
-        "start": {
-          "line": 31,
-          "column": 20
-        },
-        "end": {
-          "line": 31,
-          "column": 21
-        }
-      }
-    },
-    {
-      "type": {
-        "label": "this",
-        "keyword": "this",
-        "beforeExpr": false,
-        "startsExpr": true,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null,
-        "updateContext": null
-      },
-      "value": "this",
-      "start": 539,
-      "end": 543,
-      "loc": {
-        "start": {
-          "line": 31,
-          "column": 21
-        },
-        "end": {
-          "line": 31,
-          "column": 25
-        }
-      }
-    },
-    {
-      "type": {
-        "label": ".",
-        "beforeExpr": false,
-        "startsExpr": false,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null,
-        "updateContext": null
-      },
-      "start": 543,
-      "end": 544,
-      "loc": {
-        "start": {
-          "line": 31,
-          "column": 25
-        },
-        "end": {
-          "line": 31,
-          "column": 26
-        }
-      }
-    },
-    {
-      "type": {
-        "label": "name",
-        "beforeExpr": false,
-        "startsExpr": true,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null
-      },
-      "value": "url",
-      "start": 544,
-      "end": 547,
-      "loc": {
-        "start": {
-          "line": 31,
-          "column": 26
-        },
-        "end": {
-          "line": 31,
-          "column": 29
-        }
-      }
-    },
-    {
-      "type": {
-        "label": "+/-",
-        "beforeExpr": true,
-        "startsExpr": true,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": true,
-        "postfix": false,
-        "binop": 9,
-        "updateContext": null
-      },
-      "value": "+",
-      "start": 547,
-      "end": 548,
-      "loc": {
-        "start": {
-          "line": 31,
-          "column": 29
-        },
-        "end": {
-          "line": 31,
-          "column": 30
-        }
-      }
-    },
-    {
-      "type": {
-        "label": "string",
-        "beforeExpr": false,
-        "startsExpr": true,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null,
-        "updateContext": null
-      },
-      "value": "/fzp/core",
-      "start": 548,
-      "end": 559,
-      "loc": {
-        "start": {
-          "line": 31,
-          "column": 30
-        },
-        "end": {
-          "line": 31,
-          "column": 41
-        }
-      }
-    },
-    {
-      "type": {
-        "label": ",",
-        "beforeExpr": true,
-        "startsExpr": false,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null,
-        "updateContext": null
-      },
-      "start": 559,
-      "end": 560,
-      "loc": {
-        "start": {
-          "line": 31,
-          "column": 41
-        },
-        "end": {
-          "line": 31,
-          "column": 42
-        }
-      }
-    },
-    {
-      "type": {
-        "label": "{",
-        "beforeExpr": true,
-        "startsExpr": true,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null
-      },
-      "start": 561,
-      "end": 562,
-      "loc": {
-        "start": {
-          "line": 31,
-          "column": 43
-        },
-        "end": {
-          "line": 31,
-          "column": 44
-        }
-      }
-    },
-    {
-      "type": {
-        "label": "name",
-        "beforeExpr": false,
-        "startsExpr": true,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null
-      },
-      "value": "responseType",
-      "start": 562,
-      "end": 574,
-      "loc": {
-        "start": {
-          "line": 31,
-          "column": 44
-        },
-        "end": {
-          "line": 31,
-          "column": 56
-        }
-      }
-    },
-    {
-      "type": {
-        "label": ":",
-        "beforeExpr": true,
-        "startsExpr": false,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null,
-        "updateContext": null
-      },
-      "start": 574,
-      "end": 575,
-      "loc": {
-        "start": {
-          "line": 31,
-          "column": 56
-        },
-        "end": {
-          "line": 31,
-          "column": 57
-        }
-      }
-    },
-    {
-      "type": {
-        "label": "string",
-        "beforeExpr": false,
-        "startsExpr": true,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null,
-        "updateContext": null
-      },
-      "value": "json",
-      "start": 576,
-      "end": 582,
-      "loc": {
-        "start": {
-          "line": 31,
-          "column": 58
-        },
-        "end": {
-          "line": 31,
-          "column": 64
-        }
-      }
-    },
-    {
-      "type": {
-        "label": "}",
-        "beforeExpr": false,
-        "startsExpr": false,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null
-      },
-      "start": 582,
-      "end": 583,
-      "loc": {
-        "start": {
-          "line": 31,
-          "column": 64
-        },
-        "end": {
-          "line": 31,
-          "column": 65
-        }
-      }
-    },
-    {
-      "type": {
-        "label": ")",
-        "beforeExpr": false,
-        "startsExpr": false,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null
-      },
-      "start": 583,
-      "end": 584,
-      "loc": {
-        "start": {
-          "line": 31,
-          "column": 65
-        },
-        "end": {
-          "line": 31,
-          "column": 66
-        }
-      }
-    },
-    {
-      "type": {
-        "label": ".",
-        "beforeExpr": false,
-        "startsExpr": false,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null,
-        "updateContext": null
-      },
-      "start": 589,
-      "end": 590,
-      "loc": {
-        "start": {
-          "line": 32,
-          "column": 4
-        },
-        "end": {
-          "line": 32,
-          "column": 5
-        }
-      }
-    },
-    {
-      "type": {
-        "label": "name",
-        "beforeExpr": false,
-        "startsExpr": true,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null
-      },
-      "value": "then",
-      "start": 590,
-      "end": 594,
-      "loc": {
-        "start": {
-          "line": 32,
-          "column": 5
-        },
-        "end": {
-          "line": 32,
-          "column": 9
-        }
-      }
-    },
-    {
-      "type": {
-        "label": "(",
-        "beforeExpr": true,
-        "startsExpr": true,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null
-      },
-      "start": 594,
-      "end": 595,
-      "loc": {
-        "start": {
-          "line": 32,
-          "column": 9
-        },
-        "end": {
-          "line": 32,
-          "column": 10
-        }
-      }
-    },
-    {
-      "type": {
-        "label": "(",
-        "beforeExpr": true,
-        "startsExpr": true,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null
-      },
-      "start": 595,
-      "end": 596,
-      "loc": {
-        "start": {
-          "line": 32,
-          "column": 10
-        },
-        "end": {
-          "line": 32,
-          "column": 11
-        }
-      }
-    },
-    {
-      "type": {
-        "label": "name",
-        "beforeExpr": false,
-        "startsExpr": true,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null
-      },
-      "value": "res",
-      "start": 596,
-      "end": 599,
-      "loc": {
-        "start": {
-          "line": 32,
-          "column": 11
-        },
-        "end": {
-          "line": 32,
-          "column": 14
-        }
-      }
-    },
-    {
-      "type": {
-        "label": ")",
-        "beforeExpr": false,
-        "startsExpr": false,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null
-      },
-      "start": 599,
-      "end": 600,
-      "loc": {
-        "start": {
-          "line": 32,
-          "column": 14
-        },
-        "end": {
-          "line": 32,
-          "column": 15
-        }
-      }
-    },
-    {
-      "type": {
-        "label": "=>",
-        "beforeExpr": true,
-        "startsExpr": false,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null,
-        "updateContext": null
-      },
-      "start": 601,
-      "end": 603,
-      "loc": {
-        "start": {
-          "line": 32,
-          "column": 16
-        },
-        "end": {
-          "line": 32,
-          "column": 18
-        }
-      }
-    },
-    {
-      "type": {
-        "label": "{",
-        "beforeExpr": true,
-        "startsExpr": true,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null
-      },
-      "start": 604,
-      "end": 605,
-      "loc": {
-        "start": {
-          "line": 32,
-          "column": 19
-        },
-        "end": {
-          "line": 32,
-          "column": 20
-        }
-      }
-    },
-    {
-      "type": {
-        "label": "return",
-        "keyword": "return",
-        "beforeExpr": true,
-        "startsExpr": false,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null,
-        "updateContext": null
-      },
-      "value": "return",
-      "start": 612,
-      "end": 618,
-      "loc": {
-        "start": {
-          "line": 33,
-          "column": 6
-        },
-        "end": {
-          "line": 33,
-          "column": 12
-        }
-      }
-    },
-    {
-      "type": {
-        "label": "name",
-        "beforeExpr": false,
-        "startsExpr": true,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null
-      },
-      "value": "res",
-      "start": 619,
-      "end": 622,
-      "loc": {
-        "start": {
-          "line": 33,
-          "column": 13
-        },
-        "end": {
-          "line": 33,
-          "column": 16
-        }
-      }
-    },
-    {
-      "type": {
-        "label": ".",
-        "beforeExpr": false,
-        "startsExpr": false,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null,
-        "updateContext": null
-      },
-      "start": 622,
-      "end": 623,
-      "loc": {
-        "start": {
-          "line": 33,
-          "column": 16
-        },
-        "end": {
-          "line": 33,
-          "column": 17
-        }
-      }
-    },
-    {
-      "type": {
-        "label": "name",
-        "beforeExpr": false,
-        "startsExpr": true,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null
-      },
-      "value": "data",
-      "start": 623,
-      "end": 627,
-      "loc": {
-        "start": {
-          "line": 33,
-          "column": 17
-        },
-        "end": {
-          "line": 33,
-          "column": 21
-        }
-      }
-    },
-    {
-      "type": {
-        "label": ";",
-        "beforeExpr": true,
-        "startsExpr": false,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null,
-        "updateContext": null
-      },
-      "start": 627,
-      "end": 628,
-      "loc": {
-        "start": {
-          "line": 33,
-          "column": 21
-        },
-        "end": {
-          "line": 33,
-          "column": 22
-        }
-      }
-    },
-    {
-      "type": {
-        "label": "}",
-        "beforeExpr": false,
-        "startsExpr": false,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null
-      },
-      "start": 633,
-      "end": 634,
-      "loc": {
-        "start": {
-          "line": 34,
-          "column": 4
-        },
-        "end": {
-          "line": 34,
-          "column": 5
-        }
-      }
-    },
-    {
-      "type": {
-        "label": ")",
-        "beforeExpr": false,
-        "startsExpr": false,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null
-      },
-      "start": 634,
-      "end": 635,
-      "loc": {
-        "start": {
-          "line": 34,
-          "column": 5
-        },
-        "end": {
-          "line": 34,
-          "column": 6
-        }
-      }
-    },
-    {
-      "type": {
-        "label": ";",
-        "beforeExpr": true,
-        "startsExpr": false,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null,
-        "updateContext": null
-      },
-      "start": 635,
-      "end": 636,
-      "loc": {
-        "start": {
-          "line": 34,
-          "column": 6
-        },
-        "end": {
-          "line": 34,
-          "column": 7
-        }
-      }
-    },
-    {
-      "type": {
-        "label": "}",
-        "beforeExpr": false,
-        "startsExpr": false,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null
-      },
-      "start": 639,
-      "end": 640,
-      "loc": {
-        "start": {
-          "line": 35,
-          "column": 2
-        },
-        "end": {
-          "line": 35,
-          "column": 3
-        }
-      }
-    },
-    {
-      "type": "CommentBlock",
-      "value": "*\n   * Get a list of all Obsolete-FZP files. for old sketches only!\n   * @return {Promise}\n   ",
-      "start": 643,
-      "end": 741,
-      "loc": {
-        "start": {
-          "line": 36,
-          "column": 2
-        },
-        "end": {
-          "line": 39,
-          "column": 5
-        }
-      }
-    },
-    {
-      "type": {
-        "label": "name",
-        "beforeExpr": false,
-        "startsExpr": true,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null
-      },
-      "value": "getFzpsObsolete",
-      "start": 744,
-      "end": 759,
-      "loc": {
-        "start": {
-          "line": 40,
-          "column": 2
-        },
-        "end": {
-          "line": 40,
-          "column": 17
-        }
-      }
-    },
-    {
-      "type": {
-        "label": "(",
-        "beforeExpr": true,
-        "startsExpr": true,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null
-      },
-      "start": 759,
-      "end": 760,
-      "loc": {
-        "start": {
-          "line": 40,
-          "column": 17
-        },
-        "end": {
-          "line": 40,
-          "column": 18
-        }
-      }
-    },
-    {
-      "type": {
-        "label": ")",
-        "beforeExpr": false,
-        "startsExpr": false,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null
-      },
-      "start": 760,
-      "end": 761,
-      "loc": {
-        "start": {
-          "line": 40,
-          "column": 18
-        },
-        "end": {
-          "line": 40,
-          "column": 19
-        }
-      }
-    },
-    {
-      "type": {
-        "label": "{",
-        "beforeExpr": true,
-        "startsExpr": true,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null
-      },
-      "start": 762,
-      "end": 763,
-      "loc": {
-        "start": {
-          "line": 40,
-          "column": 20
-        },
-        "end": {
-          "line": 40,
-          "column": 21
-        }
-      }
-    },
-    {
-      "type": {
-        "label": "return",
-        "keyword": "return",
-        "beforeExpr": true,
-        "startsExpr": false,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null,
-        "updateContext": null
-      },
-      "value": "return",
-      "start": 768,
-      "end": 774,
-      "loc": {
-        "start": {
-          "line": 41,
-          "column": 4
-        },
-        "end": {
-          "line": 41,
-          "column": 10
-        }
-      }
-    },
-    {
-      "type": {
-        "label": "name",
-        "beforeExpr": false,
-        "startsExpr": true,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null
-      },
-      "value": "axios",
-      "start": 775,
-      "end": 780,
-      "loc": {
-        "start": {
-          "line": 41,
-          "column": 11
-        },
-        "end": {
-          "line": 41,
-          "column": 16
-        }
-      }
-    },
-    {
-      "type": {
-        "label": ".",
-        "beforeExpr": false,
-        "startsExpr": false,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null,
-        "updateContext": null
-      },
-      "start": 780,
-      "end": 781,
-      "loc": {
-        "start": {
-          "line": 41,
-          "column": 16
-        },
-        "end": {
-          "line": 41,
-          "column": 17
-        }
-      }
-    },
-    {
-      "type": {
-        "label": "name",
-        "beforeExpr": false,
-        "startsExpr": true,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null
-      },
-      "value": "get",
-      "start": 781,
-      "end": 784,
-      "loc": {
-        "start": {
-          "line": 41,
-          "column": 17
-        },
-        "end": {
-          "line": 41,
-          "column": 20
-        }
-      }
-    },
-    {
-      "type": {
-        "label": "(",
-        "beforeExpr": true,
-        "startsExpr": true,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null
-      },
-      "start": 784,
-      "end": 785,
-      "loc": {
-        "start": {
-          "line": 41,
-          "column": 20
-        },
-        "end": {
-          "line": 41,
-          "column": 21
-        }
-      }
-    },
-    {
-      "type": {
-        "label": "this",
-        "keyword": "this",
-        "beforeExpr": false,
-        "startsExpr": true,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null,
-        "updateContext": null
-      },
-      "value": "this",
-      "start": 785,
-      "end": 789,
-      "loc": {
-        "start": {
-          "line": 41,
-          "column": 21
-        },
-        "end": {
-          "line": 41,
-          "column": 25
-        }
-      }
-    },
-    {
-      "type": {
-        "label": ".",
-        "beforeExpr": false,
-        "startsExpr": false,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null,
-        "updateContext": null
-      },
-      "start": 789,
-      "end": 790,
-      "loc": {
-        "start": {
-          "line": 41,
-          "column": 25
-        },
-        "end": {
-          "line": 41,
-          "column": 26
-        }
-      }
-    },
-    {
-      "type": {
-        "label": "name",
-        "beforeExpr": false,
-        "startsExpr": true,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null
-      },
-      "value": "url",
-      "start": 790,
-      "end": 793,
-      "loc": {
-        "start": {
-          "line": 41,
-          "column": 26
-        },
-        "end": {
-          "line": 41,
-          "column": 29
-        }
-      }
-    },
-    {
-      "type": {
-        "label": "+/-",
-        "beforeExpr": true,
-        "startsExpr": true,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": true,
-        "postfix": false,
-        "binop": 9,
-        "updateContext": null
-      },
-      "value": "+",
-      "start": 793,
-      "end": 794,
-      "loc": {
-        "start": {
-          "line": 41,
-          "column": 29
-        },
-        "end": {
-          "line": 41,
-          "column": 30
-        }
-      }
-    },
-    {
-      "type": {
-        "label": "string",
-        "beforeExpr": false,
-        "startsExpr": true,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null,
-        "updateContext": null
-      },
-      "value": "/fzp/obsolete",
-      "start": 794,
-      "end": 809,
-      "loc": {
-        "start": {
-          "line": 41,
-          "column": 30
-        },
-        "end": {
-          "line": 41,
-          "column": 45
-        }
-      }
-    },
-    {
-      "type": {
-        "label": ",",
-        "beforeExpr": true,
-        "startsExpr": false,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null,
-        "updateContext": null
-      },
-      "start": 809,
-      "end": 810,
-      "loc": {
-        "start": {
-          "line": 41,
-          "column": 45
-        },
-        "end": {
-          "line": 41,
-          "column": 46
-        }
-      }
-    },
-    {
-      "type": {
-        "label": "{",
-        "beforeExpr": true,
-        "startsExpr": true,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null
-      },
-      "start": 811,
-      "end": 812,
-      "loc": {
-        "start": {
-          "line": 41,
-          "column": 47
-        },
-        "end": {
-          "line": 41,
-          "column": 48
-        }
-      }
-    },
-    {
-      "type": {
-        "label": "name",
-        "beforeExpr": false,
-        "startsExpr": true,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null
-      },
-      "value": "responseType",
-      "start": 812,
-      "end": 824,
-      "loc": {
-        "start": {
-          "line": 41,
-          "column": 48
-        },
-        "end": {
-          "line": 41,
-          "column": 60
-        }
-      }
-    },
-    {
-      "type": {
-        "label": ":",
-        "beforeExpr": true,
-        "startsExpr": false,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null,
-        "updateContext": null
-      },
-      "start": 824,
-      "end": 825,
-      "loc": {
-        "start": {
-          "line": 41,
-          "column": 60
-        },
-        "end": {
-          "line": 41,
-          "column": 61
-        }
-      }
-    },
-    {
-      "type": {
-        "label": "string",
-        "beforeExpr": false,
-        "startsExpr": true,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null,
-        "updateContext": null
-      },
-      "value": "json",
-      "start": 826,
-      "end": 832,
-      "loc": {
-        "start": {
-          "line": 41,
-          "column": 62
-        },
-        "end": {
-          "line": 41,
-          "column": 68
-        }
-      }
-    },
-    {
-      "type": {
-        "label": "}",
-        "beforeExpr": false,
-        "startsExpr": false,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null
-      },
-      "start": 832,
-      "end": 833,
-      "loc": {
-        "start": {
-          "line": 41,
-          "column": 68
-        },
-        "end": {
-          "line": 41,
-          "column": 69
-        }
-      }
-    },
-    {
-      "type": {
-        "label": ")",
-        "beforeExpr": false,
-        "startsExpr": false,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null
-      },
-      "start": 833,
-      "end": 834,
-      "loc": {
-        "start": {
-          "line": 41,
-          "column": 69
-        },
-        "end": {
-          "line": 41,
-          "column": 70
-        }
-      }
-    },
-    {
-      "type": {
-        "label": ".",
-        "beforeExpr": false,
-        "startsExpr": false,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null,
-        "updateContext": null
-      },
-      "start": 839,
-      "end": 840,
-      "loc": {
-        "start": {
-          "line": 42,
-          "column": 4
-        },
-        "end": {
-          "line": 42,
-          "column": 5
-        }
-      }
-    },
-    {
-      "type": {
-        "label": "name",
-        "beforeExpr": false,
-        "startsExpr": true,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null
-      },
-      "value": "then",
-      "start": 840,
-      "end": 844,
-      "loc": {
-        "start": {
-          "line": 42,
-          "column": 5
-        },
-        "end": {
-          "line": 42,
-          "column": 9
-        }
-      }
-    },
-    {
-      "type": {
-        "label": "(",
-        "beforeExpr": true,
-        "startsExpr": true,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null
-      },
-      "start": 844,
-      "end": 845,
-      "loc": {
-        "start": {
-          "line": 42,
-          "column": 9
-        },
-        "end": {
-          "line": 42,
-          "column": 10
-        }
-      }
-    },
-    {
-      "type": {
-        "label": "(",
-        "beforeExpr": true,
-        "startsExpr": true,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null
-      },
-      "start": 845,
-      "end": 846,
-      "loc": {
-        "start": {
-          "line": 42,
-          "column": 10
-        },
-        "end": {
-          "line": 42,
-          "column": 11
-        }
-      }
-    },
-    {
-      "type": {
-        "label": "name",
-        "beforeExpr": false,
-        "startsExpr": true,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null
-      },
-      "value": "res",
-      "start": 846,
-      "end": 849,
-      "loc": {
-        "start": {
-          "line": 42,
-          "column": 11
-        },
-        "end": {
-          "line": 42,
-          "column": 14
-        }
-      }
-    },
-    {
-      "type": {
-        "label": ")",
-        "beforeExpr": false,
-        "startsExpr": false,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null
-      },
-      "start": 849,
-      "end": 850,
-      "loc": {
-        "start": {
-          "line": 42,
-          "column": 14
-        },
-        "end": {
-          "line": 42,
-          "column": 15
-        }
-      }
-    },
-    {
-      "type": {
-        "label": "=>",
-        "beforeExpr": true,
-        "startsExpr": false,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null,
-        "updateContext": null
-      },
-      "start": 851,
-      "end": 853,
-      "loc": {
-        "start": {
-          "line": 42,
-          "column": 16
-        },
-        "end": {
-          "line": 42,
-          "column": 18
-        }
-      }
-    },
-    {
-      "type": {
-        "label": "{",
-        "beforeExpr": true,
-        "startsExpr": true,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null
-      },
-      "start": 854,
-      "end": 855,
-      "loc": {
-        "start": {
-          "line": 42,
-          "column": 19
-        },
-        "end": {
-          "line": 42,
-          "column": 20
-        }
-      }
-    },
-    {
-      "type": {
-        "label": "return",
-        "keyword": "return",
-        "beforeExpr": true,
-        "startsExpr": false,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null,
-        "updateContext": null
-      },
-      "value": "return",
-      "start": 862,
-      "end": 868,
-      "loc": {
-        "start": {
-          "line": 43,
-          "column": 6
-        },
-        "end": {
-          "line": 43,
-          "column": 12
-        }
-      }
-    },
-    {
-      "type": {
-        "label": "name",
-        "beforeExpr": false,
-        "startsExpr": true,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null
-      },
-      "value": "res",
-      "start": 869,
-      "end": 872,
-      "loc": {
-        "start": {
-          "line": 43,
-          "column": 13
-        },
-        "end": {
-          "line": 43,
-          "column": 16
-        }
-      }
-    },
-    {
-      "type": {
-        "label": ".",
-        "beforeExpr": false,
-        "startsExpr": false,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null,
-        "updateContext": null
-      },
-      "start": 872,
-      "end": 873,
-      "loc": {
-        "start": {
-          "line": 43,
-          "column": 16
-        },
-        "end": {
-          "line": 43,
-          "column": 17
-        }
-      }
-    },
-    {
-      "type": {
-        "label": "name",
-        "beforeExpr": false,
-        "startsExpr": true,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null
-      },
-      "value": "data",
-      "start": 873,
-      "end": 877,
-      "loc": {
-        "start": {
-          "line": 43,
-          "column": 17
-        },
-        "end": {
-          "line": 43,
-          "column": 21
-        }
-      }
-    },
-    {
-      "type": {
-        "label": ";",
-        "beforeExpr": true,
-        "startsExpr": false,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null,
-        "updateContext": null
-      },
-      "start": 877,
-      "end": 878,
-      "loc": {
-        "start": {
-          "line": 43,
-          "column": 21
-        },
-        "end": {
-          "line": 43,
-          "column": 22
-        }
-      }
-    },
-    {
-      "type": {
-        "label": "}",
-        "beforeExpr": false,
-        "startsExpr": false,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null
-      },
-      "start": 883,
-      "end": 884,
-      "loc": {
-        "start": {
-          "line": 44,
-          "column": 4
-        },
-        "end": {
-          "line": 44,
-          "column": 5
-        }
-      }
-    },
-    {
-      "type": {
-        "label": ")",
-        "beforeExpr": false,
-        "startsExpr": false,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null
-      },
-      "start": 884,
-      "end": 885,
-      "loc": {
-        "start": {
-          "line": 44,
-          "column": 5
-        },
-        "end": {
-          "line": 44,
-          "column": 6
-        }
-      }
-    },
-    {
-      "type": {
-        "label": ";",
-        "beforeExpr": true,
-        "startsExpr": false,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null,
-        "updateContext": null
-      },
-      "start": 885,
-      "end": 886,
-      "loc": {
-        "start": {
-          "line": 44,
-          "column": 6
-        },
-        "end": {
-          "line": 44,
-          "column": 7
-        }
-      }
-    },
-    {
-      "type": {
-        "label": "}",
-        "beforeExpr": false,
-        "startsExpr": false,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null
-      },
-      "start": 889,
-      "end": 890,
-      "loc": {
-        "start": {
-          "line": 45,
-          "column": 2
-        },
-        "end": {
-          "line": 45,
-          "column": 3
-        }
-      }
-    },
-    {
-      "type": "CommentBlock",
-      "value": "*\n   * Get a single FZP and response the xml as a string\n   * @param  {String} src\n   * @return {Promise} the fetch promise\n   ",
-      "start": 894,
-      "end": 1025,
-      "loc": {
-        "start": {
-          "line": 47,
-          "column": 2
-        },
-        "end": {
-          "line": 51,
-          "column": 5
-        }
-      }
-    },
-    {
-      "type": {
-        "label": "name",
-        "beforeExpr": false,
-        "startsExpr": true,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null
-      },
-      "value": "getFzp",
-      "start": 1029,
-      "end": 1035,
-      "loc": {
-        "start": {
-          "line": 52,
-          "column": 3
-        },
-        "end": {
-          "line": 52,
-          "column": 9
-        }
-      }
-    },
-    {
-      "type": {
-        "label": "(",
-        "beforeExpr": true,
-        "startsExpr": true,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null
-      },
-      "start": 1035,
-      "end": 1036,
-      "loc": {
-        "start": {
-          "line": 52,
-          "column": 9
-        },
-        "end": {
-          "line": 52,
-          "column": 10
+          "line": 64,
+          "column": 24
         }
       }
     },
@@ -9820,16 +12926,121 @@
         "binop": null
       },
       "value": "src",
-      "start": 1036,
-      "end": 1039,
+      "start": 1486,
+      "end": 1489,
       "loc": {
         "start": {
-          "line": 52,
-          "column": 10
+          "line": 64,
+          "column": 24
         },
         "end": {
-          "line": 52,
-          "column": 13
+          "line": 64,
+          "column": 27
+        }
+      }
+    },
+    {
+      "type": {
+        "label": ",",
+        "beforeExpr": true,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null,
+        "updateContext": null
+      },
+      "start": 1489,
+      "end": 1490,
+      "loc": {
+        "start": {
+          "line": 64,
+          "column": 27
+        },
+        "end": {
+          "line": 64,
+          "column": 28
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "name",
+        "beforeExpr": false,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "value": "url",
+      "start": 1491,
+      "end": 1494,
+      "loc": {
+        "start": {
+          "line": 64,
+          "column": 29
+        },
+        "end": {
+          "line": 64,
+          "column": 32
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "=",
+        "beforeExpr": true,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": true,
+        "prefix": false,
+        "postfix": false,
+        "binop": null,
+        "updateContext": null
+      },
+      "value": "=",
+      "start": 1495,
+      "end": 1496,
+      "loc": {
+        "start": {
+          "line": 64,
+          "column": 33
+        },
+        "end": {
+          "line": 64,
+          "column": 34
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "name",
+        "beforeExpr": false,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "value": "FritzingPartsAPI",
+      "start": 1497,
+      "end": 1513,
+      "loc": {
+        "start": {
+          "line": 64,
+          "column": 35
+        },
+        "end": {
+          "line": 64,
+          "column": 51
         }
       }
     },
@@ -9845,16 +13056,16 @@
         "postfix": false,
         "binop": null
       },
-      "start": 1039,
-      "end": 1040,
+      "start": 1513,
+      "end": 1514,
       "loc": {
         "start": {
-          "line": 52,
-          "column": 13
+          "line": 64,
+          "column": 51
         },
         "end": {
-          "line": 52,
-          "column": 14
+          "line": 64,
+          "column": 52
         }
       }
     },
@@ -9870,16 +13081,16 @@
         "postfix": false,
         "binop": null
       },
-      "start": 1041,
-      "end": 1042,
+      "start": 1515,
+      "end": 1516,
       "loc": {
         "start": {
-          "line": 52,
-          "column": 15
+          "line": 64,
+          "column": 53
         },
         "end": {
-          "line": 52,
-          "column": 16
+          "line": 64,
+          "column": 54
         }
       }
     },
@@ -9898,16 +13109,16 @@
         "updateContext": null
       },
       "value": "return",
-      "start": 1048,
-      "end": 1054,
+      "start": 1519,
+      "end": 1525,
       "loc": {
         "start": {
-          "line": 53,
-          "column": 5
+          "line": 65,
+          "column": 2
         },
         "end": {
-          "line": 53,
-          "column": 11
+          "line": 65,
+          "column": 8
         }
       }
     },
@@ -9924,16 +13135,16 @@
         "binop": null
       },
       "value": "axios",
-      "start": 1055,
-      "end": 1060,
+      "start": 1526,
+      "end": 1531,
       "loc": {
         "start": {
-          "line": 53,
-          "column": 12
+          "line": 65,
+          "column": 9
         },
         "end": {
-          "line": 53,
-          "column": 17
+          "line": 65,
+          "column": 14
         }
       }
     },
@@ -9950,16 +13161,16 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 1060,
-      "end": 1061,
+      "start": 1531,
+      "end": 1532,
       "loc": {
         "start": {
-          "line": 53,
-          "column": 17
+          "line": 65,
+          "column": 14
         },
         "end": {
-          "line": 53,
-          "column": 18
+          "line": 65,
+          "column": 15
         }
       }
     },
@@ -9976,16 +13187,16 @@
         "binop": null
       },
       "value": "get",
-      "start": 1061,
-      "end": 1064,
+      "start": 1532,
+      "end": 1535,
       "loc": {
         "start": {
-          "line": 53,
-          "column": 18
+          "line": 65,
+          "column": 15
         },
         "end": {
-          "line": 53,
-          "column": 21
+          "line": 65,
+          "column": 18
         }
       }
     },
@@ -10001,23 +13212,22 @@
         "postfix": false,
         "binop": null
       },
-      "start": 1064,
-      "end": 1065,
+      "start": 1535,
+      "end": 1536,
       "loc": {
         "start": {
-          "line": 53,
-          "column": 21
+          "line": 65,
+          "column": 18
         },
         "end": {
-          "line": 53,
-          "column": 22
+          "line": 65,
+          "column": 19
         }
       }
     },
     {
       "type": {
-        "label": "this",
-        "keyword": "this",
+        "label": "`",
         "beforeExpr": false,
         "startsExpr": true,
         "rightAssociative": false,
@@ -10025,26 +13235,24 @@
         "isAssign": false,
         "prefix": false,
         "postfix": false,
-        "binop": null,
-        "updateContext": null
+        "binop": null
       },
-      "value": "this",
-      "start": 1065,
-      "end": 1069,
+      "start": 1536,
+      "end": 1537,
       "loc": {
         "start": {
-          "line": 53,
-          "column": 22
+          "line": 65,
+          "column": 19
         },
         "end": {
-          "line": 53,
-          "column": 26
+          "line": 65,
+          "column": 20
         }
       }
     },
     {
       "type": {
-        "label": ".",
+        "label": "template",
         "beforeExpr": false,
         "startsExpr": false,
         "rightAssociative": false,
@@ -10055,16 +13263,42 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 1069,
-      "end": 1070,
+      "value": "",
+      "start": 1537,
+      "end": 1537,
       "loc": {
         "start": {
-          "line": 53,
-          "column": 26
+          "line": 65,
+          "column": 20
         },
         "end": {
-          "line": 53,
-          "column": 27
+          "line": 65,
+          "column": 20
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "${",
+        "beforeExpr": true,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "start": 1537,
+      "end": 1539,
+      "loc": {
+        "start": {
+          "line": 65,
+          "column": 20
+        },
+        "end": {
+          "line": 65,
+          "column": 22
         }
       }
     },
@@ -10081,51 +13315,49 @@
         "binop": null
       },
       "value": "url",
-      "start": 1070,
-      "end": 1073,
+      "start": 1539,
+      "end": 1542,
       "loc": {
         "start": {
-          "line": 53,
-          "column": 27
+          "line": 65,
+          "column": 22
         },
         "end": {
-          "line": 53,
-          "column": 30
+          "line": 65,
+          "column": 25
         }
       }
     },
     {
       "type": {
-        "label": "+/-",
-        "beforeExpr": true,
-        "startsExpr": true,
+        "label": "}",
+        "beforeExpr": false,
+        "startsExpr": false,
         "rightAssociative": false,
         "isLoop": false,
         "isAssign": false,
-        "prefix": true,
+        "prefix": false,
         "postfix": false,
-        "binop": 9,
-        "updateContext": null
+        "binop": null
       },
-      "value": "+",
-      "start": 1073,
-      "end": 1074,
+      "start": 1542,
+      "end": 1543,
       "loc": {
         "start": {
-          "line": 53,
-          "column": 30
+          "line": 65,
+          "column": 25
         },
         "end": {
-          "line": 53,
-          "column": 31
+          "line": 65,
+          "column": 26
         }
       }
     },
     {
       "type": {
-        "label": "string",
+        "label": "template",
         "beforeExpr": false,
-        "startsExpr": true,
+        "startsExpr": false,
         "rightAssociative": false,
         "isLoop": false,
         "isAssign": false,
@@ -10135,43 +13367,41 @@
         "updateContext": null
       },
       "value": "/",
-      "start": 1074,
-      "end": 1077,
+      "start": 1543,
+      "end": 1544,
       "loc": {
         "start": {
-          "line": 53,
-          "column": 31
+          "line": 65,
+          "column": 26
         },
         "end": {
-          "line": 53,
-          "column": 34
+          "line": 65,
+          "column": 27
         }
       }
     },
     {
       "type": {
-        "label": "+/-",
+        "label": "${",
         "beforeExpr": true,
         "startsExpr": true,
         "rightAssociative": false,
         "isLoop": false,
         "isAssign": false,
-        "prefix": true,
+        "prefix": false,
         "postfix": false,
-        "binop": 9,
-        "updateContext": null
+        "binop": null
       },
-      "value": "+",
-      "start": 1077,
-      "end": 1078,
+      "start": 1544,
+      "end": 1546,
       "loc": {
         "start": {
-          "line": 53,
-          "column": 34
+          "line": 65,
+          "column": 27
         },
         "end": {
-          "line": 53,
-          "column": 35
+          "line": 65,
+          "column": 29
         }
       }
     },
@@ -10188,16 +13418,93 @@
         "binop": null
       },
       "value": "src",
-      "start": 1078,
-      "end": 1081,
+      "start": 1546,
+      "end": 1549,
       "loc": {
         "start": {
-          "line": 53,
-          "column": 35
+          "line": 65,
+          "column": 29
         },
         "end": {
-          "line": 53,
-          "column": 38
+          "line": 65,
+          "column": 32
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "}",
+        "beforeExpr": false,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "start": 1549,
+      "end": 1550,
+      "loc": {
+        "start": {
+          "line": 65,
+          "column": 32
+        },
+        "end": {
+          "line": 65,
+          "column": 33
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "template",
+        "beforeExpr": false,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null,
+        "updateContext": null
+      },
+      "value": "",
+      "start": 1550,
+      "end": 1550,
+      "loc": {
+        "start": {
+          "line": 65,
+          "column": 33
+        },
+        "end": {
+          "line": 65,
+          "column": 33
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "`",
+        "beforeExpr": false,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "start": 1550,
+      "end": 1551,
+      "loc": {
+        "start": {
+          "line": 65,
+          "column": 33
+        },
+        "end": {
+          "line": 65,
+          "column": 34
         }
       }
     },
@@ -10214,16 +13521,16 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 1081,
-      "end": 1082,
+      "start": 1551,
+      "end": 1552,
       "loc": {
         "start": {
-          "line": 53,
-          "column": 38
+          "line": 65,
+          "column": 34
         },
         "end": {
-          "line": 53,
-          "column": 39
+          "line": 65,
+          "column": 35
         }
       }
     },
@@ -10239,16 +13546,16 @@
         "postfix": false,
         "binop": null
       },
-      "start": 1083,
-      "end": 1084,
+      "start": 1553,
+      "end": 1554,
       "loc": {
         "start": {
-          "line": 53,
-          "column": 40
+          "line": 65,
+          "column": 36
         },
         "end": {
-          "line": 53,
-          "column": 41
+          "line": 65,
+          "column": 37
         }
       }
     },
@@ -10265,16 +13572,16 @@
         "binop": null
       },
       "value": "responseType",
-      "start": 1084,
-      "end": 1096,
+      "start": 1554,
+      "end": 1566,
       "loc": {
         "start": {
-          "line": 53,
-          "column": 41
+          "line": 65,
+          "column": 37
         },
         "end": {
-          "line": 53,
-          "column": 53
+          "line": 65,
+          "column": 49
         }
       }
     },
@@ -10291,16 +13598,16 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 1096,
-      "end": 1097,
+      "start": 1566,
+      "end": 1567,
       "loc": {
         "start": {
-          "line": 53,
-          "column": 53
+          "line": 65,
+          "column": 49
         },
         "end": {
-          "line": 53,
-          "column": 54
+          "line": 65,
+          "column": 50
         }
       }
     },
@@ -10318,16 +13625,16 @@
         "updateContext": null
       },
       "value": "xml",
-      "start": 1098,
-      "end": 1103,
+      "start": 1568,
+      "end": 1573,
       "loc": {
         "start": {
-          "line": 53,
-          "column": 55
+          "line": 65,
+          "column": 51
         },
         "end": {
-          "line": 53,
-          "column": 60
+          "line": 65,
+          "column": 56
         }
       }
     },
@@ -10343,16 +13650,16 @@
         "postfix": false,
         "binop": null
       },
-      "start": 1103,
-      "end": 1104,
+      "start": 1573,
+      "end": 1574,
       "loc": {
         "start": {
-          "line": 53,
-          "column": 60
+          "line": 65,
+          "column": 56
         },
         "end": {
-          "line": 53,
-          "column": 61
+          "line": 65,
+          "column": 57
         }
       }
     },
@@ -10368,16 +13675,16 @@
         "postfix": false,
         "binop": null
       },
-      "start": 1104,
-      "end": 1105,
+      "start": 1574,
+      "end": 1575,
       "loc": {
         "start": {
-          "line": 53,
-          "column": 61
+          "line": 65,
+          "column": 57
         },
         "end": {
-          "line": 53,
-          "column": 62
+          "line": 65,
+          "column": 58
         }
       }
     },
@@ -10394,16 +13701,16 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 1111,
-      "end": 1112,
+      "start": 1578,
+      "end": 1579,
       "loc": {
         "start": {
-          "line": 54,
-          "column": 5
+          "line": 66,
+          "column": 2
         },
         "end": {
-          "line": 54,
-          "column": 6
+          "line": 66,
+          "column": 3
         }
       }
     },
@@ -10420,16 +13727,16 @@
         "binop": null
       },
       "value": "then",
-      "start": 1112,
-      "end": 1116,
+      "start": 1579,
+      "end": 1583,
       "loc": {
         "start": {
-          "line": 54,
-          "column": 6
+          "line": 66,
+          "column": 3
         },
         "end": {
-          "line": 54,
-          "column": 10
+          "line": 66,
+          "column": 7
         }
       }
     },
@@ -10445,16 +13752,16 @@
         "postfix": false,
         "binop": null
       },
-      "start": 1116,
-      "end": 1117,
+      "start": 1583,
+      "end": 1584,
       "loc": {
         "start": {
-          "line": 54,
-          "column": 10
+          "line": 66,
+          "column": 7
         },
         "end": {
-          "line": 54,
-          "column": 11
+          "line": 66,
+          "column": 8
         }
       }
     },
@@ -10470,16 +13777,16 @@
         "postfix": false,
         "binop": null
       },
-      "start": 1117,
-      "end": 1118,
+      "start": 1584,
+      "end": 1585,
       "loc": {
         "start": {
-          "line": 54,
-          "column": 11
+          "line": 66,
+          "column": 8
         },
         "end": {
-          "line": 54,
-          "column": 12
+          "line": 66,
+          "column": 9
         }
       }
     },
@@ -10496,16 +13803,16 @@
         "binop": null
       },
       "value": "res",
-      "start": 1118,
-      "end": 1121,
+      "start": 1585,
+      "end": 1588,
       "loc": {
         "start": {
-          "line": 54,
-          "column": 12
+          "line": 66,
+          "column": 9
         },
         "end": {
-          "line": 54,
-          "column": 15
+          "line": 66,
+          "column": 12
         }
       }
     },
@@ -10521,16 +13828,16 @@
         "postfix": false,
         "binop": null
       },
-      "start": 1121,
-      "end": 1122,
+      "start": 1588,
+      "end": 1589,
       "loc": {
         "start": {
-          "line": 54,
-          "column": 15
+          "line": 66,
+          "column": 12
         },
         "end": {
-          "line": 54,
-          "column": 16
+          "line": 66,
+          "column": 13
         }
       }
     },
@@ -10547,16 +13854,16 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 1123,
-      "end": 1125,
+      "start": 1590,
+      "end": 1592,
       "loc": {
         "start": {
-          "line": 54,
-          "column": 17
+          "line": 66,
+          "column": 14
         },
         "end": {
-          "line": 54,
-          "column": 19
+          "line": 66,
+          "column": 16
         }
       }
     },
@@ -10572,16 +13879,16 @@
         "postfix": false,
         "binop": null
       },
-      "start": 1126,
-      "end": 1127,
+      "start": 1593,
+      "end": 1594,
       "loc": {
         "start": {
-          "line": 54,
-          "column": 20
+          "line": 66,
+          "column": 17
         },
         "end": {
-          "line": 54,
-          "column": 21
+          "line": 66,
+          "column": 18
         }
       }
     },
@@ -10600,16 +13907,16 @@
         "updateContext": null
       },
       "value": "return",
-      "start": 1135,
-      "end": 1141,
+      "start": 1599,
+      "end": 1605,
       "loc": {
         "start": {
-          "line": 55,
-          "column": 7
+          "line": 67,
+          "column": 4
         },
         "end": {
-          "line": 55,
-          "column": 13
+          "line": 67,
+          "column": 10
         }
       }
     },
@@ -10625,17 +13932,17 @@
         "postfix": false,
         "binop": null
       },
-      "value": "res",
-      "start": 1142,
-      "end": 1145,
+      "value": "Promise",
+      "start": 1606,
+      "end": 1613,
       "loc": {
         "start": {
-          "line": 55,
-          "column": 14
+          "line": 67,
+          "column": 11
         },
         "end": {
-          "line": 55,
-          "column": 17
+          "line": 67,
+          "column": 18
         }
       }
     },
@@ -10652,16 +13959,119 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 1145,
-      "end": 1146,
+      "start": 1613,
+      "end": 1614,
       "loc": {
         "start": {
-          "line": 55,
-          "column": 17
+          "line": 67,
+          "column": 18
         },
         "end": {
-          "line": 55,
-          "column": 18
+          "line": 67,
+          "column": 19
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "name",
+        "beforeExpr": false,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "value": "resolve",
+      "start": 1614,
+      "end": 1621,
+      "loc": {
+        "start": {
+          "line": 67,
+          "column": 19
+        },
+        "end": {
+          "line": 67,
+          "column": 26
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "(",
+        "beforeExpr": true,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "start": 1621,
+      "end": 1622,
+      "loc": {
+        "start": {
+          "line": 67,
+          "column": 26
+        },
+        "end": {
+          "line": 67,
+          "column": 27
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "name",
+        "beforeExpr": false,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "value": "res",
+      "start": 1622,
+      "end": 1625,
+      "loc": {
+        "start": {
+          "line": 67,
+          "column": 27
+        },
+        "end": {
+          "line": 67,
+          "column": 30
+        }
+      }
+    },
+    {
+      "type": {
+        "label": ".",
+        "beforeExpr": false,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null,
+        "updateContext": null
+      },
+      "start": 1625,
+      "end": 1626,
+      "loc": {
+        "start": {
+          "line": 67,
+          "column": 30
+        },
+        "end": {
+          "line": 67,
+          "column": 31
         }
       }
     },
@@ -10678,67 +14088,16 @@
         "binop": null
       },
       "value": "data",
-      "start": 1146,
-      "end": 1150,
+      "start": 1626,
+      "end": 1630,
       "loc": {
         "start": {
-          "line": 55,
-          "column": 18
+          "line": 67,
+          "column": 31
         },
         "end": {
-          "line": 55,
-          "column": 22
-        }
-      }
-    },
-    {
-      "type": {
-        "label": ";",
-        "beforeExpr": true,
-        "startsExpr": false,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null,
-        "updateContext": null
-      },
-      "start": 1150,
-      "end": 1151,
-      "loc": {
-        "start": {
-          "line": 55,
-          "column": 22
-        },
-        "end": {
-          "line": 55,
-          "column": 23
-        }
-      }
-    },
-    {
-      "type": {
-        "label": "}",
-        "beforeExpr": false,
-        "startsExpr": false,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null
-      },
-      "start": 1157,
-      "end": 1158,
-      "loc": {
-        "start": {
-          "line": 56,
-          "column": 5
-        },
-        "end": {
-          "line": 56,
-          "column": 6
+          "line": 67,
+          "column": 35
         }
       }
     },
@@ -10754,16 +14113,16 @@
         "postfix": false,
         "binop": null
       },
-      "start": 1158,
-      "end": 1159,
+      "start": 1630,
+      "end": 1631,
       "loc": {
         "start": {
-          "line": 56,
-          "column": 6
+          "line": 67,
+          "column": 35
         },
         "end": {
-          "line": 56,
-          "column": 7
+          "line": 67,
+          "column": 36
         }
       }
     },
@@ -10780,16 +14139,16 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 1159,
-      "end": 1160,
+      "start": 1631,
+      "end": 1632,
       "loc": {
         "start": {
-          "line": 56,
-          "column": 7
+          "line": 67,
+          "column": 36
         },
         "end": {
-          "line": 56,
-          "column": 8
+          "line": 67,
+          "column": 37
         }
       }
     },
@@ -10805,32 +14164,162 @@
         "postfix": false,
         "binop": null
       },
-      "start": 1164,
-      "end": 1165,
+      "start": 1635,
+      "end": 1636,
       "loc": {
         "start": {
-          "line": 57,
+          "line": 68,
+          "column": 2
+        },
+        "end": {
+          "line": 68,
+          "column": 3
+        }
+      }
+    },
+    {
+      "type": {
+        "label": ")",
+        "beforeExpr": false,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "start": 1636,
+      "end": 1637,
+      "loc": {
+        "start": {
+          "line": 68,
           "column": 3
         },
         "end": {
-          "line": 57,
+          "line": 68,
           "column": 4
         }
       }
     },
     {
-      "type": "CommentBlock",
-      "value": "*\n    * Get a single part fzp from the core parts\n    * @param  {String} src\n    * @return {Promise} the fetch promise returns xml\n    ",
-      "start": 1170,
-      "end": 1309,
+      "type": {
+        "label": ";",
+        "beforeExpr": true,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null,
+        "updateContext": null
+      },
+      "start": 1637,
+      "end": 1638,
       "loc": {
         "start": {
-          "line": 59,
-          "column": 3
+          "line": 68,
+          "column": 4
         },
         "end": {
-          "line": 63,
-          "column": 6
+          "line": 68,
+          "column": 5
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "}",
+        "beforeExpr": false,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "start": 1639,
+      "end": 1640,
+      "loc": {
+        "start": {
+          "line": 69,
+          "column": 0
+        },
+        "end": {
+          "line": 69,
+          "column": 1
+        }
+      }
+    },
+    {
+      "type": {
+        "label": ";",
+        "beforeExpr": true,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null,
+        "updateContext": null
+      },
+      "start": 1640,
+      "end": 1641,
+      "loc": {
+        "start": {
+          "line": 69,
+          "column": 1
+        },
+        "end": {
+          "line": 69,
+          "column": 2
+        }
+      }
+    },
+    {
+      "type": "CommentBlock",
+      "value": "*\n  * Get a single part fzp from the core parts\n  *\n  * @param  {String} src\n  * @param  {String} url - The base URL of the parts api\n  * @return {Promise} the fetch promise returns xml\n  ",
+      "start": 1644,
+      "end": 1836,
+      "loc": {
+        "start": {
+          "line": 71,
+          "column": 1
+        },
+        "end": {
+          "line": 77,
+          "column": 4
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "const",
+        "keyword": "const",
+        "beforeExpr": false,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null,
+        "updateContext": null
+      },
+      "value": "const",
+      "start": 1837,
+      "end": 1842,
+      "loc": {
+        "start": {
+          "line": 78,
+          "column": 0
+        },
+        "end": {
+          "line": 78,
+          "column": 5
         }
       }
     },
@@ -10847,16 +14336,70 @@
         "binop": null
       },
       "value": "getFzpCore",
-      "start": 1312,
-      "end": 1322,
+      "start": 1843,
+      "end": 1853,
       "loc": {
         "start": {
-          "line": 64,
-          "column": 2
+          "line": 78,
+          "column": 6
         },
         "end": {
-          "line": 64,
-          "column": 12
+          "line": 78,
+          "column": 16
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "=",
+        "beforeExpr": true,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": true,
+        "prefix": false,
+        "postfix": false,
+        "binop": null,
+        "updateContext": null
+      },
+      "value": "=",
+      "start": 1854,
+      "end": 1855,
+      "loc": {
+        "start": {
+          "line": 78,
+          "column": 17
+        },
+        "end": {
+          "line": 78,
+          "column": 18
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "function",
+        "keyword": "function",
+        "beforeExpr": false,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "value": "function",
+      "start": 1856,
+      "end": 1864,
+      "loc": {
+        "start": {
+          "line": 78,
+          "column": 19
+        },
+        "end": {
+          "line": 78,
+          "column": 27
         }
       }
     },
@@ -10872,16 +14415,16 @@
         "postfix": false,
         "binop": null
       },
-      "start": 1322,
-      "end": 1323,
+      "start": 1864,
+      "end": 1865,
       "loc": {
         "start": {
-          "line": 64,
-          "column": 12
+          "line": 78,
+          "column": 27
         },
         "end": {
-          "line": 64,
-          "column": 13
+          "line": 78,
+          "column": 28
         }
       }
     },
@@ -10898,16 +14441,121 @@
         "binop": null
       },
       "value": "src",
-      "start": 1323,
-      "end": 1326,
+      "start": 1865,
+      "end": 1868,
       "loc": {
         "start": {
-          "line": 64,
-          "column": 13
+          "line": 78,
+          "column": 28
         },
         "end": {
-          "line": 64,
-          "column": 16
+          "line": 78,
+          "column": 31
+        }
+      }
+    },
+    {
+      "type": {
+        "label": ",",
+        "beforeExpr": true,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null,
+        "updateContext": null
+      },
+      "start": 1868,
+      "end": 1869,
+      "loc": {
+        "start": {
+          "line": 78,
+          "column": 31
+        },
+        "end": {
+          "line": 78,
+          "column": 32
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "name",
+        "beforeExpr": false,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "value": "url",
+      "start": 1870,
+      "end": 1873,
+      "loc": {
+        "start": {
+          "line": 78,
+          "column": 33
+        },
+        "end": {
+          "line": 78,
+          "column": 36
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "=",
+        "beforeExpr": true,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": true,
+        "prefix": false,
+        "postfix": false,
+        "binop": null,
+        "updateContext": null
+      },
+      "value": "=",
+      "start": 1874,
+      "end": 1875,
+      "loc": {
+        "start": {
+          "line": 78,
+          "column": 37
+        },
+        "end": {
+          "line": 78,
+          "column": 38
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "name",
+        "beforeExpr": false,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "value": "FritzingPartsAPI",
+      "start": 1876,
+      "end": 1892,
+      "loc": {
+        "start": {
+          "line": 78,
+          "column": 39
+        },
+        "end": {
+          "line": 78,
+          "column": 55
         }
       }
     },
@@ -10923,16 +14571,16 @@
         "postfix": false,
         "binop": null
       },
-      "start": 1326,
-      "end": 1327,
+      "start": 1892,
+      "end": 1893,
       "loc": {
         "start": {
-          "line": 64,
-          "column": 16
+          "line": 78,
+          "column": 55
         },
         "end": {
-          "line": 64,
-          "column": 17
+          "line": 78,
+          "column": 56
         }
       }
     },
@@ -10948,16 +14596,16 @@
         "postfix": false,
         "binop": null
       },
-      "start": 1328,
-      "end": 1329,
+      "start": 1894,
+      "end": 1895,
       "loc": {
         "start": {
-          "line": 64,
-          "column": 18
+          "line": 78,
+          "column": 57
         },
         "end": {
-          "line": 64,
-          "column": 19
+          "line": 78,
+          "column": 58
         }
       }
     },
@@ -10976,16 +14624,16 @@
         "updateContext": null
       },
       "value": "return",
-      "start": 1334,
-      "end": 1340,
+      "start": 1898,
+      "end": 1904,
       "loc": {
         "start": {
-          "line": 65,
-          "column": 4
+          "line": 79,
+          "column": 2
         },
         "end": {
-          "line": 65,
-          "column": 10
+          "line": 79,
+          "column": 8
         }
       }
     },
@@ -11002,16 +14650,16 @@
         "binop": null
       },
       "value": "axios",
-      "start": 1341,
-      "end": 1346,
+      "start": 1905,
+      "end": 1910,
       "loc": {
         "start": {
-          "line": 65,
-          "column": 11
+          "line": 79,
+          "column": 9
         },
         "end": {
-          "line": 65,
-          "column": 16
+          "line": 79,
+          "column": 14
         }
       }
     },
@@ -11028,16 +14676,16 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 1346,
-      "end": 1347,
+      "start": 1910,
+      "end": 1911,
       "loc": {
         "start": {
-          "line": 65,
-          "column": 16
+          "line": 79,
+          "column": 14
         },
         "end": {
-          "line": 65,
-          "column": 17
+          "line": 79,
+          "column": 15
         }
       }
     },
@@ -11054,16 +14702,16 @@
         "binop": null
       },
       "value": "get",
-      "start": 1347,
-      "end": 1350,
+      "start": 1911,
+      "end": 1914,
       "loc": {
         "start": {
-          "line": 65,
-          "column": 17
+          "line": 79,
+          "column": 15
         },
         "end": {
-          "line": 65,
-          "column": 20
+          "line": 79,
+          "column": 18
         }
       }
     },
@@ -11079,23 +14727,22 @@
         "postfix": false,
         "binop": null
       },
-      "start": 1350,
-      "end": 1351,
+      "start": 1914,
+      "end": 1915,
       "loc": {
         "start": {
-          "line": 65,
-          "column": 20
+          "line": 79,
+          "column": 18
         },
         "end": {
-          "line": 65,
-          "column": 21
+          "line": 79,
+          "column": 19
         }
       }
     },
     {
       "type": {
-        "label": "this",
-        "keyword": "this",
+        "label": "`",
         "beforeExpr": false,
         "startsExpr": true,
         "rightAssociative": false,
@@ -11103,26 +14750,24 @@
         "isAssign": false,
         "prefix": false,
         "postfix": false,
-        "binop": null,
-        "updateContext": null
+        "binop": null
       },
-      "value": "this",
-      "start": 1351,
-      "end": 1355,
+      "start": 1915,
+      "end": 1916,
       "loc": {
         "start": {
-          "line": 65,
-          "column": 21
+          "line": 79,
+          "column": 19
         },
         "end": {
-          "line": 65,
-          "column": 25
+          "line": 79,
+          "column": 20
         }
       }
     },
     {
       "type": {
-        "label": ".",
+        "label": "template",
         "beforeExpr": false,
         "startsExpr": false,
         "rightAssociative": false,
@@ -11133,16 +14778,42 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 1355,
-      "end": 1356,
+      "value": "",
+      "start": 1916,
+      "end": 1916,
       "loc": {
         "start": {
-          "line": 65,
-          "column": 25
+          "line": 79,
+          "column": 20
         },
         "end": {
-          "line": 65,
-          "column": 26
+          "line": 79,
+          "column": 20
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "${",
+        "beforeExpr": true,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "start": 1916,
+      "end": 1918,
+      "loc": {
+        "start": {
+          "line": 79,
+          "column": 20
+        },
+        "end": {
+          "line": 79,
+          "column": 22
         }
       }
     },
@@ -11159,51 +14830,49 @@
         "binop": null
       },
       "value": "url",
-      "start": 1356,
-      "end": 1359,
+      "start": 1918,
+      "end": 1921,
       "loc": {
         "start": {
-          "line": 65,
-          "column": 26
+          "line": 79,
+          "column": 22
         },
         "end": {
-          "line": 65,
-          "column": 29
+          "line": 79,
+          "column": 25
         }
       }
     },
     {
       "type": {
-        "label": "+/-",
-        "beforeExpr": true,
-        "startsExpr": true,
+        "label": "}",
+        "beforeExpr": false,
+        "startsExpr": false,
         "rightAssociative": false,
         "isLoop": false,
         "isAssign": false,
-        "prefix": true,
+        "prefix": false,
         "postfix": false,
-        "binop": 9,
-        "updateContext": null
+        "binop": null
       },
-      "value": "+",
-      "start": 1359,
-      "end": 1360,
+      "start": 1921,
+      "end": 1922,
       "loc": {
         "start": {
-          "line": 65,
-          "column": 29
+          "line": 79,
+          "column": 25
         },
         "end": {
-          "line": 65,
-          "column": 30
+          "line": 79,
+          "column": 26
         }
       }
     },
     {
       "type": {
-        "label": "string",
+        "label": "template",
         "beforeExpr": false,
-        "startsExpr": true,
+        "startsExpr": false,
         "rightAssociative": false,
         "isLoop": false,
         "isAssign": false,
@@ -11213,1812 +14882,22 @@
         "updateContext": null
       },
       "value": "/core/",
-      "start": 1360,
-      "end": 1368,
-      "loc": {
-        "start": {
-          "line": 65,
-          "column": 30
-        },
-        "end": {
-          "line": 65,
-          "column": 38
-        }
-      }
-    },
-    {
-      "type": {
-        "label": "+/-",
-        "beforeExpr": true,
-        "startsExpr": true,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": true,
-        "postfix": false,
-        "binop": 9,
-        "updateContext": null
-      },
-      "value": "+",
-      "start": 1368,
-      "end": 1369,
-      "loc": {
-        "start": {
-          "line": 65,
-          "column": 38
-        },
-        "end": {
-          "line": 65,
-          "column": 39
-        }
-      }
-    },
-    {
-      "type": {
-        "label": "name",
-        "beforeExpr": false,
-        "startsExpr": true,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null
-      },
-      "value": "src",
-      "start": 1369,
-      "end": 1372,
-      "loc": {
-        "start": {
-          "line": 65,
-          "column": 39
-        },
-        "end": {
-          "line": 65,
-          "column": 42
-        }
-      }
-    },
-    {
-      "type": {
-        "label": ",",
-        "beforeExpr": true,
-        "startsExpr": false,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null,
-        "updateContext": null
-      },
-      "start": 1372,
-      "end": 1373,
-      "loc": {
-        "start": {
-          "line": 65,
-          "column": 42
-        },
-        "end": {
-          "line": 65,
-          "column": 43
-        }
-      }
-    },
-    {
-      "type": {
-        "label": "{",
-        "beforeExpr": true,
-        "startsExpr": true,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null
-      },
-      "start": 1374,
-      "end": 1375,
-      "loc": {
-        "start": {
-          "line": 65,
-          "column": 44
-        },
-        "end": {
-          "line": 65,
-          "column": 45
-        }
-      }
-    },
-    {
-      "type": {
-        "label": "name",
-        "beforeExpr": false,
-        "startsExpr": true,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null
-      },
-      "value": "responseType",
-      "start": 1375,
-      "end": 1387,
-      "loc": {
-        "start": {
-          "line": 65,
-          "column": 45
-        },
-        "end": {
-          "line": 65,
-          "column": 57
-        }
-      }
-    },
-    {
-      "type": {
-        "label": ":",
-        "beforeExpr": true,
-        "startsExpr": false,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null,
-        "updateContext": null
-      },
-      "start": 1387,
-      "end": 1388,
-      "loc": {
-        "start": {
-          "line": 65,
-          "column": 57
-        },
-        "end": {
-          "line": 65,
-          "column": 58
-        }
-      }
-    },
-    {
-      "type": {
-        "label": "string",
-        "beforeExpr": false,
-        "startsExpr": true,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null,
-        "updateContext": null
-      },
-      "value": "xml",
-      "start": 1389,
-      "end": 1394,
-      "loc": {
-        "start": {
-          "line": 65,
-          "column": 59
-        },
-        "end": {
-          "line": 65,
-          "column": 64
-        }
-      }
-    },
-    {
-      "type": {
-        "label": "}",
-        "beforeExpr": false,
-        "startsExpr": false,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null
-      },
-      "start": 1394,
-      "end": 1395,
-      "loc": {
-        "start": {
-          "line": 65,
-          "column": 64
-        },
-        "end": {
-          "line": 65,
-          "column": 65
-        }
-      }
-    },
-    {
-      "type": {
-        "label": ")",
-        "beforeExpr": false,
-        "startsExpr": false,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null
-      },
-      "start": 1395,
-      "end": 1396,
-      "loc": {
-        "start": {
-          "line": 65,
-          "column": 65
-        },
-        "end": {
-          "line": 65,
-          "column": 66
-        }
-      }
-    },
-    {
-      "type": {
-        "label": ".",
-        "beforeExpr": false,
-        "startsExpr": false,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null,
-        "updateContext": null
-      },
-      "start": 1401,
-      "end": 1402,
-      "loc": {
-        "start": {
-          "line": 66,
-          "column": 4
-        },
-        "end": {
-          "line": 66,
-          "column": 5
-        }
-      }
-    },
-    {
-      "type": {
-        "label": "name",
-        "beforeExpr": false,
-        "startsExpr": true,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null
-      },
-      "value": "then",
-      "start": 1402,
-      "end": 1406,
-      "loc": {
-        "start": {
-          "line": 66,
-          "column": 5
-        },
-        "end": {
-          "line": 66,
-          "column": 9
-        }
-      }
-    },
-    {
-      "type": {
-        "label": "(",
-        "beforeExpr": true,
-        "startsExpr": true,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null
-      },
-      "start": 1406,
-      "end": 1407,
-      "loc": {
-        "start": {
-          "line": 66,
-          "column": 9
-        },
-        "end": {
-          "line": 66,
-          "column": 10
-        }
-      }
-    },
-    {
-      "type": {
-        "label": "(",
-        "beforeExpr": true,
-        "startsExpr": true,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null
-      },
-      "start": 1407,
-      "end": 1408,
-      "loc": {
-        "start": {
-          "line": 66,
-          "column": 10
-        },
-        "end": {
-          "line": 66,
-          "column": 11
-        }
-      }
-    },
-    {
-      "type": {
-        "label": "name",
-        "beforeExpr": false,
-        "startsExpr": true,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null
-      },
-      "value": "res",
-      "start": 1408,
-      "end": 1411,
-      "loc": {
-        "start": {
-          "line": 66,
-          "column": 11
-        },
-        "end": {
-          "line": 66,
-          "column": 14
-        }
-      }
-    },
-    {
-      "type": {
-        "label": ")",
-        "beforeExpr": false,
-        "startsExpr": false,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null
-      },
-      "start": 1411,
-      "end": 1412,
-      "loc": {
-        "start": {
-          "line": 66,
-          "column": 14
-        },
-        "end": {
-          "line": 66,
-          "column": 15
-        }
-      }
-    },
-    {
-      "type": {
-        "label": "=>",
-        "beforeExpr": true,
-        "startsExpr": false,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null,
-        "updateContext": null
-      },
-      "start": 1413,
-      "end": 1415,
-      "loc": {
-        "start": {
-          "line": 66,
-          "column": 16
-        },
-        "end": {
-          "line": 66,
-          "column": 18
-        }
-      }
-    },
-    {
-      "type": {
-        "label": "{",
-        "beforeExpr": true,
-        "startsExpr": true,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null
-      },
-      "start": 1416,
-      "end": 1417,
-      "loc": {
-        "start": {
-          "line": 66,
-          "column": 19
-        },
-        "end": {
-          "line": 66,
-          "column": 20
-        }
-      }
-    },
-    {
-      "type": {
-        "label": "return",
-        "keyword": "return",
-        "beforeExpr": true,
-        "startsExpr": false,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null,
-        "updateContext": null
-      },
-      "value": "return",
-      "start": 1424,
-      "end": 1430,
-      "loc": {
-        "start": {
-          "line": 67,
-          "column": 6
-        },
-        "end": {
-          "line": 67,
-          "column": 12
-        }
-      }
-    },
-    {
-      "type": {
-        "label": "name",
-        "beforeExpr": false,
-        "startsExpr": true,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null
-      },
-      "value": "res",
-      "start": 1431,
-      "end": 1434,
-      "loc": {
-        "start": {
-          "line": 67,
-          "column": 13
-        },
-        "end": {
-          "line": 67,
-          "column": 16
-        }
-      }
-    },
-    {
-      "type": {
-        "label": ".",
-        "beforeExpr": false,
-        "startsExpr": false,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null,
-        "updateContext": null
-      },
-      "start": 1434,
-      "end": 1435,
-      "loc": {
-        "start": {
-          "line": 67,
-          "column": 16
-        },
-        "end": {
-          "line": 67,
-          "column": 17
-        }
-      }
-    },
-    {
-      "type": {
-        "label": "name",
-        "beforeExpr": false,
-        "startsExpr": true,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null
-      },
-      "value": "data",
-      "start": 1435,
-      "end": 1439,
-      "loc": {
-        "start": {
-          "line": 67,
-          "column": 17
-        },
-        "end": {
-          "line": 67,
-          "column": 21
-        }
-      }
-    },
-    {
-      "type": {
-        "label": ";",
-        "beforeExpr": true,
-        "startsExpr": false,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null,
-        "updateContext": null
-      },
-      "start": 1439,
-      "end": 1440,
-      "loc": {
-        "start": {
-          "line": 67,
-          "column": 21
-        },
-        "end": {
-          "line": 67,
-          "column": 22
-        }
-      }
-    },
-    {
-      "type": {
-        "label": "}",
-        "beforeExpr": false,
-        "startsExpr": false,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null
-      },
-      "start": 1445,
-      "end": 1446,
-      "loc": {
-        "start": {
-          "line": 68,
-          "column": 4
-        },
-        "end": {
-          "line": 68,
-          "column": 5
-        }
-      }
-    },
-    {
-      "type": {
-        "label": ")",
-        "beforeExpr": false,
-        "startsExpr": false,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null
-      },
-      "start": 1446,
-      "end": 1447,
-      "loc": {
-        "start": {
-          "line": 68,
-          "column": 5
-        },
-        "end": {
-          "line": 68,
-          "column": 6
-        }
-      }
-    },
-    {
-      "type": {
-        "label": ";",
-        "beforeExpr": true,
-        "startsExpr": false,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null,
-        "updateContext": null
-      },
-      "start": 1447,
-      "end": 1448,
-      "loc": {
-        "start": {
-          "line": 68,
-          "column": 6
-        },
-        "end": {
-          "line": 68,
-          "column": 7
-        }
-      }
-    },
-    {
-      "type": {
-        "label": "}",
-        "beforeExpr": false,
-        "startsExpr": false,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null
-      },
-      "start": 1451,
-      "end": 1452,
-      "loc": {
-        "start": {
-          "line": 69,
-          "column": 2
-        },
-        "end": {
-          "line": 69,
-          "column": 3
-        }
-      }
-    },
-    {
-      "type": "CommentBlock",
-      "value": "*\n   * Get a single part fzp from the obsolete parts, this is for old sketches only!\n   * @param  {String} src\n   * @return {Promise} the fetch promise returns xml\n   ",
-      "start": 1455,
-      "end": 1626,
-      "loc": {
-        "start": {
-          "line": 70,
-          "column": 2
-        },
-        "end": {
-          "line": 74,
-          "column": 5
-        }
-      }
-    },
-    {
-      "type": {
-        "label": "name",
-        "beforeExpr": false,
-        "startsExpr": true,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null
-      },
-      "value": "getFzpObsolete",
-      "start": 1629,
-      "end": 1643,
-      "loc": {
-        "start": {
-          "line": 75,
-          "column": 2
-        },
-        "end": {
-          "line": 75,
-          "column": 16
-        }
-      }
-    },
-    {
-      "type": {
-        "label": "(",
-        "beforeExpr": true,
-        "startsExpr": true,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null
-      },
-      "start": 1643,
-      "end": 1644,
-      "loc": {
-        "start": {
-          "line": 75,
-          "column": 16
-        },
-        "end": {
-          "line": 75,
-          "column": 17
-        }
-      }
-    },
-    {
-      "type": {
-        "label": "name",
-        "beforeExpr": false,
-        "startsExpr": true,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null
-      },
-      "value": "src",
-      "start": 1644,
-      "end": 1647,
-      "loc": {
-        "start": {
-          "line": 75,
-          "column": 17
-        },
-        "end": {
-          "line": 75,
-          "column": 20
-        }
-      }
-    },
-    {
-      "type": {
-        "label": ")",
-        "beforeExpr": false,
-        "startsExpr": false,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null
-      },
-      "start": 1647,
-      "end": 1648,
-      "loc": {
-        "start": {
-          "line": 75,
-          "column": 20
-        },
-        "end": {
-          "line": 75,
-          "column": 21
-        }
-      }
-    },
-    {
-      "type": {
-        "label": "{",
-        "beforeExpr": true,
-        "startsExpr": true,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null
-      },
-      "start": 1649,
-      "end": 1650,
-      "loc": {
-        "start": {
-          "line": 75,
-          "column": 22
-        },
-        "end": {
-          "line": 75,
-          "column": 23
-        }
-      }
-    },
-    {
-      "type": {
-        "label": "return",
-        "keyword": "return",
-        "beforeExpr": true,
-        "startsExpr": false,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null,
-        "updateContext": null
-      },
-      "value": "return",
-      "start": 1655,
-      "end": 1661,
-      "loc": {
-        "start": {
-          "line": 76,
-          "column": 4
-        },
-        "end": {
-          "line": 76,
-          "column": 10
-        }
-      }
-    },
-    {
-      "type": {
-        "label": "name",
-        "beforeExpr": false,
-        "startsExpr": true,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null
-      },
-      "value": "axios",
-      "start": 1662,
-      "end": 1667,
-      "loc": {
-        "start": {
-          "line": 76,
-          "column": 11
-        },
-        "end": {
-          "line": 76,
-          "column": 16
-        }
-      }
-    },
-    {
-      "type": {
-        "label": ".",
-        "beforeExpr": false,
-        "startsExpr": false,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null,
-        "updateContext": null
-      },
-      "start": 1667,
-      "end": 1668,
-      "loc": {
-        "start": {
-          "line": 76,
-          "column": 16
-        },
-        "end": {
-          "line": 76,
-          "column": 17
-        }
-      }
-    },
-    {
-      "type": {
-        "label": "name",
-        "beforeExpr": false,
-        "startsExpr": true,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null
-      },
-      "value": "get",
-      "start": 1668,
-      "end": 1671,
-      "loc": {
-        "start": {
-          "line": 76,
-          "column": 17
-        },
-        "end": {
-          "line": 76,
-          "column": 20
-        }
-      }
-    },
-    {
-      "type": {
-        "label": "(",
-        "beforeExpr": true,
-        "startsExpr": true,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null
-      },
-      "start": 1671,
-      "end": 1672,
-      "loc": {
-        "start": {
-          "line": 76,
-          "column": 20
-        },
-        "end": {
-          "line": 76,
-          "column": 21
-        }
-      }
-    },
-    {
-      "type": {
-        "label": "this",
-        "keyword": "this",
-        "beforeExpr": false,
-        "startsExpr": true,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null,
-        "updateContext": null
-      },
-      "value": "this",
-      "start": 1672,
-      "end": 1676,
-      "loc": {
-        "start": {
-          "line": 76,
-          "column": 21
-        },
-        "end": {
-          "line": 76,
-          "column": 25
-        }
-      }
-    },
-    {
-      "type": {
-        "label": ".",
-        "beforeExpr": false,
-        "startsExpr": false,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null,
-        "updateContext": null
-      },
-      "start": 1676,
-      "end": 1677,
-      "loc": {
-        "start": {
-          "line": 76,
-          "column": 25
-        },
-        "end": {
-          "line": 76,
-          "column": 26
-        }
-      }
-    },
-    {
-      "type": {
-        "label": "name",
-        "beforeExpr": false,
-        "startsExpr": true,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null
-      },
-      "value": "url",
-      "start": 1677,
-      "end": 1680,
-      "loc": {
-        "start": {
-          "line": 76,
-          "column": 26
-        },
-        "end": {
-          "line": 76,
-          "column": 29
-        }
-      }
-    },
-    {
-      "type": {
-        "label": "+/-",
-        "beforeExpr": true,
-        "startsExpr": true,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": true,
-        "postfix": false,
-        "binop": 9,
-        "updateContext": null
-      },
-      "value": "+",
-      "start": 1680,
-      "end": 1681,
-      "loc": {
-        "start": {
-          "line": 76,
-          "column": 29
-        },
-        "end": {
-          "line": 76,
-          "column": 30
-        }
-      }
-    },
-    {
-      "type": {
-        "label": "string",
-        "beforeExpr": false,
-        "startsExpr": true,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null,
-        "updateContext": null
-      },
-      "value": "/obsolete/",
-      "start": 1681,
-      "end": 1693,
-      "loc": {
-        "start": {
-          "line": 76,
-          "column": 30
-        },
-        "end": {
-          "line": 76,
-          "column": 42
-        }
-      }
-    },
-    {
-      "type": {
-        "label": "+/-",
-        "beforeExpr": true,
-        "startsExpr": true,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": true,
-        "postfix": false,
-        "binop": 9,
-        "updateContext": null
-      },
-      "value": "+",
-      "start": 1693,
-      "end": 1694,
-      "loc": {
-        "start": {
-          "line": 76,
-          "column": 42
-        },
-        "end": {
-          "line": 76,
-          "column": 43
-        }
-      }
-    },
-    {
-      "type": {
-        "label": "name",
-        "beforeExpr": false,
-        "startsExpr": true,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null
-      },
-      "value": "src",
-      "start": 1694,
-      "end": 1697,
-      "loc": {
-        "start": {
-          "line": 76,
-          "column": 43
-        },
-        "end": {
-          "line": 76,
-          "column": 46
-        }
-      }
-    },
-    {
-      "type": {
-        "label": ",",
-        "beforeExpr": true,
-        "startsExpr": false,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null,
-        "updateContext": null
-      },
-      "start": 1697,
-      "end": 1698,
-      "loc": {
-        "start": {
-          "line": 76,
-          "column": 46
-        },
-        "end": {
-          "line": 76,
-          "column": 47
-        }
-      }
-    },
-    {
-      "type": {
-        "label": "{",
-        "beforeExpr": true,
-        "startsExpr": true,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null
-      },
-      "start": 1699,
-      "end": 1700,
-      "loc": {
-        "start": {
-          "line": 76,
-          "column": 48
-        },
-        "end": {
-          "line": 76,
-          "column": 49
-        }
-      }
-    },
-    {
-      "type": {
-        "label": "name",
-        "beforeExpr": false,
-        "startsExpr": true,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null
-      },
-      "value": "responseType",
-      "start": 1700,
-      "end": 1712,
-      "loc": {
-        "start": {
-          "line": 76,
-          "column": 49
-        },
-        "end": {
-          "line": 76,
-          "column": 61
-        }
-      }
-    },
-    {
-      "type": {
-        "label": ":",
-        "beforeExpr": true,
-        "startsExpr": false,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null,
-        "updateContext": null
-      },
-      "start": 1712,
-      "end": 1713,
-      "loc": {
-        "start": {
-          "line": 76,
-          "column": 61
-        },
-        "end": {
-          "line": 76,
-          "column": 62
-        }
-      }
-    },
-    {
-      "type": {
-        "label": "string",
-        "beforeExpr": false,
-        "startsExpr": true,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null,
-        "updateContext": null
-      },
-      "value": "xml",
-      "start": 1714,
-      "end": 1719,
-      "loc": {
-        "start": {
-          "line": 76,
-          "column": 63
-        },
-        "end": {
-          "line": 76,
-          "column": 68
-        }
-      }
-    },
-    {
-      "type": {
-        "label": "}",
-        "beforeExpr": false,
-        "startsExpr": false,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null
-      },
-      "start": 1719,
-      "end": 1720,
-      "loc": {
-        "start": {
-          "line": 76,
-          "column": 68
-        },
-        "end": {
-          "line": 76,
-          "column": 69
-        }
-      }
-    },
-    {
-      "type": {
-        "label": ")",
-        "beforeExpr": false,
-        "startsExpr": false,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null
-      },
-      "start": 1720,
-      "end": 1721,
-      "loc": {
-        "start": {
-          "line": 76,
-          "column": 69
-        },
-        "end": {
-          "line": 76,
-          "column": 70
-        }
-      }
-    },
-    {
-      "type": {
-        "label": ".",
-        "beforeExpr": false,
-        "startsExpr": false,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null,
-        "updateContext": null
-      },
-      "start": 1726,
-      "end": 1727,
-      "loc": {
-        "start": {
-          "line": 77,
-          "column": 4
-        },
-        "end": {
-          "line": 77,
-          "column": 5
-        }
-      }
-    },
-    {
-      "type": {
-        "label": "name",
-        "beforeExpr": false,
-        "startsExpr": true,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null
-      },
-      "value": "then",
-      "start": 1727,
-      "end": 1731,
-      "loc": {
-        "start": {
-          "line": 77,
-          "column": 5
-        },
-        "end": {
-          "line": 77,
-          "column": 9
-        }
-      }
-    },
-    {
-      "type": {
-        "label": "(",
-        "beforeExpr": true,
-        "startsExpr": true,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null
-      },
-      "start": 1731,
-      "end": 1732,
-      "loc": {
-        "start": {
-          "line": 77,
-          "column": 9
-        },
-        "end": {
-          "line": 77,
-          "column": 10
-        }
-      }
-    },
-    {
-      "type": {
-        "label": "(",
-        "beforeExpr": true,
-        "startsExpr": true,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null
-      },
-      "start": 1732,
-      "end": 1733,
-      "loc": {
-        "start": {
-          "line": 77,
-          "column": 10
-        },
-        "end": {
-          "line": 77,
-          "column": 11
-        }
-      }
-    },
-    {
-      "type": {
-        "label": "name",
-        "beforeExpr": false,
-        "startsExpr": true,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null
-      },
-      "value": "res",
-      "start": 1733,
-      "end": 1736,
-      "loc": {
-        "start": {
-          "line": 77,
-          "column": 11
-        },
-        "end": {
-          "line": 77,
-          "column": 14
-        }
-      }
-    },
-    {
-      "type": {
-        "label": ")",
-        "beforeExpr": false,
-        "startsExpr": false,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null
-      },
-      "start": 1736,
-      "end": 1737,
-      "loc": {
-        "start": {
-          "line": 77,
-          "column": 14
-        },
-        "end": {
-          "line": 77,
-          "column": 15
-        }
-      }
-    },
-    {
-      "type": {
-        "label": "=>",
-        "beforeExpr": true,
-        "startsExpr": false,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null,
-        "updateContext": null
-      },
-      "start": 1738,
-      "end": 1740,
-      "loc": {
-        "start": {
-          "line": 77,
-          "column": 16
-        },
-        "end": {
-          "line": 77,
-          "column": 18
-        }
-      }
-    },
-    {
-      "type": {
-        "label": "{",
-        "beforeExpr": true,
-        "startsExpr": true,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null
-      },
-      "start": 1741,
-      "end": 1742,
-      "loc": {
-        "start": {
-          "line": 77,
-          "column": 19
-        },
-        "end": {
-          "line": 77,
-          "column": 20
-        }
-      }
-    },
-    {
-      "type": {
-        "label": "return",
-        "keyword": "return",
-        "beforeExpr": true,
-        "startsExpr": false,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null,
-        "updateContext": null
-      },
-      "value": "return",
-      "start": 1749,
-      "end": 1755,
-      "loc": {
-        "start": {
-          "line": 78,
-          "column": 6
-        },
-        "end": {
-          "line": 78,
-          "column": 12
-        }
-      }
-    },
-    {
-      "type": {
-        "label": "name",
-        "beforeExpr": false,
-        "startsExpr": true,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null
-      },
-      "value": "res",
-      "start": 1756,
-      "end": 1759,
-      "loc": {
-        "start": {
-          "line": 78,
-          "column": 13
-        },
-        "end": {
-          "line": 78,
-          "column": 16
-        }
-      }
-    },
-    {
-      "type": {
-        "label": ".",
-        "beforeExpr": false,
-        "startsExpr": false,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null,
-        "updateContext": null
-      },
-      "start": 1759,
-      "end": 1760,
-      "loc": {
-        "start": {
-          "line": 78,
-          "column": 16
-        },
-        "end": {
-          "line": 78,
-          "column": 17
-        }
-      }
-    },
-    {
-      "type": {
-        "label": "name",
-        "beforeExpr": false,
-        "startsExpr": true,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null
-      },
-      "value": "data",
-      "start": 1760,
-      "end": 1764,
-      "loc": {
-        "start": {
-          "line": 78,
-          "column": 17
-        },
-        "end": {
-          "line": 78,
-          "column": 21
-        }
-      }
-    },
-    {
-      "type": {
-        "label": ";",
-        "beforeExpr": true,
-        "startsExpr": false,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null,
-        "updateContext": null
-      },
-      "start": 1764,
-      "end": 1765,
-      "loc": {
-        "start": {
-          "line": 78,
-          "column": 21
-        },
-        "end": {
-          "line": 78,
-          "column": 22
-        }
-      }
-    },
-    {
-      "type": {
-        "label": "}",
-        "beforeExpr": false,
-        "startsExpr": false,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null
-      },
-      "start": 1770,
-      "end": 1771,
-      "loc": {
-        "start": {
-          "line": 79,
-          "column": 4
-        },
-        "end": {
-          "line": 79,
-          "column": 5
-        }
-      }
-    },
-    {
-      "type": {
-        "label": ")",
-        "beforeExpr": false,
-        "startsExpr": false,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null
-      },
-      "start": 1771,
-      "end": 1772,
-      "loc": {
-        "start": {
-          "line": 79,
-          "column": 5
-        },
-        "end": {
-          "line": 79,
-          "column": 6
-        }
-      }
-    },
-    {
-      "type": {
-        "label": ";",
-        "beforeExpr": true,
-        "startsExpr": false,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null,
-        "updateContext": null
-      },
-      "start": 1772,
-      "end": 1773,
-      "loc": {
-        "start": {
-          "line": 79,
-          "column": 6
-        },
-        "end": {
-          "line": 79,
-          "column": 7
-        }
-      }
-    },
-    {
-      "type": {
-        "label": "}",
-        "beforeExpr": false,
-        "startsExpr": false,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null
-      },
-      "start": 1776,
-      "end": 1777,
-      "loc": {
-        "start": {
-          "line": 80,
-          "column": 2
-        },
-        "end": {
-          "line": 80,
-          "column": 3
-        }
-      }
-    },
-    {
-      "type": "CommentBlock",
-      "value": "*\n   * Get a single part svg and response the svg as a string\n   * @param  {String} src\n   * @return {Promise} the fetch promise\n   ",
-      "start": 1782,
-      "end": 1918,
-      "loc": {
-        "start": {
-          "line": 83,
-          "column": 2
-        },
-        "end": {
-          "line": 87,
-          "column": 5
-        }
-      }
-    },
-    {
-      "type": {
-        "label": "name",
-        "beforeExpr": false,
-        "startsExpr": true,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null
-      },
-      "value": "getSvg",
       "start": 1922,
       "end": 1928,
       "loc": {
         "start": {
-          "line": 88,
-          "column": 3
+          "line": 79,
+          "column": 26
         },
         "end": {
-          "line": 88,
-          "column": 9
+          "line": 79,
+          "column": 32
         }
       }
     },
     {
       "type": {
-        "label": "(",
+        "label": "${",
         "beforeExpr": true,
         "startsExpr": true,
         "rightAssociative": false,
@@ -13029,15 +14908,15 @@
         "binop": null
       },
       "start": 1928,
-      "end": 1929,
+      "end": 1930,
       "loc": {
         "start": {
-          "line": 88,
-          "column": 9
+          "line": 79,
+          "column": 32
         },
         "end": {
-          "line": 88,
-          "column": 10
+          "line": 79,
+          "column": 34
         }
       }
     },
@@ -13054,22 +14933,22 @@
         "binop": null
       },
       "value": "src",
-      "start": 1929,
-      "end": 1932,
+      "start": 1930,
+      "end": 1933,
       "loc": {
         "start": {
-          "line": 88,
-          "column": 10
+          "line": 79,
+          "column": 34
         },
         "end": {
-          "line": 88,
-          "column": 13
+          "line": 79,
+          "column": 37
         }
       }
     },
     {
       "type": {
-        "label": ")",
+        "label": "}",
         "beforeExpr": false,
         "startsExpr": false,
         "rightAssociative": false,
@@ -13079,23 +14958,50 @@
         "postfix": false,
         "binop": null
       },
-      "start": 1932,
-      "end": 1933,
+      "start": 1933,
+      "end": 1934,
       "loc": {
         "start": {
-          "line": 88,
-          "column": 13
+          "line": 79,
+          "column": 37
         },
         "end": {
-          "line": 88,
-          "column": 14
+          "line": 79,
+          "column": 38
         }
       }
     },
     {
       "type": {
-        "label": "{",
-        "beforeExpr": true,
+        "label": "template",
+        "beforeExpr": false,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null,
+        "updateContext": null
+      },
+      "value": "",
+      "start": 1934,
+      "end": 1934,
+      "loc": {
+        "start": {
+          "line": 79,
+          "column": 38
+        },
+        "end": {
+          "line": 79,
+          "column": 38
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "`",
+        "beforeExpr": false,
         "startsExpr": true,
         "rightAssociative": false,
         "isLoop": false,
@@ -13108,19 +15014,18 @@
       "end": 1935,
       "loc": {
         "start": {
-          "line": 88,
-          "column": 15
+          "line": 79,
+          "column": 38
         },
         "end": {
-          "line": 88,
-          "column": 16
+          "line": 79,
+          "column": 39
         }
       }
     },
     {
       "type": {
-        "label": "return",
-        "keyword": "return",
+        "label": ",",
         "beforeExpr": true,
         "startsExpr": false,
         "rightAssociative": false,
@@ -13131,17 +15036,41 @@
         "binop": null,
         "updateContext": null
       },
-      "value": "return",
-      "start": 1941,
-      "end": 1947,
+      "start": 1935,
+      "end": 1936,
       "loc": {
         "start": {
-          "line": 89,
-          "column": 5
+          "line": 79,
+          "column": 39
         },
         "end": {
-          "line": 89,
-          "column": 11
+          "line": 79,
+          "column": 40
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "{",
+        "beforeExpr": true,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "start": 1937,
+      "end": 1938,
+      "loc": {
+        "start": {
+          "line": 79,
+          "column": 41
+        },
+        "end": {
+          "line": 79,
+          "column": 42
         }
       }
     },
@@ -13157,24 +15086,24 @@
         "postfix": false,
         "binop": null
       },
-      "value": "axios",
-      "start": 1948,
-      "end": 1953,
+      "value": "responseType",
+      "start": 1938,
+      "end": 1950,
       "loc": {
         "start": {
-          "line": 89,
-          "column": 12
+          "line": 79,
+          "column": 42
         },
         "end": {
-          "line": 89,
-          "column": 17
+          "line": 79,
+          "column": 54
         }
       }
     },
     {
       "type": {
-        "label": ".",
-        "beforeExpr": false,
+        "label": ":",
+        "beforeExpr": true,
         "startsExpr": false,
         "rightAssociative": false,
         "isLoop": false,
@@ -13184,22 +15113,22 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 1953,
-      "end": 1954,
+      "start": 1950,
+      "end": 1951,
       "loc": {
         "start": {
-          "line": 89,
-          "column": 17
+          "line": 79,
+          "column": 54
         },
         "end": {
-          "line": 89,
-          "column": 18
+          "line": 79,
+          "column": 55
         }
       }
     },
     {
       "type": {
-        "label": "name",
+        "label": "string",
         "beforeExpr": false,
         "startsExpr": true,
         "rightAssociative": false,
@@ -13207,27 +15136,28 @@
         "isAssign": false,
         "prefix": false,
         "postfix": false,
-        "binop": null
+        "binop": null,
+        "updateContext": null
       },
-      "value": "get",
-      "start": 1954,
+      "value": "xml",
+      "start": 1952,
       "end": 1957,
       "loc": {
         "start": {
-          "line": 89,
-          "column": 18
+          "line": 79,
+          "column": 56
         },
         "end": {
-          "line": 89,
-          "column": 21
+          "line": 79,
+          "column": 61
         }
       }
     },
     {
       "type": {
-        "label": "(",
-        "beforeExpr": true,
-        "startsExpr": true,
+        "label": "}",
+        "beforeExpr": false,
+        "startsExpr": false,
         "rightAssociative": false,
         "isLoop": false,
         "isAssign": false,
@@ -13239,40 +15169,37 @@
       "end": 1958,
       "loc": {
         "start": {
-          "line": 89,
-          "column": 21
+          "line": 79,
+          "column": 61
         },
         "end": {
-          "line": 89,
-          "column": 22
+          "line": 79,
+          "column": 62
         }
       }
     },
     {
       "type": {
-        "label": "this",
-        "keyword": "this",
+        "label": ")",
         "beforeExpr": false,
-        "startsExpr": true,
+        "startsExpr": false,
         "rightAssociative": false,
         "isLoop": false,
         "isAssign": false,
         "prefix": false,
         "postfix": false,
-        "binop": null,
-        "updateContext": null
+        "binop": null
       },
-      "value": "this",
       "start": 1958,
-      "end": 1962,
+      "end": 1959,
       "loc": {
         "start": {
-          "line": 89,
-          "column": 22
+          "line": 79,
+          "column": 62
         },
         "end": {
-          "line": 89,
-          "column": 26
+          "line": 79,
+          "column": 63
         }
       }
     },
@@ -13293,351 +15220,12 @@
       "end": 1963,
       "loc": {
         "start": {
-          "line": 89,
-          "column": 26
+          "line": 80,
+          "column": 2
         },
         "end": {
-          "line": 89,
-          "column": 27
-        }
-      }
-    },
-    {
-      "type": {
-        "label": "name",
-        "beforeExpr": false,
-        "startsExpr": true,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null
-      },
-      "value": "url",
-      "start": 1963,
-      "end": 1966,
-      "loc": {
-        "start": {
-          "line": 89,
-          "column": 27
-        },
-        "end": {
-          "line": 89,
-          "column": 30
-        }
-      }
-    },
-    {
-      "type": {
-        "label": "+/-",
-        "beforeExpr": true,
-        "startsExpr": true,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": true,
-        "postfix": false,
-        "binop": 9,
-        "updateContext": null
-      },
-      "value": "+",
-      "start": 1966,
-      "end": 1967,
-      "loc": {
-        "start": {
-          "line": 89,
-          "column": 30
-        },
-        "end": {
-          "line": 89,
-          "column": 31
-        }
-      }
-    },
-    {
-      "type": {
-        "label": "string",
-        "beforeExpr": false,
-        "startsExpr": true,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null,
-        "updateContext": null
-      },
-      "value": "/svg/",
-      "start": 1967,
-      "end": 1974,
-      "loc": {
-        "start": {
-          "line": 89,
-          "column": 31
-        },
-        "end": {
-          "line": 89,
-          "column": 38
-        }
-      }
-    },
-    {
-      "type": {
-        "label": "+/-",
-        "beforeExpr": true,
-        "startsExpr": true,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": true,
-        "postfix": false,
-        "binop": 9,
-        "updateContext": null
-      },
-      "value": "+",
-      "start": 1974,
-      "end": 1975,
-      "loc": {
-        "start": {
-          "line": 89,
-          "column": 38
-        },
-        "end": {
-          "line": 89,
-          "column": 39
-        }
-      }
-    },
-    {
-      "type": {
-        "label": "name",
-        "beforeExpr": false,
-        "startsExpr": true,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null
-      },
-      "value": "src",
-      "start": 1975,
-      "end": 1978,
-      "loc": {
-        "start": {
-          "line": 89,
-          "column": 39
-        },
-        "end": {
-          "line": 89,
-          "column": 42
-        }
-      }
-    },
-    {
-      "type": {
-        "label": ",",
-        "beforeExpr": true,
-        "startsExpr": false,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null,
-        "updateContext": null
-      },
-      "start": 1978,
-      "end": 1979,
-      "loc": {
-        "start": {
-          "line": 89,
-          "column": 42
-        },
-        "end": {
-          "line": 89,
-          "column": 43
-        }
-      }
-    },
-    {
-      "type": {
-        "label": "{",
-        "beforeExpr": true,
-        "startsExpr": true,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null
-      },
-      "start": 1980,
-      "end": 1981,
-      "loc": {
-        "start": {
-          "line": 89,
-          "column": 44
-        },
-        "end": {
-          "line": 89,
-          "column": 45
-        }
-      }
-    },
-    {
-      "type": {
-        "label": "name",
-        "beforeExpr": false,
-        "startsExpr": true,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null
-      },
-      "value": "responseType",
-      "start": 1981,
-      "end": 1993,
-      "loc": {
-        "start": {
-          "line": 89,
-          "column": 45
-        },
-        "end": {
-          "line": 89,
-          "column": 57
-        }
-      }
-    },
-    {
-      "type": {
-        "label": ":",
-        "beforeExpr": true,
-        "startsExpr": false,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null,
-        "updateContext": null
-      },
-      "start": 1993,
-      "end": 1994,
-      "loc": {
-        "start": {
-          "line": 89,
-          "column": 57
-        },
-        "end": {
-          "line": 89,
-          "column": 58
-        }
-      }
-    },
-    {
-      "type": {
-        "label": "string",
-        "beforeExpr": false,
-        "startsExpr": true,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null,
-        "updateContext": null
-      },
-      "value": "xml",
-      "start": 1995,
-      "end": 2000,
-      "loc": {
-        "start": {
-          "line": 89,
-          "column": 59
-        },
-        "end": {
-          "line": 89,
-          "column": 64
-        }
-      }
-    },
-    {
-      "type": {
-        "label": "}",
-        "beforeExpr": false,
-        "startsExpr": false,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null
-      },
-      "start": 2000,
-      "end": 2001,
-      "loc": {
-        "start": {
-          "line": 89,
-          "column": 64
-        },
-        "end": {
-          "line": 89,
-          "column": 65
-        }
-      }
-    },
-    {
-      "type": {
-        "label": ")",
-        "beforeExpr": false,
-        "startsExpr": false,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null
-      },
-      "start": 2001,
-      "end": 2002,
-      "loc": {
-        "start": {
-          "line": 89,
-          "column": 65
-        },
-        "end": {
-          "line": 89,
-          "column": 66
-        }
-      }
-    },
-    {
-      "type": {
-        "label": ".",
-        "beforeExpr": false,
-        "startsExpr": false,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null,
-        "updateContext": null
-      },
-      "start": 2008,
-      "end": 2009,
-      "loc": {
-        "start": {
-          "line": 90,
-          "column": 5
-        },
-        "end": {
-          "line": 90,
-          "column": 6
+          "line": 80,
+          "column": 3
         }
       }
     },
@@ -13654,16 +15242,16 @@
         "binop": null
       },
       "value": "then",
-      "start": 2009,
-      "end": 2013,
+      "start": 1963,
+      "end": 1967,
       "loc": {
         "start": {
-          "line": 90,
-          "column": 6
+          "line": 80,
+          "column": 3
         },
         "end": {
-          "line": 90,
-          "column": 10
+          "line": 80,
+          "column": 7
         }
       }
     },
@@ -13679,16 +15267,16 @@
         "postfix": false,
         "binop": null
       },
-      "start": 2013,
-      "end": 2014,
+      "start": 1967,
+      "end": 1968,
       "loc": {
         "start": {
-          "line": 90,
-          "column": 10
+          "line": 80,
+          "column": 7
         },
         "end": {
-          "line": 90,
-          "column": 11
+          "line": 80,
+          "column": 8
         }
       }
     },
@@ -13704,16 +15292,16 @@
         "postfix": false,
         "binop": null
       },
-      "start": 2014,
-      "end": 2015,
+      "start": 1968,
+      "end": 1969,
       "loc": {
         "start": {
-          "line": 90,
-          "column": 11
+          "line": 80,
+          "column": 8
         },
         "end": {
-          "line": 90,
-          "column": 12
+          "line": 80,
+          "column": 9
         }
       }
     },
@@ -13730,16 +15318,16 @@
         "binop": null
       },
       "value": "res",
-      "start": 2015,
-      "end": 2018,
+      "start": 1969,
+      "end": 1972,
       "loc": {
         "start": {
-          "line": 90,
-          "column": 12
+          "line": 80,
+          "column": 9
         },
         "end": {
-          "line": 90,
-          "column": 15
+          "line": 80,
+          "column": 12
         }
       }
     },
@@ -13755,16 +15343,16 @@
         "postfix": false,
         "binop": null
       },
-      "start": 2018,
-      "end": 2019,
+      "start": 1972,
+      "end": 1973,
       "loc": {
         "start": {
-          "line": 90,
-          "column": 15
+          "line": 80,
+          "column": 12
         },
         "end": {
-          "line": 90,
-          "column": 16
+          "line": 80,
+          "column": 13
         }
       }
     },
@@ -13781,392 +15369,16 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 2020,
-      "end": 2022,
+      "start": 1974,
+      "end": 1976,
       "loc": {
         "start": {
-          "line": 90,
-          "column": 17
-        },
-        "end": {
-          "line": 90,
-          "column": 19
-        }
-      }
-    },
-    {
-      "type": {
-        "label": "{",
-        "beforeExpr": true,
-        "startsExpr": true,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null
-      },
-      "start": 2023,
-      "end": 2024,
-      "loc": {
-        "start": {
-          "line": 90,
-          "column": 20
-        },
-        "end": {
-          "line": 90,
-          "column": 21
-        }
-      }
-    },
-    {
-      "type": {
-        "label": "return",
-        "keyword": "return",
-        "beforeExpr": true,
-        "startsExpr": false,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null,
-        "updateContext": null
-      },
-      "value": "return",
-      "start": 2032,
-      "end": 2038,
-      "loc": {
-        "start": {
-          "line": 91,
-          "column": 7
-        },
-        "end": {
-          "line": 91,
-          "column": 13
-        }
-      }
-    },
-    {
-      "type": {
-        "label": "name",
-        "beforeExpr": false,
-        "startsExpr": true,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null
-      },
-      "value": "res",
-      "start": 2039,
-      "end": 2042,
-      "loc": {
-        "start": {
-          "line": 91,
+          "line": 80,
           "column": 14
         },
         "end": {
-          "line": 91,
-          "column": 17
-        }
-      }
-    },
-    {
-      "type": {
-        "label": ".",
-        "beforeExpr": false,
-        "startsExpr": false,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null,
-        "updateContext": null
-      },
-      "start": 2042,
-      "end": 2043,
-      "loc": {
-        "start": {
-          "line": 91,
-          "column": 17
-        },
-        "end": {
-          "line": 91,
-          "column": 18
-        }
-      }
-    },
-    {
-      "type": {
-        "label": "name",
-        "beforeExpr": false,
-        "startsExpr": true,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null
-      },
-      "value": "data",
-      "start": 2043,
-      "end": 2047,
-      "loc": {
-        "start": {
-          "line": 91,
-          "column": 18
-        },
-        "end": {
-          "line": 91,
-          "column": 22
-        }
-      }
-    },
-    {
-      "type": {
-        "label": ";",
-        "beforeExpr": true,
-        "startsExpr": false,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null,
-        "updateContext": null
-      },
-      "start": 2047,
-      "end": 2048,
-      "loc": {
-        "start": {
-          "line": 91,
-          "column": 22
-        },
-        "end": {
-          "line": 91,
-          "column": 23
-        }
-      }
-    },
-    {
-      "type": {
-        "label": "}",
-        "beforeExpr": false,
-        "startsExpr": false,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null
-      },
-      "start": 2054,
-      "end": 2055,
-      "loc": {
-        "start": {
-          "line": 92,
-          "column": 5
-        },
-        "end": {
-          "line": 92,
-          "column": 6
-        }
-      }
-    },
-    {
-      "type": {
-        "label": ")",
-        "beforeExpr": false,
-        "startsExpr": false,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null
-      },
-      "start": 2055,
-      "end": 2056,
-      "loc": {
-        "start": {
-          "line": 92,
-          "column": 6
-        },
-        "end": {
-          "line": 92,
-          "column": 7
-        }
-      }
-    },
-    {
-      "type": {
-        "label": ";",
-        "beforeExpr": true,
-        "startsExpr": false,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null,
-        "updateContext": null
-      },
-      "start": 2056,
-      "end": 2057,
-      "loc": {
-        "start": {
-          "line": 92,
-          "column": 7
-        },
-        "end": {
-          "line": 92,
-          "column": 8
-        }
-      }
-    },
-    {
-      "type": {
-        "label": "}",
-        "beforeExpr": false,
-        "startsExpr": false,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null
-      },
-      "start": 2061,
-      "end": 2062,
-      "loc": {
-        "start": {
-          "line": 93,
-          "column": 3
-        },
-        "end": {
-          "line": 93,
-          "column": 4
-        }
-      }
-    },
-    {
-      "type": "CommentBlock",
-      "value": "*\n    * Get a single part svg from the core parts as svg-string\n    * @param  {String} src\n    * @return {Promise} the fetch promise returns xml\n    ",
-      "start": 2066,
-      "end": 2219,
-      "loc": {
-        "start": {
-          "line": 94,
-          "column": 3
-        },
-        "end": {
-          "line": 98,
-          "column": 6
-        }
-      }
-    },
-    {
-      "type": {
-        "label": "name",
-        "beforeExpr": false,
-        "startsExpr": true,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null
-      },
-      "value": "getSvgCore",
-      "start": 2222,
-      "end": 2232,
-      "loc": {
-        "start": {
-          "line": 99,
-          "column": 2
-        },
-        "end": {
-          "line": 99,
-          "column": 12
-        }
-      }
-    },
-    {
-      "type": {
-        "label": "(",
-        "beforeExpr": true,
-        "startsExpr": true,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null
-      },
-      "start": 2232,
-      "end": 2233,
-      "loc": {
-        "start": {
-          "line": 99,
-          "column": 12
-        },
-        "end": {
-          "line": 99,
-          "column": 13
-        }
-      }
-    },
-    {
-      "type": {
-        "label": "name",
-        "beforeExpr": false,
-        "startsExpr": true,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null
-      },
-      "value": "src",
-      "start": 2233,
-      "end": 2236,
-      "loc": {
-        "start": {
-          "line": 99,
-          "column": 13
-        },
-        "end": {
-          "line": 99,
+          "line": 80,
           "column": 16
-        }
-      }
-    },
-    {
-      "type": {
-        "label": ")",
-        "beforeExpr": false,
-        "startsExpr": false,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null
-      },
-      "start": 2236,
-      "end": 2237,
-      "loc": {
-        "start": {
-          "line": 99,
-          "column": 16
-        },
-        "end": {
-          "line": 99,
-          "column": 17
         }
       }
     },
@@ -14182,16 +15394,16 @@
         "postfix": false,
         "binop": null
       },
-      "start": 2238,
-      "end": 2239,
+      "start": 1977,
+      "end": 1978,
       "loc": {
         "start": {
-          "line": 99,
-          "column": 18
+          "line": 80,
+          "column": 17
         },
         "end": {
-          "line": 99,
-          "column": 19
+          "line": 80,
+          "column": 18
         }
       }
     },
@@ -14210,15 +15422,15 @@
         "updateContext": null
       },
       "value": "return",
-      "start": 2244,
-      "end": 2250,
+      "start": 1983,
+      "end": 1989,
       "loc": {
         "start": {
-          "line": 100,
+          "line": 81,
           "column": 4
         },
         "end": {
-          "line": 100,
+          "line": 81,
           "column": 10
         }
       }
@@ -14235,17 +15447,17 @@
         "postfix": false,
         "binop": null
       },
-      "value": "axios",
-      "start": 2251,
-      "end": 2256,
+      "value": "Promise",
+      "start": 1990,
+      "end": 1997,
       "loc": {
         "start": {
-          "line": 100,
+          "line": 81,
           "column": 11
         },
         "end": {
-          "line": 100,
-          "column": 16
+          "line": 81,
+          "column": 18
         }
       }
     },
@@ -14262,16 +15474,16 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 2256,
-      "end": 2257,
+      "start": 1997,
+      "end": 1998,
       "loc": {
         "start": {
-          "line": 100,
-          "column": 16
+          "line": 81,
+          "column": 18
         },
         "end": {
-          "line": 100,
-          "column": 17
+          "line": 81,
+          "column": 19
         }
       }
     },
@@ -14287,17 +15499,17 @@
         "postfix": false,
         "binop": null
       },
-      "value": "get",
-      "start": 2257,
-      "end": 2260,
+      "value": "resolve",
+      "start": 1998,
+      "end": 2005,
       "loc": {
         "start": {
-          "line": 100,
-          "column": 17
+          "line": 81,
+          "column": 19
         },
         "end": {
-          "line": 100,
-          "column": 20
+          "line": 81,
+          "column": 26
         }
       }
     },
@@ -14313,23 +15525,22 @@
         "postfix": false,
         "binop": null
       },
-      "start": 2260,
-      "end": 2261,
+      "start": 2005,
+      "end": 2006,
       "loc": {
         "start": {
-          "line": 100,
-          "column": 20
+          "line": 81,
+          "column": 26
         },
         "end": {
-          "line": 100,
-          "column": 21
+          "line": 81,
+          "column": 27
         }
       }
     },
     {
       "type": {
-        "label": "this",
-        "keyword": "this",
+        "label": "name",
         "beforeExpr": false,
         "startsExpr": true,
         "rightAssociative": false,
@@ -14337,20 +15548,19 @@
         "isAssign": false,
         "prefix": false,
         "postfix": false,
-        "binop": null,
-        "updateContext": null
+        "binop": null
       },
-      "value": "this",
-      "start": 2261,
-      "end": 2265,
+      "value": "res",
+      "start": 2006,
+      "end": 2009,
       "loc": {
         "start": {
-          "line": 100,
-          "column": 21
+          "line": 81,
+          "column": 27
         },
         "end": {
-          "line": 100,
-          "column": 25
+          "line": 81,
+          "column": 30
         }
       }
     },
@@ -14367,16 +15577,16 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 2265,
-      "end": 2266,
+      "start": 2009,
+      "end": 2010,
       "loc": {
         "start": {
-          "line": 100,
-          "column": 25
+          "line": 81,
+          "column": 30
         },
         "end": {
-          "line": 100,
-          "column": 26
+          "line": 81,
+          "column": 31
         }
       }
     },
@@ -14392,52 +15602,50 @@
         "postfix": false,
         "binop": null
       },
-      "value": "url",
-      "start": 2266,
-      "end": 2269,
+      "value": "data",
+      "start": 2010,
+      "end": 2014,
       "loc": {
         "start": {
-          "line": 100,
-          "column": 26
+          "line": 81,
+          "column": 31
         },
         "end": {
-          "line": 100,
-          "column": 29
+          "line": 81,
+          "column": 35
         }
       }
     },
     {
       "type": {
-        "label": "+/-",
-        "beforeExpr": true,
-        "startsExpr": true,
+        "label": ")",
+        "beforeExpr": false,
+        "startsExpr": false,
         "rightAssociative": false,
         "isLoop": false,
         "isAssign": false,
-        "prefix": true,
+        "prefix": false,
         "postfix": false,
-        "binop": 9,
-        "updateContext": null
+        "binop": null
       },
-      "value": "+",
-      "start": 2269,
-      "end": 2270,
+      "start": 2014,
+      "end": 2015,
       "loc": {
         "start": {
-          "line": 100,
-          "column": 29
+          "line": 81,
+          "column": 35
         },
         "end": {
-          "line": 100,
-          "column": 30
+          "line": 81,
+          "column": 36
         }
       }
     },
     {
       "type": {
-        "label": "string",
-        "beforeExpr": false,
-        "startsExpr": true,
+        "label": ";",
+        "beforeExpr": true,
+        "startsExpr": false,
         "rightAssociative": false,
         "isLoop": false,
         "isAssign": false,
@@ -14446,44 +15654,292 @@
         "binop": null,
         "updateContext": null
       },
-      "value": "/svg/core/",
-      "start": 2270,
-      "end": 2282,
+      "start": 2015,
+      "end": 2016,
       "loc": {
         "start": {
-          "line": 100,
-          "column": 30
+          "line": 81,
+          "column": 36
         },
         "end": {
-          "line": 100,
-          "column": 42
+          "line": 81,
+          "column": 37
         }
       }
     },
     {
       "type": {
-        "label": "+/-",
+        "label": "}",
+        "beforeExpr": false,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "start": 2019,
+      "end": 2020,
+      "loc": {
+        "start": {
+          "line": 82,
+          "column": 2
+        },
+        "end": {
+          "line": 82,
+          "column": 3
+        }
+      }
+    },
+    {
+      "type": {
+        "label": ")",
+        "beforeExpr": false,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "start": 2020,
+      "end": 2021,
+      "loc": {
+        "start": {
+          "line": 82,
+          "column": 3
+        },
+        "end": {
+          "line": 82,
+          "column": 4
+        }
+      }
+    },
+    {
+      "type": {
+        "label": ";",
+        "beforeExpr": true,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null,
+        "updateContext": null
+      },
+      "start": 2021,
+      "end": 2022,
+      "loc": {
+        "start": {
+          "line": 82,
+          "column": 4
+        },
+        "end": {
+          "line": 82,
+          "column": 5
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "}",
+        "beforeExpr": false,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "start": 2023,
+      "end": 2024,
+      "loc": {
+        "start": {
+          "line": 83,
+          "column": 0
+        },
+        "end": {
+          "line": 83,
+          "column": 1
+        }
+      }
+    },
+    {
+      "type": {
+        "label": ";",
+        "beforeExpr": true,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null,
+        "updateContext": null
+      },
+      "start": 2024,
+      "end": 2025,
+      "loc": {
+        "start": {
+          "line": 83,
+          "column": 1
+        },
+        "end": {
+          "line": 83,
+          "column": 2
+        }
+      }
+    },
+    {
+      "type": "CommentBlock",
+      "value": "*\n * Get a single part fzp from the obsolete parts, this is for old sketches only!\n *\n * @param  {String} src\n * @param  {String} url - The base URL of the parts api\n * @return {Promise} the fetch promise returns xml\n ",
+      "start": 2027,
+      "end": 2249,
+      "loc": {
+        "start": {
+          "line": 85,
+          "column": 0
+        },
+        "end": {
+          "line": 91,
+          "column": 3
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "const",
+        "keyword": "const",
+        "beforeExpr": false,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null,
+        "updateContext": null
+      },
+      "value": "const",
+      "start": 2250,
+      "end": 2255,
+      "loc": {
+        "start": {
+          "line": 92,
+          "column": 0
+        },
+        "end": {
+          "line": 92,
+          "column": 5
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "name",
+        "beforeExpr": false,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "value": "getFzpObsolete",
+      "start": 2256,
+      "end": 2270,
+      "loc": {
+        "start": {
+          "line": 92,
+          "column": 6
+        },
+        "end": {
+          "line": 92,
+          "column": 20
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "=",
+        "beforeExpr": true,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": true,
+        "prefix": false,
+        "postfix": false,
+        "binop": null,
+        "updateContext": null
+      },
+      "value": "=",
+      "start": 2271,
+      "end": 2272,
+      "loc": {
+        "start": {
+          "line": 92,
+          "column": 21
+        },
+        "end": {
+          "line": 92,
+          "column": 22
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "function",
+        "keyword": "function",
+        "beforeExpr": false,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "value": "function",
+      "start": 2273,
+      "end": 2281,
+      "loc": {
+        "start": {
+          "line": 92,
+          "column": 23
+        },
+        "end": {
+          "line": 92,
+          "column": 31
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "(",
         "beforeExpr": true,
         "startsExpr": true,
         "rightAssociative": false,
         "isLoop": false,
         "isAssign": false,
-        "prefix": true,
+        "prefix": false,
         "postfix": false,
-        "binop": 9,
-        "updateContext": null
+        "binop": null
       },
-      "value": "+",
-      "start": 2282,
-      "end": 2283,
+      "start": 2281,
+      "end": 2282,
       "loc": {
         "start": {
-          "line": 100,
-          "column": 42
+          "line": 92,
+          "column": 31
         },
         "end": {
-          "line": 100,
-          "column": 43
+          "line": 92,
+          "column": 32
         }
       }
     },
@@ -14500,16 +15956,16 @@
         "binop": null
       },
       "value": "src",
-      "start": 2283,
-      "end": 2286,
+      "start": 2282,
+      "end": 2285,
       "loc": {
         "start": {
-          "line": 100,
-          "column": 43
+          "line": 92,
+          "column": 32
         },
         "end": {
-          "line": 100,
-          "column": 46
+          "line": 92,
+          "column": 35
         }
       }
     },
@@ -14526,41 +15982,16 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 2286,
-      "end": 2287,
+      "start": 2285,
+      "end": 2286,
       "loc": {
         "start": {
-          "line": 100,
-          "column": 46
+          "line": 92,
+          "column": 35
         },
         "end": {
-          "line": 100,
-          "column": 47
-        }
-      }
-    },
-    {
-      "type": {
-        "label": "{",
-        "beforeExpr": true,
-        "startsExpr": true,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null
-      },
-      "start": 2288,
-      "end": 2289,
-      "loc": {
-        "start": {
-          "line": 100,
-          "column": 48
-        },
-        "end": {
-          "line": 100,
-          "column": 49
+          "line": 92,
+          "column": 36
         }
       }
     },
@@ -14576,49 +16007,50 @@
         "postfix": false,
         "binop": null
       },
-      "value": "responseType",
-      "start": 2289,
-      "end": 2301,
+      "value": "url",
+      "start": 2287,
+      "end": 2290,
       "loc": {
         "start": {
-          "line": 100,
-          "column": 49
+          "line": 92,
+          "column": 37
         },
         "end": {
-          "line": 100,
-          "column": 61
+          "line": 92,
+          "column": 40
         }
       }
     },
     {
       "type": {
-        "label": ":",
+        "label": "=",
         "beforeExpr": true,
         "startsExpr": false,
         "rightAssociative": false,
         "isLoop": false,
-        "isAssign": false,
+        "isAssign": true,
         "prefix": false,
         "postfix": false,
         "binop": null,
         "updateContext": null
       },
-      "start": 2301,
-      "end": 2302,
+      "value": "=",
+      "start": 2291,
+      "end": 2292,
       "loc": {
         "start": {
-          "line": 100,
-          "column": 61
+          "line": 92,
+          "column": 41
         },
         "end": {
-          "line": 100,
-          "column": 62
+          "line": 92,
+          "column": 42
         }
       }
     },
     {
       "type": {
-        "label": "string",
+        "label": "name",
         "beforeExpr": false,
         "startsExpr": true,
         "rightAssociative": false,
@@ -14626,45 +16058,19 @@
         "isAssign": false,
         "prefix": false,
         "postfix": false,
-        "binop": null,
-        "updateContext": null
-      },
-      "value": "xml",
-      "start": 2303,
-      "end": 2308,
-      "loc": {
-        "start": {
-          "line": 100,
-          "column": 63
-        },
-        "end": {
-          "line": 100,
-          "column": 68
-        }
-      }
-    },
-    {
-      "type": {
-        "label": "}",
-        "beforeExpr": false,
-        "startsExpr": false,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
         "binop": null
       },
-      "start": 2308,
+      "value": "FritzingPartsAPI",
+      "start": 2293,
       "end": 2309,
       "loc": {
         "start": {
-          "line": 100,
-          "column": 68
+          "line": 92,
+          "column": 43
         },
         "end": {
-          "line": 100,
-          "column": 69
+          "line": 92,
+          "column": 59
         }
       }
     },
@@ -14684,70 +16090,18 @@
       "end": 2310,
       "loc": {
         "start": {
-          "line": 100,
-          "column": 69
+          "line": 92,
+          "column": 59
         },
         "end": {
-          "line": 100,
-          "column": 70
+          "line": 92,
+          "column": 60
         }
       }
     },
     {
       "type": {
-        "label": ".",
-        "beforeExpr": false,
-        "startsExpr": false,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null,
-        "updateContext": null
-      },
-      "start": 2315,
-      "end": 2316,
-      "loc": {
-        "start": {
-          "line": 101,
-          "column": 4
-        },
-        "end": {
-          "line": 101,
-          "column": 5
-        }
-      }
-    },
-    {
-      "type": {
-        "label": "name",
-        "beforeExpr": false,
-        "startsExpr": true,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null
-      },
-      "value": "then",
-      "start": 2316,
-      "end": 2320,
-      "loc": {
-        "start": {
-          "line": 101,
-          "column": 5
-        },
-        "end": {
-          "line": 101,
-          "column": 9
-        }
-      }
-    },
-    {
-      "type": {
-        "label": "(",
+        "label": "{",
         "beforeExpr": true,
         "startsExpr": true,
         "rightAssociative": false,
@@ -14757,547 +16111,44 @@
         "postfix": false,
         "binop": null
       },
-      "start": 2320,
+      "start": 2311,
+      "end": 2312,
+      "loc": {
+        "start": {
+          "line": 92,
+          "column": 61
+        },
+        "end": {
+          "line": 92,
+          "column": 62
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "return",
+        "keyword": "return",
+        "beforeExpr": true,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null,
+        "updateContext": null
+      },
+      "value": "return",
+      "start": 2315,
       "end": 2321,
       "loc": {
         "start": {
-          "line": 101,
-          "column": 9
-        },
-        "end": {
-          "line": 101,
-          "column": 10
-        }
-      }
-    },
-    {
-      "type": {
-        "label": "(",
-        "beforeExpr": true,
-        "startsExpr": true,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null
-      },
-      "start": 2321,
-      "end": 2322,
-      "loc": {
-        "start": {
-          "line": 101,
-          "column": 10
-        },
-        "end": {
-          "line": 101,
-          "column": 11
-        }
-      }
-    },
-    {
-      "type": {
-        "label": "name",
-        "beforeExpr": false,
-        "startsExpr": true,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null
-      },
-      "value": "res",
-      "start": 2322,
-      "end": 2325,
-      "loc": {
-        "start": {
-          "line": 101,
-          "column": 11
-        },
-        "end": {
-          "line": 101,
-          "column": 14
-        }
-      }
-    },
-    {
-      "type": {
-        "label": ")",
-        "beforeExpr": false,
-        "startsExpr": false,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null
-      },
-      "start": 2325,
-      "end": 2326,
-      "loc": {
-        "start": {
-          "line": 101,
-          "column": 14
-        },
-        "end": {
-          "line": 101,
-          "column": 15
-        }
-      }
-    },
-    {
-      "type": {
-        "label": "=>",
-        "beforeExpr": true,
-        "startsExpr": false,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null,
-        "updateContext": null
-      },
-      "start": 2327,
-      "end": 2329,
-      "loc": {
-        "start": {
-          "line": 101,
-          "column": 16
-        },
-        "end": {
-          "line": 101,
-          "column": 18
-        }
-      }
-    },
-    {
-      "type": {
-        "label": "{",
-        "beforeExpr": true,
-        "startsExpr": true,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null
-      },
-      "start": 2330,
-      "end": 2331,
-      "loc": {
-        "start": {
-          "line": 101,
-          "column": 19
-        },
-        "end": {
-          "line": 101,
-          "column": 20
-        }
-      }
-    },
-    {
-      "type": {
-        "label": "return",
-        "keyword": "return",
-        "beforeExpr": true,
-        "startsExpr": false,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null,
-        "updateContext": null
-      },
-      "value": "return",
-      "start": 2338,
-      "end": 2344,
-      "loc": {
-        "start": {
-          "line": 102,
-          "column": 6
-        },
-        "end": {
-          "line": 102,
-          "column": 12
-        }
-      }
-    },
-    {
-      "type": {
-        "label": "name",
-        "beforeExpr": false,
-        "startsExpr": true,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null
-      },
-      "value": "res",
-      "start": 2345,
-      "end": 2348,
-      "loc": {
-        "start": {
-          "line": 102,
-          "column": 13
-        },
-        "end": {
-          "line": 102,
-          "column": 16
-        }
-      }
-    },
-    {
-      "type": {
-        "label": ".",
-        "beforeExpr": false,
-        "startsExpr": false,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null,
-        "updateContext": null
-      },
-      "start": 2348,
-      "end": 2349,
-      "loc": {
-        "start": {
-          "line": 102,
-          "column": 16
-        },
-        "end": {
-          "line": 102,
-          "column": 17
-        }
-      }
-    },
-    {
-      "type": {
-        "label": "name",
-        "beforeExpr": false,
-        "startsExpr": true,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null
-      },
-      "value": "data",
-      "start": 2349,
-      "end": 2353,
-      "loc": {
-        "start": {
-          "line": 102,
-          "column": 17
-        },
-        "end": {
-          "line": 102,
-          "column": 21
-        }
-      }
-    },
-    {
-      "type": {
-        "label": ";",
-        "beforeExpr": true,
-        "startsExpr": false,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null,
-        "updateContext": null
-      },
-      "start": 2353,
-      "end": 2354,
-      "loc": {
-        "start": {
-          "line": 102,
-          "column": 21
-        },
-        "end": {
-          "line": 102,
-          "column": 22
-        }
-      }
-    },
-    {
-      "type": {
-        "label": "}",
-        "beforeExpr": false,
-        "startsExpr": false,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null
-      },
-      "start": 2359,
-      "end": 2360,
-      "loc": {
-        "start": {
-          "line": 103,
-          "column": 4
-        },
-        "end": {
-          "line": 103,
-          "column": 5
-        }
-      }
-    },
-    {
-      "type": {
-        "label": ")",
-        "beforeExpr": false,
-        "startsExpr": false,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null
-      },
-      "start": 2360,
-      "end": 2361,
-      "loc": {
-        "start": {
-          "line": 103,
-          "column": 5
-        },
-        "end": {
-          "line": 103,
-          "column": 6
-        }
-      }
-    },
-    {
-      "type": {
-        "label": ";",
-        "beforeExpr": true,
-        "startsExpr": false,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null,
-        "updateContext": null
-      },
-      "start": 2361,
-      "end": 2362,
-      "loc": {
-        "start": {
-          "line": 103,
-          "column": 6
-        },
-        "end": {
-          "line": 103,
-          "column": 7
-        }
-      }
-    },
-    {
-      "type": {
-        "label": "}",
-        "beforeExpr": false,
-        "startsExpr": false,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null
-      },
-      "start": 2365,
-      "end": 2366,
-      "loc": {
-        "start": {
-          "line": 104,
+          "line": 93,
           "column": 2
         },
         "end": {
-          "line": 104,
-          "column": 3
-        }
-      }
-    },
-    {
-      "type": "CommentBlock",
-      "value": "*\n   * Get a single part svg from the obsolete svgs, this is for old-sketches only! the response is a svg-string\n   * @param  {String} src\n   * @return {Promise} the fetch promise\n   ",
-      "start": 2369,
-      "end": 2556,
-      "loc": {
-        "start": {
-          "line": 105,
-          "column": 2
-        },
-        "end": {
-          "line": 109,
-          "column": 5
-        }
-      }
-    },
-    {
-      "type": {
-        "label": "name",
-        "beforeExpr": false,
-        "startsExpr": true,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null
-      },
-      "value": "getSvgObsolete",
-      "start": 2559,
-      "end": 2573,
-      "loc": {
-        "start": {
-          "line": 110,
-          "column": 2
-        },
-        "end": {
-          "line": 110,
-          "column": 16
-        }
-      }
-    },
-    {
-      "type": {
-        "label": "(",
-        "beforeExpr": true,
-        "startsExpr": true,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null
-      },
-      "start": 2573,
-      "end": 2574,
-      "loc": {
-        "start": {
-          "line": 110,
-          "column": 16
-        },
-        "end": {
-          "line": 110,
-          "column": 17
-        }
-      }
-    },
-    {
-      "type": {
-        "label": "name",
-        "beforeExpr": false,
-        "startsExpr": true,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null
-      },
-      "value": "src",
-      "start": 2574,
-      "end": 2577,
-      "loc": {
-        "start": {
-          "line": 110,
-          "column": 17
-        },
-        "end": {
-          "line": 110,
-          "column": 20
-        }
-      }
-    },
-    {
-      "type": {
-        "label": ")",
-        "beforeExpr": false,
-        "startsExpr": false,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null
-      },
-      "start": 2577,
-      "end": 2578,
-      "loc": {
-        "start": {
-          "line": 110,
-          "column": 20
-        },
-        "end": {
-          "line": 110,
-          "column": 21
-        }
-      }
-    },
-    {
-      "type": {
-        "label": "{",
-        "beforeExpr": true,
-        "startsExpr": true,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null
-      },
-      "start": 2579,
-      "end": 2580,
-      "loc": {
-        "start": {
-          "line": 110,
-          "column": 22
-        },
-        "end": {
-          "line": 110,
-          "column": 23
-        }
-      }
-    },
-    {
-      "type": {
-        "label": "return",
-        "keyword": "return",
-        "beforeExpr": true,
-        "startsExpr": false,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null,
-        "updateContext": null
-      },
-      "value": "return",
-      "start": 2585,
-      "end": 2591,
-      "loc": {
-        "start": {
-          "line": 111,
-          "column": 4
-        },
-        "end": {
-          "line": 111,
-          "column": 10
+          "line": 93,
+          "column": 8
         }
       }
     },
@@ -15314,16 +16165,16 @@
         "binop": null
       },
       "value": "axios",
-      "start": 2592,
-      "end": 2597,
+      "start": 2322,
+      "end": 2327,
       "loc": {
         "start": {
-          "line": 111,
-          "column": 11
+          "line": 93,
+          "column": 9
         },
         "end": {
-          "line": 111,
-          "column": 16
+          "line": 93,
+          "column": 14
         }
       }
     },
@@ -15340,16 +16191,16 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 2597,
-      "end": 2598,
+      "start": 2327,
+      "end": 2328,
       "loc": {
         "start": {
-          "line": 111,
-          "column": 16
+          "line": 93,
+          "column": 14
         },
         "end": {
-          "line": 111,
-          "column": 17
+          "line": 93,
+          "column": 15
         }
       }
     },
@@ -15366,16 +16217,16 @@
         "binop": null
       },
       "value": "get",
-      "start": 2598,
-      "end": 2601,
+      "start": 2328,
+      "end": 2331,
       "loc": {
         "start": {
-          "line": 111,
-          "column": 17
+          "line": 93,
+          "column": 15
         },
         "end": {
-          "line": 111,
-          "column": 20
+          "line": 93,
+          "column": 18
         }
       }
     },
@@ -15391,23 +16242,22 @@
         "postfix": false,
         "binop": null
       },
-      "start": 2601,
-      "end": 2602,
+      "start": 2331,
+      "end": 2332,
       "loc": {
         "start": {
-          "line": 111,
-          "column": 20
+          "line": 93,
+          "column": 18
         },
         "end": {
-          "line": 111,
-          "column": 21
+          "line": 93,
+          "column": 19
         }
       }
     },
     {
       "type": {
-        "label": "this",
-        "keyword": "this",
+        "label": "`",
         "beforeExpr": false,
         "startsExpr": true,
         "rightAssociative": false,
@@ -15415,26 +16265,24 @@
         "isAssign": false,
         "prefix": false,
         "postfix": false,
-        "binop": null,
-        "updateContext": null
+        "binop": null
       },
-      "value": "this",
-      "start": 2602,
-      "end": 2606,
+      "start": 2332,
+      "end": 2333,
       "loc": {
         "start": {
-          "line": 111,
-          "column": 21
+          "line": 93,
+          "column": 19
         },
         "end": {
-          "line": 111,
-          "column": 25
+          "line": 93,
+          "column": 20
         }
       }
     },
     {
       "type": {
-        "label": ".",
+        "label": "template",
         "beforeExpr": false,
         "startsExpr": false,
         "rightAssociative": false,
@@ -15445,16 +16293,42 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 2606,
-      "end": 2607,
+      "value": "",
+      "start": 2333,
+      "end": 2333,
       "loc": {
         "start": {
-          "line": 111,
-          "column": 25
+          "line": 93,
+          "column": 20
         },
         "end": {
-          "line": 111,
-          "column": 26
+          "line": 93,
+          "column": 20
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "${",
+        "beforeExpr": true,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "start": 2333,
+      "end": 2335,
+      "loc": {
+        "start": {
+          "line": 93,
+          "column": 20
+        },
+        "end": {
+          "line": 93,
+          "column": 22
         }
       }
     },
@@ -15471,51 +16345,49 @@
         "binop": null
       },
       "value": "url",
-      "start": 2607,
-      "end": 2610,
+      "start": 2335,
+      "end": 2338,
       "loc": {
         "start": {
-          "line": 111,
-          "column": 26
+          "line": 93,
+          "column": 22
         },
         "end": {
-          "line": 111,
-          "column": 29
+          "line": 93,
+          "column": 25
         }
       }
     },
     {
       "type": {
-        "label": "+/-",
-        "beforeExpr": true,
-        "startsExpr": true,
+        "label": "}",
+        "beforeExpr": false,
+        "startsExpr": false,
         "rightAssociative": false,
         "isLoop": false,
         "isAssign": false,
-        "prefix": true,
+        "prefix": false,
         "postfix": false,
-        "binop": 9,
-        "updateContext": null
+        "binop": null
       },
-      "value": "+",
-      "start": 2610,
-      "end": 2611,
+      "start": 2338,
+      "end": 2339,
       "loc": {
         "start": {
-          "line": 111,
-          "column": 29
+          "line": 93,
+          "column": 25
         },
         "end": {
-          "line": 111,
-          "column": 30
+          "line": 93,
+          "column": 26
         }
       }
     },
     {
       "type": {
-        "label": "string",
+        "label": "template",
         "beforeExpr": false,
-        "startsExpr": true,
+        "startsExpr": false,
         "rightAssociative": false,
         "isLoop": false,
         "isAssign": false,
@@ -15524,44 +16396,42 @@
         "binop": null,
         "updateContext": null
       },
-      "value": "/svg/obsolete/",
-      "start": 2611,
-      "end": 2627,
+      "value": "/obsolete/",
+      "start": 2339,
+      "end": 2349,
       "loc": {
         "start": {
-          "line": 111,
-          "column": 30
+          "line": 93,
+          "column": 26
         },
         "end": {
-          "line": 111,
-          "column": 46
+          "line": 93,
+          "column": 36
         }
       }
     },
     {
       "type": {
-        "label": "+/-",
+        "label": "${",
         "beforeExpr": true,
         "startsExpr": true,
         "rightAssociative": false,
         "isLoop": false,
         "isAssign": false,
-        "prefix": true,
+        "prefix": false,
         "postfix": false,
-        "binop": 9,
-        "updateContext": null
+        "binop": null
       },
-      "value": "+",
-      "start": 2627,
-      "end": 2628,
+      "start": 2349,
+      "end": 2351,
       "loc": {
         "start": {
-          "line": 111,
-          "column": 46
+          "line": 93,
+          "column": 36
         },
         "end": {
-          "line": 111,
-          "column": 47
+          "line": 93,
+          "column": 38
         }
       }
     },
@@ -15578,16 +16448,93 @@
         "binop": null
       },
       "value": "src",
-      "start": 2628,
-      "end": 2631,
+      "start": 2351,
+      "end": 2354,
       "loc": {
         "start": {
-          "line": 111,
-          "column": 47
+          "line": 93,
+          "column": 38
         },
         "end": {
-          "line": 111,
-          "column": 50
+          "line": 93,
+          "column": 41
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "}",
+        "beforeExpr": false,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "start": 2354,
+      "end": 2355,
+      "loc": {
+        "start": {
+          "line": 93,
+          "column": 41
+        },
+        "end": {
+          "line": 93,
+          "column": 42
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "template",
+        "beforeExpr": false,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null,
+        "updateContext": null
+      },
+      "value": "",
+      "start": 2355,
+      "end": 2355,
+      "loc": {
+        "start": {
+          "line": 93,
+          "column": 42
+        },
+        "end": {
+          "line": 93,
+          "column": 42
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "`",
+        "beforeExpr": false,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "start": 2355,
+      "end": 2356,
+      "loc": {
+        "start": {
+          "line": 93,
+          "column": 42
+        },
+        "end": {
+          "line": 93,
+          "column": 43
         }
       }
     },
@@ -15604,16 +16551,16 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 2631,
-      "end": 2632,
+      "start": 2356,
+      "end": 2357,
       "loc": {
         "start": {
-          "line": 111,
-          "column": 50
+          "line": 93,
+          "column": 43
         },
         "end": {
-          "line": 111,
-          "column": 51
+          "line": 93,
+          "column": 44
         }
       }
     },
@@ -15629,16 +16576,16 @@
         "postfix": false,
         "binop": null
       },
-      "start": 2633,
-      "end": 2634,
+      "start": 2358,
+      "end": 2359,
       "loc": {
         "start": {
-          "line": 111,
-          "column": 52
+          "line": 93,
+          "column": 45
         },
         "end": {
-          "line": 111,
-          "column": 53
+          "line": 93,
+          "column": 46
         }
       }
     },
@@ -15655,16 +16602,16 @@
         "binop": null
       },
       "value": "responseType",
-      "start": 2634,
-      "end": 2646,
+      "start": 2359,
+      "end": 2371,
       "loc": {
         "start": {
-          "line": 111,
-          "column": 53
+          "line": 93,
+          "column": 46
         },
         "end": {
-          "line": 111,
-          "column": 65
+          "line": 93,
+          "column": 58
         }
       }
     },
@@ -15681,16 +16628,16 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 2646,
-      "end": 2647,
+      "start": 2371,
+      "end": 2372,
       "loc": {
         "start": {
-          "line": 111,
-          "column": 65
+          "line": 93,
+          "column": 58
         },
         "end": {
-          "line": 111,
-          "column": 66
+          "line": 93,
+          "column": 59
         }
       }
     },
@@ -15708,16 +16655,16 @@
         "updateContext": null
       },
       "value": "xml",
-      "start": 2648,
-      "end": 2653,
+      "start": 2373,
+      "end": 2378,
       "loc": {
         "start": {
-          "line": 111,
-          "column": 67
+          "line": 93,
+          "column": 60
         },
         "end": {
-          "line": 111,
-          "column": 72
+          "line": 93,
+          "column": 65
         }
       }
     },
@@ -15733,16 +16680,16 @@
         "postfix": false,
         "binop": null
       },
-      "start": 2653,
-      "end": 2654,
+      "start": 2378,
+      "end": 2379,
       "loc": {
         "start": {
-          "line": 111,
-          "column": 72
+          "line": 93,
+          "column": 65
         },
         "end": {
-          "line": 111,
-          "column": 73
+          "line": 93,
+          "column": 66
         }
       }
     },
@@ -15758,16 +16705,16 @@
         "postfix": false,
         "binop": null
       },
-      "start": 2654,
-      "end": 2655,
+      "start": 2379,
+      "end": 2380,
       "loc": {
         "start": {
-          "line": 111,
-          "column": 73
+          "line": 93,
+          "column": 66
         },
         "end": {
-          "line": 111,
-          "column": 74
+          "line": 93,
+          "column": 67
         }
       }
     },
@@ -15784,16 +16731,16 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 2660,
-      "end": 2661,
+      "start": 2383,
+      "end": 2384,
       "loc": {
         "start": {
-          "line": 112,
-          "column": 4
+          "line": 94,
+          "column": 2
         },
         "end": {
-          "line": 112,
-          "column": 5
+          "line": 94,
+          "column": 3
         }
       }
     },
@@ -15810,16 +16757,16 @@
         "binop": null
       },
       "value": "then",
-      "start": 2661,
-      "end": 2665,
+      "start": 2384,
+      "end": 2388,
       "loc": {
         "start": {
-          "line": 112,
-          "column": 5
+          "line": 94,
+          "column": 3
         },
         "end": {
-          "line": 112,
-          "column": 9
+          "line": 94,
+          "column": 7
         }
       }
     },
@@ -15835,16 +16782,16 @@
         "postfix": false,
         "binop": null
       },
-      "start": 2665,
-      "end": 2666,
+      "start": 2388,
+      "end": 2389,
       "loc": {
         "start": {
-          "line": 112,
-          "column": 9
+          "line": 94,
+          "column": 7
         },
         "end": {
-          "line": 112,
-          "column": 10
+          "line": 94,
+          "column": 8
         }
       }
     },
@@ -15860,16 +16807,16 @@
         "postfix": false,
         "binop": null
       },
-      "start": 2666,
-      "end": 2667,
+      "start": 2389,
+      "end": 2390,
       "loc": {
         "start": {
-          "line": 112,
-          "column": 10
+          "line": 94,
+          "column": 8
         },
         "end": {
-          "line": 112,
-          "column": 11
+          "line": 94,
+          "column": 9
         }
       }
     },
@@ -15886,16 +16833,16 @@
         "binop": null
       },
       "value": "res",
-      "start": 2667,
-      "end": 2670,
+      "start": 2390,
+      "end": 2393,
       "loc": {
         "start": {
-          "line": 112,
-          "column": 11
+          "line": 94,
+          "column": 9
         },
         "end": {
-          "line": 112,
-          "column": 14
+          "line": 94,
+          "column": 12
         }
       }
     },
@@ -15911,16 +16858,16 @@
         "postfix": false,
         "binop": null
       },
-      "start": 2670,
-      "end": 2671,
+      "start": 2393,
+      "end": 2394,
       "loc": {
         "start": {
-          "line": 112,
-          "column": 14
+          "line": 94,
+          "column": 12
         },
         "end": {
-          "line": 112,
-          "column": 15
+          "line": 94,
+          "column": 13
         }
       }
     },
@@ -15937,16 +16884,16 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 2672,
-      "end": 2674,
+      "start": 2395,
+      "end": 2397,
       "loc": {
         "start": {
-          "line": 112,
-          "column": 16
+          "line": 94,
+          "column": 14
         },
         "end": {
-          "line": 112,
-          "column": 18
+          "line": 94,
+          "column": 16
         }
       }
     },
@@ -15962,16 +16909,16 @@
         "postfix": false,
         "binop": null
       },
-      "start": 2675,
-      "end": 2676,
+      "start": 2398,
+      "end": 2399,
       "loc": {
         "start": {
-          "line": 112,
-          "column": 19
+          "line": 94,
+          "column": 17
         },
         "end": {
-          "line": 112,
-          "column": 20
+          "line": 94,
+          "column": 18
         }
       }
     },
@@ -15990,16 +16937,16 @@
         "updateContext": null
       },
       "value": "return",
-      "start": 2683,
-      "end": 2689,
+      "start": 2404,
+      "end": 2410,
       "loc": {
         "start": {
-          "line": 113,
-          "column": 6
+          "line": 95,
+          "column": 4
         },
         "end": {
-          "line": 113,
-          "column": 12
+          "line": 95,
+          "column": 10
         }
       }
     },
@@ -16015,17 +16962,17 @@
         "postfix": false,
         "binop": null
       },
-      "value": "res",
-      "start": 2690,
-      "end": 2693,
+      "value": "Promise",
+      "start": 2411,
+      "end": 2418,
       "loc": {
         "start": {
-          "line": 113,
-          "column": 13
+          "line": 95,
+          "column": 11
         },
         "end": {
-          "line": 113,
-          "column": 16
+          "line": 95,
+          "column": 18
         }
       }
     },
@@ -16042,16 +16989,119 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 2693,
-      "end": 2694,
+      "start": 2418,
+      "end": 2419,
       "loc": {
         "start": {
-          "line": 113,
-          "column": 16
+          "line": 95,
+          "column": 18
         },
         "end": {
-          "line": 113,
-          "column": 17
+          "line": 95,
+          "column": 19
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "name",
+        "beforeExpr": false,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "value": "resolve",
+      "start": 2419,
+      "end": 2426,
+      "loc": {
+        "start": {
+          "line": 95,
+          "column": 19
+        },
+        "end": {
+          "line": 95,
+          "column": 26
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "(",
+        "beforeExpr": true,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "start": 2426,
+      "end": 2427,
+      "loc": {
+        "start": {
+          "line": 95,
+          "column": 26
+        },
+        "end": {
+          "line": 95,
+          "column": 27
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "name",
+        "beforeExpr": false,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "value": "res",
+      "start": 2427,
+      "end": 2430,
+      "loc": {
+        "start": {
+          "line": 95,
+          "column": 27
+        },
+        "end": {
+          "line": 95,
+          "column": 30
+        }
+      }
+    },
+    {
+      "type": {
+        "label": ".",
+        "beforeExpr": false,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null,
+        "updateContext": null
+      },
+      "start": 2430,
+      "end": 2431,
+      "loc": {
+        "start": {
+          "line": 95,
+          "column": 30
+        },
+        "end": {
+          "line": 95,
+          "column": 31
         }
       }
     },
@@ -16068,67 +17118,16 @@
         "binop": null
       },
       "value": "data",
-      "start": 2694,
-      "end": 2698,
+      "start": 2431,
+      "end": 2435,
       "loc": {
         "start": {
-          "line": 113,
-          "column": 17
+          "line": 95,
+          "column": 31
         },
         "end": {
-          "line": 113,
-          "column": 21
-        }
-      }
-    },
-    {
-      "type": {
-        "label": ";",
-        "beforeExpr": true,
-        "startsExpr": false,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null,
-        "updateContext": null
-      },
-      "start": 2698,
-      "end": 2699,
-      "loc": {
-        "start": {
-          "line": 113,
-          "column": 21
-        },
-        "end": {
-          "line": 113,
-          "column": 22
-        }
-      }
-    },
-    {
-      "type": {
-        "label": "}",
-        "beforeExpr": false,
-        "startsExpr": false,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null
-      },
-      "start": 2704,
-      "end": 2705,
-      "loc": {
-        "start": {
-          "line": 114,
-          "column": 4
-        },
-        "end": {
-          "line": 114,
-          "column": 5
+          "line": 95,
+          "column": 35
         }
       }
     },
@@ -16144,16 +17143,16 @@
         "postfix": false,
         "binop": null
       },
-      "start": 2705,
-      "end": 2706,
+      "start": 2435,
+      "end": 2436,
       "loc": {
         "start": {
-          "line": 114,
-          "column": 5
+          "line": 95,
+          "column": 35
         },
         "end": {
-          "line": 114,
-          "column": 6
+          "line": 95,
+          "column": 36
         }
       }
     },
@@ -16170,16 +17169,16 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 2706,
-      "end": 2707,
+      "start": 2436,
+      "end": 2437,
       "loc": {
         "start": {
-          "line": 114,
-          "column": 6
+          "line": 95,
+          "column": 36
         },
         "end": {
-          "line": 114,
-          "column": 7
+          "line": 95,
+          "column": 37
         }
       }
     },
@@ -16195,28 +17194,1673 @@
         "postfix": false,
         "binop": null
       },
-      "start": 2710,
-      "end": 2711,
+      "start": 2440,
+      "end": 2441,
       "loc": {
         "start": {
-          "line": 115,
+          "line": 96,
           "column": 2
         },
         "end": {
-          "line": 115,
+          "line": 96,
+          "column": 3
+        }
+      }
+    },
+    {
+      "type": {
+        "label": ")",
+        "beforeExpr": false,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "start": 2441,
+      "end": 2442,
+      "loc": {
+        "start": {
+          "line": 96,
+          "column": 3
+        },
+        "end": {
+          "line": 96,
+          "column": 4
+        }
+      }
+    },
+    {
+      "type": {
+        "label": ";",
+        "beforeExpr": true,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null,
+        "updateContext": null
+      },
+      "start": 2442,
+      "end": 2443,
+      "loc": {
+        "start": {
+          "line": 96,
+          "column": 4
+        },
+        "end": {
+          "line": 96,
+          "column": 5
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "}",
+        "beforeExpr": false,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "start": 2444,
+      "end": 2445,
+      "loc": {
+        "start": {
+          "line": 97,
+          "column": 0
+        },
+        "end": {
+          "line": 97,
+          "column": 1
+        }
+      }
+    },
+    {
+      "type": {
+        "label": ";",
+        "beforeExpr": true,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null,
+        "updateContext": null
+      },
+      "start": 2445,
+      "end": 2446,
+      "loc": {
+        "start": {
+          "line": 97,
+          "column": 1
+        },
+        "end": {
+          "line": 97,
+          "column": 2
+        }
+      }
+    },
+    {
+      "type": "CommentBlock",
+      "value": "*\n * Get a single part svg and response the svg as a string\n *\n * @param  {String} src\n * @param  {String} url - The base URL of the parts api\n * @return {Promise} the fetch promise\n ",
+      "start": 2448,
+      "end": 2635,
+      "loc": {
+        "start": {
+          "line": 99,
+          "column": 0
+        },
+        "end": {
+          "line": 105,
+          "column": 3
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "const",
+        "keyword": "const",
+        "beforeExpr": false,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null,
+        "updateContext": null
+      },
+      "value": "const",
+      "start": 2637,
+      "end": 2642,
+      "loc": {
+        "start": {
+          "line": 106,
+          "column": 1
+        },
+        "end": {
+          "line": 106,
+          "column": 6
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "name",
+        "beforeExpr": false,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "value": "getSvg",
+      "start": 2643,
+      "end": 2649,
+      "loc": {
+        "start": {
+          "line": 106,
+          "column": 7
+        },
+        "end": {
+          "line": 106,
+          "column": 13
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "=",
+        "beforeExpr": true,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": true,
+        "prefix": false,
+        "postfix": false,
+        "binop": null,
+        "updateContext": null
+      },
+      "value": "=",
+      "start": 2650,
+      "end": 2651,
+      "loc": {
+        "start": {
+          "line": 106,
+          "column": 14
+        },
+        "end": {
+          "line": 106,
+          "column": 15
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "function",
+        "keyword": "function",
+        "beforeExpr": false,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "value": "function",
+      "start": 2652,
+      "end": 2660,
+      "loc": {
+        "start": {
+          "line": 106,
+          "column": 16
+        },
+        "end": {
+          "line": 106,
+          "column": 24
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "(",
+        "beforeExpr": true,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "start": 2660,
+      "end": 2661,
+      "loc": {
+        "start": {
+          "line": 106,
+          "column": 24
+        },
+        "end": {
+          "line": 106,
+          "column": 25
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "name",
+        "beforeExpr": false,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "value": "src",
+      "start": 2661,
+      "end": 2664,
+      "loc": {
+        "start": {
+          "line": 106,
+          "column": 25
+        },
+        "end": {
+          "line": 106,
+          "column": 28
+        }
+      }
+    },
+    {
+      "type": {
+        "label": ",",
+        "beforeExpr": true,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null,
+        "updateContext": null
+      },
+      "start": 2664,
+      "end": 2665,
+      "loc": {
+        "start": {
+          "line": 106,
+          "column": 28
+        },
+        "end": {
+          "line": 106,
+          "column": 29
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "name",
+        "beforeExpr": false,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "value": "url",
+      "start": 2666,
+      "end": 2669,
+      "loc": {
+        "start": {
+          "line": 106,
+          "column": 30
+        },
+        "end": {
+          "line": 106,
+          "column": 33
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "=",
+        "beforeExpr": true,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": true,
+        "prefix": false,
+        "postfix": false,
+        "binop": null,
+        "updateContext": null
+      },
+      "value": "=",
+      "start": 2670,
+      "end": 2671,
+      "loc": {
+        "start": {
+          "line": 106,
+          "column": 34
+        },
+        "end": {
+          "line": 106,
+          "column": 35
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "name",
+        "beforeExpr": false,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "value": "FritzingPartsAPI",
+      "start": 2672,
+      "end": 2688,
+      "loc": {
+        "start": {
+          "line": 106,
+          "column": 36
+        },
+        "end": {
+          "line": 106,
+          "column": 52
+        }
+      }
+    },
+    {
+      "type": {
+        "label": ")",
+        "beforeExpr": false,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "start": 2688,
+      "end": 2689,
+      "loc": {
+        "start": {
+          "line": 106,
+          "column": 52
+        },
+        "end": {
+          "line": 106,
+          "column": 53
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "{",
+        "beforeExpr": true,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "start": 2690,
+      "end": 2691,
+      "loc": {
+        "start": {
+          "line": 106,
+          "column": 54
+        },
+        "end": {
+          "line": 106,
+          "column": 55
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "return",
+        "keyword": "return",
+        "beforeExpr": true,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null,
+        "updateContext": null
+      },
+      "value": "return",
+      "start": 2695,
+      "end": 2701,
+      "loc": {
+        "start": {
+          "line": 107,
+          "column": 3
+        },
+        "end": {
+          "line": 107,
+          "column": 9
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "name",
+        "beforeExpr": false,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "value": "axios",
+      "start": 2702,
+      "end": 2707,
+      "loc": {
+        "start": {
+          "line": 107,
+          "column": 10
+        },
+        "end": {
+          "line": 107,
+          "column": 15
+        }
+      }
+    },
+    {
+      "type": {
+        "label": ".",
+        "beforeExpr": false,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null,
+        "updateContext": null
+      },
+      "start": 2707,
+      "end": 2708,
+      "loc": {
+        "start": {
+          "line": 107,
+          "column": 15
+        },
+        "end": {
+          "line": 107,
+          "column": 16
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "name",
+        "beforeExpr": false,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "value": "get",
+      "start": 2708,
+      "end": 2711,
+      "loc": {
+        "start": {
+          "line": 107,
+          "column": 16
+        },
+        "end": {
+          "line": 107,
+          "column": 19
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "(",
+        "beforeExpr": true,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "start": 2711,
+      "end": 2712,
+      "loc": {
+        "start": {
+          "line": 107,
+          "column": 19
+        },
+        "end": {
+          "line": 107,
+          "column": 20
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "`",
+        "beforeExpr": false,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "start": 2712,
+      "end": 2713,
+      "loc": {
+        "start": {
+          "line": 107,
+          "column": 20
+        },
+        "end": {
+          "line": 107,
+          "column": 21
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "template",
+        "beforeExpr": false,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null,
+        "updateContext": null
+      },
+      "value": "",
+      "start": 2713,
+      "end": 2713,
+      "loc": {
+        "start": {
+          "line": 107,
+          "column": 21
+        },
+        "end": {
+          "line": 107,
+          "column": 21
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "${",
+        "beforeExpr": true,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "start": 2713,
+      "end": 2715,
+      "loc": {
+        "start": {
+          "line": 107,
+          "column": 21
+        },
+        "end": {
+          "line": 107,
+          "column": 23
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "name",
+        "beforeExpr": false,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "value": "url",
+      "start": 2715,
+      "end": 2718,
+      "loc": {
+        "start": {
+          "line": 107,
+          "column": 23
+        },
+        "end": {
+          "line": 107,
+          "column": 26
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "}",
+        "beforeExpr": false,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "start": 2718,
+      "end": 2719,
+      "loc": {
+        "start": {
+          "line": 107,
+          "column": 26
+        },
+        "end": {
+          "line": 107,
+          "column": 27
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "template",
+        "beforeExpr": false,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null,
+        "updateContext": null
+      },
+      "value": "/svg/",
+      "start": 2719,
+      "end": 2724,
+      "loc": {
+        "start": {
+          "line": 107,
+          "column": 27
+        },
+        "end": {
+          "line": 107,
+          "column": 32
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "${",
+        "beforeExpr": true,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "start": 2724,
+      "end": 2726,
+      "loc": {
+        "start": {
+          "line": 107,
+          "column": 32
+        },
+        "end": {
+          "line": 107,
+          "column": 34
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "name",
+        "beforeExpr": false,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "value": "src",
+      "start": 2726,
+      "end": 2729,
+      "loc": {
+        "start": {
+          "line": 107,
+          "column": 34
+        },
+        "end": {
+          "line": 107,
+          "column": 37
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "}",
+        "beforeExpr": false,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "start": 2729,
+      "end": 2730,
+      "loc": {
+        "start": {
+          "line": 107,
+          "column": 37
+        },
+        "end": {
+          "line": 107,
+          "column": 38
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "template",
+        "beforeExpr": false,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null,
+        "updateContext": null
+      },
+      "value": "",
+      "start": 2730,
+      "end": 2730,
+      "loc": {
+        "start": {
+          "line": 107,
+          "column": 38
+        },
+        "end": {
+          "line": 107,
+          "column": 38
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "`",
+        "beforeExpr": false,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "start": 2730,
+      "end": 2731,
+      "loc": {
+        "start": {
+          "line": 107,
+          "column": 38
+        },
+        "end": {
+          "line": 107,
+          "column": 39
+        }
+      }
+    },
+    {
+      "type": {
+        "label": ",",
+        "beforeExpr": true,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null,
+        "updateContext": null
+      },
+      "start": 2731,
+      "end": 2732,
+      "loc": {
+        "start": {
+          "line": 107,
+          "column": 39
+        },
+        "end": {
+          "line": 107,
+          "column": 40
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "{",
+        "beforeExpr": true,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "start": 2733,
+      "end": 2734,
+      "loc": {
+        "start": {
+          "line": 107,
+          "column": 41
+        },
+        "end": {
+          "line": 107,
+          "column": 42
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "name",
+        "beforeExpr": false,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "value": "responseType",
+      "start": 2734,
+      "end": 2746,
+      "loc": {
+        "start": {
+          "line": 107,
+          "column": 42
+        },
+        "end": {
+          "line": 107,
+          "column": 54
+        }
+      }
+    },
+    {
+      "type": {
+        "label": ":",
+        "beforeExpr": true,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null,
+        "updateContext": null
+      },
+      "start": 2746,
+      "end": 2747,
+      "loc": {
+        "start": {
+          "line": 107,
+          "column": 54
+        },
+        "end": {
+          "line": 107,
+          "column": 55
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "string",
+        "beforeExpr": false,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null,
+        "updateContext": null
+      },
+      "value": "xml",
+      "start": 2748,
+      "end": 2753,
+      "loc": {
+        "start": {
+          "line": 107,
+          "column": 56
+        },
+        "end": {
+          "line": 107,
+          "column": 61
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "}",
+        "beforeExpr": false,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "start": 2753,
+      "end": 2754,
+      "loc": {
+        "start": {
+          "line": 107,
+          "column": 61
+        },
+        "end": {
+          "line": 107,
+          "column": 62
+        }
+      }
+    },
+    {
+      "type": {
+        "label": ")",
+        "beforeExpr": false,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "start": 2754,
+      "end": 2755,
+      "loc": {
+        "start": {
+          "line": 107,
+          "column": 62
+        },
+        "end": {
+          "line": 107,
+          "column": 63
+        }
+      }
+    },
+    {
+      "type": {
+        "label": ".",
+        "beforeExpr": false,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null,
+        "updateContext": null
+      },
+      "start": 2759,
+      "end": 2760,
+      "loc": {
+        "start": {
+          "line": 108,
+          "column": 3
+        },
+        "end": {
+          "line": 108,
+          "column": 4
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "name",
+        "beforeExpr": false,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "value": "then",
+      "start": 2760,
+      "end": 2764,
+      "loc": {
+        "start": {
+          "line": 108,
+          "column": 4
+        },
+        "end": {
+          "line": 108,
+          "column": 8
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "(",
+        "beforeExpr": true,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "start": 2764,
+      "end": 2765,
+      "loc": {
+        "start": {
+          "line": 108,
+          "column": 8
+        },
+        "end": {
+          "line": 108,
+          "column": 9
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "(",
+        "beforeExpr": true,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "start": 2765,
+      "end": 2766,
+      "loc": {
+        "start": {
+          "line": 108,
+          "column": 9
+        },
+        "end": {
+          "line": 108,
+          "column": 10
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "name",
+        "beforeExpr": false,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "value": "res",
+      "start": 2766,
+      "end": 2769,
+      "loc": {
+        "start": {
+          "line": 108,
+          "column": 10
+        },
+        "end": {
+          "line": 108,
+          "column": 13
+        }
+      }
+    },
+    {
+      "type": {
+        "label": ")",
+        "beforeExpr": false,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "start": 2769,
+      "end": 2770,
+      "loc": {
+        "start": {
+          "line": 108,
+          "column": 13
+        },
+        "end": {
+          "line": 108,
+          "column": 14
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "=>",
+        "beforeExpr": true,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null,
+        "updateContext": null
+      },
+      "start": 2771,
+      "end": 2773,
+      "loc": {
+        "start": {
+          "line": 108,
+          "column": 15
+        },
+        "end": {
+          "line": 108,
+          "column": 17
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "{",
+        "beforeExpr": true,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "start": 2774,
+      "end": 2775,
+      "loc": {
+        "start": {
+          "line": 108,
+          "column": 18
+        },
+        "end": {
+          "line": 108,
+          "column": 19
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "return",
+        "keyword": "return",
+        "beforeExpr": true,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null,
+        "updateContext": null
+      },
+      "value": "return",
+      "start": 2781,
+      "end": 2787,
+      "loc": {
+        "start": {
+          "line": 109,
+          "column": 5
+        },
+        "end": {
+          "line": 109,
+          "column": 11
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "name",
+        "beforeExpr": false,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "value": "Promise",
+      "start": 2788,
+      "end": 2795,
+      "loc": {
+        "start": {
+          "line": 109,
+          "column": 12
+        },
+        "end": {
+          "line": 109,
+          "column": 19
+        }
+      }
+    },
+    {
+      "type": {
+        "label": ".",
+        "beforeExpr": false,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null,
+        "updateContext": null
+      },
+      "start": 2795,
+      "end": 2796,
+      "loc": {
+        "start": {
+          "line": 109,
+          "column": 19
+        },
+        "end": {
+          "line": 109,
+          "column": 20
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "name",
+        "beforeExpr": false,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "value": "resolve",
+      "start": 2796,
+      "end": 2803,
+      "loc": {
+        "start": {
+          "line": 109,
+          "column": 20
+        },
+        "end": {
+          "line": 109,
+          "column": 27
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "(",
+        "beforeExpr": true,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "start": 2803,
+      "end": 2804,
+      "loc": {
+        "start": {
+          "line": 109,
+          "column": 27
+        },
+        "end": {
+          "line": 109,
+          "column": 28
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "name",
+        "beforeExpr": false,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "value": "res",
+      "start": 2804,
+      "end": 2807,
+      "loc": {
+        "start": {
+          "line": 109,
+          "column": 28
+        },
+        "end": {
+          "line": 109,
+          "column": 31
+        }
+      }
+    },
+    {
+      "type": {
+        "label": ".",
+        "beforeExpr": false,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null,
+        "updateContext": null
+      },
+      "start": 2807,
+      "end": 2808,
+      "loc": {
+        "start": {
+          "line": 109,
+          "column": 31
+        },
+        "end": {
+          "line": 109,
+          "column": 32
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "name",
+        "beforeExpr": false,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "value": "data",
+      "start": 2808,
+      "end": 2812,
+      "loc": {
+        "start": {
+          "line": 109,
+          "column": 32
+        },
+        "end": {
+          "line": 109,
+          "column": 36
+        }
+      }
+    },
+    {
+      "type": {
+        "label": ")",
+        "beforeExpr": false,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "start": 2812,
+      "end": 2813,
+      "loc": {
+        "start": {
+          "line": 109,
+          "column": 36
+        },
+        "end": {
+          "line": 109,
+          "column": 37
+        }
+      }
+    },
+    {
+      "type": {
+        "label": ";",
+        "beforeExpr": true,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null,
+        "updateContext": null
+      },
+      "start": 2813,
+      "end": 2814,
+      "loc": {
+        "start": {
+          "line": 109,
+          "column": 37
+        },
+        "end": {
+          "line": 109,
+          "column": 38
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "}",
+        "beforeExpr": false,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "start": 2818,
+      "end": 2819,
+      "loc": {
+        "start": {
+          "line": 110,
+          "column": 3
+        },
+        "end": {
+          "line": 110,
+          "column": 4
+        }
+      }
+    },
+    {
+      "type": {
+        "label": ")",
+        "beforeExpr": false,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "start": 2819,
+      "end": 2820,
+      "loc": {
+        "start": {
+          "line": 110,
+          "column": 4
+        },
+        "end": {
+          "line": 110,
+          "column": 5
+        }
+      }
+    },
+    {
+      "type": {
+        "label": ";",
+        "beforeExpr": true,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null,
+        "updateContext": null
+      },
+      "start": 2820,
+      "end": 2821,
+      "loc": {
+        "start": {
+          "line": 110,
+          "column": 5
+        },
+        "end": {
+          "line": 110,
+          "column": 6
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "}",
+        "beforeExpr": false,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "start": 2823,
+      "end": 2824,
+      "loc": {
+        "start": {
+          "line": 111,
+          "column": 1
+        },
+        "end": {
+          "line": 111,
+          "column": 2
+        }
+      }
+    },
+    {
+      "type": {
+        "label": ";",
+        "beforeExpr": true,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null,
+        "updateContext": null
+      },
+      "start": 2824,
+      "end": 2825,
+      "loc": {
+        "start": {
+          "line": 111,
+          "column": 2
+        },
+        "end": {
+          "line": 111,
           "column": 3
         }
       }
     },
     {
       "type": "CommentBlock",
-      "value": "*\n   * Get a list of all FZB files\n   * @return {Promise}\n   ",
-      "start": 2715,
-      "end": 2780,
+      "value": "*\n  * Get a single part svg from the core parts as svg-string\n  *\n  * @param  {String} src\n  * @param  {String} url - The base URL of the parts api\n  * @return {Promise} the fetch promise returns xml\n  ",
+      "start": 2828,
+      "end": 3034,
       "loc": {
         "start": {
-          "line": 117,
-          "column": 2
+          "line": 113,
+          "column": 1
+        },
+        "end": {
+          "line": 119,
+          "column": 4
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "const",
+        "keyword": "const",
+        "beforeExpr": false,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null,
+        "updateContext": null
+      },
+      "value": "const",
+      "start": 3035,
+      "end": 3040,
+      "loc": {
+        "start": {
+          "line": 120,
+          "column": 0
         },
         "end": {
           "line": 120,
@@ -16236,17 +18880,71 @@
         "postfix": false,
         "binop": null
       },
-      "value": "getFzbs",
-      "start": 2783,
-      "end": 2790,
+      "value": "getSvgCore",
+      "start": 3041,
+      "end": 3051,
       "loc": {
         "start": {
-          "line": 121,
-          "column": 2
+          "line": 120,
+          "column": 6
         },
         "end": {
-          "line": 121,
-          "column": 9
+          "line": 120,
+          "column": 16
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "=",
+        "beforeExpr": true,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": true,
+        "prefix": false,
+        "postfix": false,
+        "binop": null,
+        "updateContext": null
+      },
+      "value": "=",
+      "start": 3052,
+      "end": 3053,
+      "loc": {
+        "start": {
+          "line": 120,
+          "column": 17
+        },
+        "end": {
+          "line": 120,
+          "column": 18
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "function",
+        "keyword": "function",
+        "beforeExpr": false,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "value": "function",
+      "start": 3054,
+      "end": 3062,
+      "loc": {
+        "start": {
+          "line": 120,
+          "column": 19
+        },
+        "end": {
+          "line": 120,
+          "column": 27
         }
       }
     },
@@ -16262,16 +18960,147 @@
         "postfix": false,
         "binop": null
       },
-      "start": 2790,
-      "end": 2791,
+      "start": 3062,
+      "end": 3063,
       "loc": {
         "start": {
-          "line": 121,
-          "column": 9
+          "line": 120,
+          "column": 27
         },
         "end": {
-          "line": 121,
-          "column": 10
+          "line": 120,
+          "column": 28
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "name",
+        "beforeExpr": false,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "value": "src",
+      "start": 3063,
+      "end": 3066,
+      "loc": {
+        "start": {
+          "line": 120,
+          "column": 28
+        },
+        "end": {
+          "line": 120,
+          "column": 31
+        }
+      }
+    },
+    {
+      "type": {
+        "label": ",",
+        "beforeExpr": true,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null,
+        "updateContext": null
+      },
+      "start": 3066,
+      "end": 3067,
+      "loc": {
+        "start": {
+          "line": 120,
+          "column": 31
+        },
+        "end": {
+          "line": 120,
+          "column": 32
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "name",
+        "beforeExpr": false,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "value": "url",
+      "start": 3068,
+      "end": 3071,
+      "loc": {
+        "start": {
+          "line": 120,
+          "column": 33
+        },
+        "end": {
+          "line": 120,
+          "column": 36
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "=",
+        "beforeExpr": true,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": true,
+        "prefix": false,
+        "postfix": false,
+        "binop": null,
+        "updateContext": null
+      },
+      "value": "=",
+      "start": 3072,
+      "end": 3073,
+      "loc": {
+        "start": {
+          "line": 120,
+          "column": 37
+        },
+        "end": {
+          "line": 120,
+          "column": 38
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "name",
+        "beforeExpr": false,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "value": "FritzingPartsAPI",
+      "start": 3074,
+      "end": 3090,
+      "loc": {
+        "start": {
+          "line": 120,
+          "column": 39
+        },
+        "end": {
+          "line": 120,
+          "column": 55
         }
       }
     },
@@ -16287,16 +19116,16 @@
         "postfix": false,
         "binop": null
       },
-      "start": 2791,
-      "end": 2792,
+      "start": 3090,
+      "end": 3091,
       "loc": {
         "start": {
-          "line": 121,
-          "column": 10
+          "line": 120,
+          "column": 55
         },
         "end": {
-          "line": 121,
-          "column": 11
+          "line": 120,
+          "column": 56
         }
       }
     },
@@ -16312,16 +19141,16 @@
         "postfix": false,
         "binop": null
       },
-      "start": 2793,
-      "end": 2794,
+      "start": 3092,
+      "end": 3093,
       "loc": {
         "start": {
-          "line": 121,
-          "column": 12
+          "line": 120,
+          "column": 57
         },
         "end": {
-          "line": 121,
-          "column": 13
+          "line": 120,
+          "column": 58
         }
       }
     },
@@ -16340,16 +19169,16 @@
         "updateContext": null
       },
       "value": "return",
-      "start": 2799,
-      "end": 2805,
+      "start": 3096,
+      "end": 3102,
       "loc": {
         "start": {
-          "line": 122,
-          "column": 4
+          "line": 121,
+          "column": 2
         },
         "end": {
-          "line": 122,
-          "column": 10
+          "line": 121,
+          "column": 8
         }
       }
     },
@@ -16366,16 +19195,16 @@
         "binop": null
       },
       "value": "axios",
-      "start": 2806,
-      "end": 2811,
+      "start": 3103,
+      "end": 3108,
       "loc": {
         "start": {
-          "line": 122,
-          "column": 11
+          "line": 121,
+          "column": 9
         },
         "end": {
-          "line": 122,
-          "column": 16
+          "line": 121,
+          "column": 14
         }
       }
     },
@@ -16392,16 +19221,16 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 2811,
-      "end": 2812,
+      "start": 3108,
+      "end": 3109,
       "loc": {
         "start": {
-          "line": 122,
-          "column": 16
+          "line": 121,
+          "column": 14
         },
         "end": {
-          "line": 122,
-          "column": 17
+          "line": 121,
+          "column": 15
         }
       }
     },
@@ -16418,16 +19247,16 @@
         "binop": null
       },
       "value": "get",
-      "start": 2812,
-      "end": 2815,
+      "start": 3109,
+      "end": 3112,
       "loc": {
         "start": {
-          "line": 122,
-          "column": 17
+          "line": 121,
+          "column": 15
         },
         "end": {
-          "line": 122,
-          "column": 20
+          "line": 121,
+          "column": 18
         }
       }
     },
@@ -16443,23 +19272,22 @@
         "postfix": false,
         "binop": null
       },
-      "start": 2815,
-      "end": 2816,
+      "start": 3112,
+      "end": 3113,
       "loc": {
         "start": {
-          "line": 122,
-          "column": 20
+          "line": 121,
+          "column": 18
         },
         "end": {
-          "line": 122,
-          "column": 21
+          "line": 121,
+          "column": 19
         }
       }
     },
     {
       "type": {
-        "label": "this",
-        "keyword": "this",
+        "label": "`",
         "beforeExpr": false,
         "startsExpr": true,
         "rightAssociative": false,
@@ -16467,26 +19295,24 @@
         "isAssign": false,
         "prefix": false,
         "postfix": false,
-        "binop": null,
-        "updateContext": null
+        "binop": null
       },
-      "value": "this",
-      "start": 2816,
-      "end": 2820,
+      "start": 3113,
+      "end": 3114,
       "loc": {
         "start": {
-          "line": 122,
-          "column": 21
+          "line": 121,
+          "column": 19
         },
         "end": {
-          "line": 122,
-          "column": 25
+          "line": 121,
+          "column": 20
         }
       }
     },
     {
       "type": {
-        "label": ".",
+        "label": "template",
         "beforeExpr": false,
         "startsExpr": false,
         "rightAssociative": false,
@@ -16497,16 +19323,42 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 2820,
-      "end": 2821,
+      "value": "",
+      "start": 3114,
+      "end": 3114,
       "loc": {
         "start": {
-          "line": 122,
-          "column": 25
+          "line": 121,
+          "column": 20
         },
         "end": {
-          "line": 122,
-          "column": 26
+          "line": 121,
+          "column": 20
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "${",
+        "beforeExpr": true,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "start": 3114,
+      "end": 3116,
+      "loc": {
+        "start": {
+          "line": 121,
+          "column": 20
+        },
+        "end": {
+          "line": 121,
+          "column": 22
         }
       }
     },
@@ -16523,51 +19375,49 @@
         "binop": null
       },
       "value": "url",
-      "start": 2821,
-      "end": 2824,
+      "start": 3116,
+      "end": 3119,
       "loc": {
         "start": {
-          "line": 122,
-          "column": 26
+          "line": 121,
+          "column": 22
         },
         "end": {
-          "line": 122,
-          "column": 29
+          "line": 121,
+          "column": 25
         }
       }
     },
     {
       "type": {
-        "label": "+/-",
-        "beforeExpr": true,
-        "startsExpr": true,
+        "label": "}",
+        "beforeExpr": false,
+        "startsExpr": false,
         "rightAssociative": false,
         "isLoop": false,
         "isAssign": false,
-        "prefix": true,
+        "prefix": false,
         "postfix": false,
-        "binop": 9,
-        "updateContext": null
+        "binop": null
       },
-      "value": "+",
-      "start": 2824,
-      "end": 2825,
+      "start": 3119,
+      "end": 3120,
       "loc": {
         "start": {
-          "line": 122,
-          "column": 29
+          "line": 121,
+          "column": 25
         },
         "end": {
-          "line": 122,
-          "column": 30
+          "line": 121,
+          "column": 26
         }
       }
     },
     {
       "type": {
-        "label": "string",
+        "label": "template",
         "beforeExpr": false,
-        "startsExpr": true,
+        "startsExpr": false,
         "rightAssociative": false,
         "isLoop": false,
         "isAssign": false,
@@ -16576,17 +19426,145 @@
         "binop": null,
         "updateContext": null
       },
-      "value": "/fzb",
-      "start": 2825,
-      "end": 2831,
+      "value": "/svg/core/",
+      "start": 3120,
+      "end": 3130,
       "loc": {
         "start": {
-          "line": 122,
-          "column": 30
+          "line": 121,
+          "column": 26
         },
         "end": {
-          "line": 122,
+          "line": 121,
           "column": 36
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "${",
+        "beforeExpr": true,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "start": 3130,
+      "end": 3132,
+      "loc": {
+        "start": {
+          "line": 121,
+          "column": 36
+        },
+        "end": {
+          "line": 121,
+          "column": 38
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "name",
+        "beforeExpr": false,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "value": "src",
+      "start": 3132,
+      "end": 3135,
+      "loc": {
+        "start": {
+          "line": 121,
+          "column": 38
+        },
+        "end": {
+          "line": 121,
+          "column": 41
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "}",
+        "beforeExpr": false,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "start": 3135,
+      "end": 3136,
+      "loc": {
+        "start": {
+          "line": 121,
+          "column": 41
+        },
+        "end": {
+          "line": 121,
+          "column": 42
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "template",
+        "beforeExpr": false,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null,
+        "updateContext": null
+      },
+      "value": "",
+      "start": 3136,
+      "end": 3136,
+      "loc": {
+        "start": {
+          "line": 121,
+          "column": 42
+        },
+        "end": {
+          "line": 121,
+          "column": 42
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "`",
+        "beforeExpr": false,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "start": 3136,
+      "end": 3137,
+      "loc": {
+        "start": {
+          "line": 121,
+          "column": 42
+        },
+        "end": {
+          "line": 121,
+          "column": 43
         }
       }
     },
@@ -16603,16 +19581,16 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 2831,
-      "end": 2832,
+      "start": 3137,
+      "end": 3138,
       "loc": {
         "start": {
-          "line": 122,
-          "column": 36
+          "line": 121,
+          "column": 43
         },
         "end": {
-          "line": 122,
-          "column": 37
+          "line": 121,
+          "column": 44
         }
       }
     },
@@ -16628,16 +19606,16 @@
         "postfix": false,
         "binop": null
       },
-      "start": 2833,
-      "end": 2834,
+      "start": 3139,
+      "end": 3140,
       "loc": {
         "start": {
-          "line": 122,
-          "column": 38
+          "line": 121,
+          "column": 45
         },
         "end": {
-          "line": 122,
-          "column": 39
+          "line": 121,
+          "column": 46
         }
       }
     },
@@ -16654,16 +19632,16 @@
         "binop": null
       },
       "value": "responseType",
-      "start": 2834,
-      "end": 2846,
+      "start": 3140,
+      "end": 3152,
       "loc": {
         "start": {
-          "line": 122,
-          "column": 39
+          "line": 121,
+          "column": 46
         },
         "end": {
-          "line": 122,
-          "column": 51
+          "line": 121,
+          "column": 58
         }
       }
     },
@@ -16680,16 +19658,2891 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 2846,
-      "end": 2847,
+      "start": 3152,
+      "end": 3153,
+      "loc": {
+        "start": {
+          "line": 121,
+          "column": 58
+        },
+        "end": {
+          "line": 121,
+          "column": 59
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "string",
+        "beforeExpr": false,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null,
+        "updateContext": null
+      },
+      "value": "xml",
+      "start": 3154,
+      "end": 3159,
+      "loc": {
+        "start": {
+          "line": 121,
+          "column": 60
+        },
+        "end": {
+          "line": 121,
+          "column": 65
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "}",
+        "beforeExpr": false,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "start": 3159,
+      "end": 3160,
+      "loc": {
+        "start": {
+          "line": 121,
+          "column": 65
+        },
+        "end": {
+          "line": 121,
+          "column": 66
+        }
+      }
+    },
+    {
+      "type": {
+        "label": ")",
+        "beforeExpr": false,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "start": 3160,
+      "end": 3161,
+      "loc": {
+        "start": {
+          "line": 121,
+          "column": 66
+        },
+        "end": {
+          "line": 121,
+          "column": 67
+        }
+      }
+    },
+    {
+      "type": {
+        "label": ".",
+        "beforeExpr": false,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null,
+        "updateContext": null
+      },
+      "start": 3164,
+      "end": 3165,
       "loc": {
         "start": {
           "line": 122,
-          "column": 51
+          "column": 2
         },
         "end": {
           "line": 122,
-          "column": 52
+          "column": 3
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "name",
+        "beforeExpr": false,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "value": "then",
+      "start": 3165,
+      "end": 3169,
+      "loc": {
+        "start": {
+          "line": 122,
+          "column": 3
+        },
+        "end": {
+          "line": 122,
+          "column": 7
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "(",
+        "beforeExpr": true,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "start": 3169,
+      "end": 3170,
+      "loc": {
+        "start": {
+          "line": 122,
+          "column": 7
+        },
+        "end": {
+          "line": 122,
+          "column": 8
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "(",
+        "beforeExpr": true,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "start": 3170,
+      "end": 3171,
+      "loc": {
+        "start": {
+          "line": 122,
+          "column": 8
+        },
+        "end": {
+          "line": 122,
+          "column": 9
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "name",
+        "beforeExpr": false,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "value": "res",
+      "start": 3171,
+      "end": 3174,
+      "loc": {
+        "start": {
+          "line": 122,
+          "column": 9
+        },
+        "end": {
+          "line": 122,
+          "column": 12
+        }
+      }
+    },
+    {
+      "type": {
+        "label": ")",
+        "beforeExpr": false,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "start": 3174,
+      "end": 3175,
+      "loc": {
+        "start": {
+          "line": 122,
+          "column": 12
+        },
+        "end": {
+          "line": 122,
+          "column": 13
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "=>",
+        "beforeExpr": true,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null,
+        "updateContext": null
+      },
+      "start": 3176,
+      "end": 3178,
+      "loc": {
+        "start": {
+          "line": 122,
+          "column": 14
+        },
+        "end": {
+          "line": 122,
+          "column": 16
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "{",
+        "beforeExpr": true,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "start": 3179,
+      "end": 3180,
+      "loc": {
+        "start": {
+          "line": 122,
+          "column": 17
+        },
+        "end": {
+          "line": 122,
+          "column": 18
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "return",
+        "keyword": "return",
+        "beforeExpr": true,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null,
+        "updateContext": null
+      },
+      "value": "return",
+      "start": 3185,
+      "end": 3191,
+      "loc": {
+        "start": {
+          "line": 123,
+          "column": 4
+        },
+        "end": {
+          "line": 123,
+          "column": 10
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "name",
+        "beforeExpr": false,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "value": "Promise",
+      "start": 3192,
+      "end": 3199,
+      "loc": {
+        "start": {
+          "line": 123,
+          "column": 11
+        },
+        "end": {
+          "line": 123,
+          "column": 18
+        }
+      }
+    },
+    {
+      "type": {
+        "label": ".",
+        "beforeExpr": false,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null,
+        "updateContext": null
+      },
+      "start": 3199,
+      "end": 3200,
+      "loc": {
+        "start": {
+          "line": 123,
+          "column": 18
+        },
+        "end": {
+          "line": 123,
+          "column": 19
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "name",
+        "beforeExpr": false,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "value": "resolve",
+      "start": 3200,
+      "end": 3207,
+      "loc": {
+        "start": {
+          "line": 123,
+          "column": 19
+        },
+        "end": {
+          "line": 123,
+          "column": 26
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "(",
+        "beforeExpr": true,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "start": 3207,
+      "end": 3208,
+      "loc": {
+        "start": {
+          "line": 123,
+          "column": 26
+        },
+        "end": {
+          "line": 123,
+          "column": 27
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "name",
+        "beforeExpr": false,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "value": "res",
+      "start": 3208,
+      "end": 3211,
+      "loc": {
+        "start": {
+          "line": 123,
+          "column": 27
+        },
+        "end": {
+          "line": 123,
+          "column": 30
+        }
+      }
+    },
+    {
+      "type": {
+        "label": ".",
+        "beforeExpr": false,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null,
+        "updateContext": null
+      },
+      "start": 3211,
+      "end": 3212,
+      "loc": {
+        "start": {
+          "line": 123,
+          "column": 30
+        },
+        "end": {
+          "line": 123,
+          "column": 31
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "name",
+        "beforeExpr": false,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "value": "data",
+      "start": 3212,
+      "end": 3216,
+      "loc": {
+        "start": {
+          "line": 123,
+          "column": 31
+        },
+        "end": {
+          "line": 123,
+          "column": 35
+        }
+      }
+    },
+    {
+      "type": {
+        "label": ")",
+        "beforeExpr": false,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "start": 3216,
+      "end": 3217,
+      "loc": {
+        "start": {
+          "line": 123,
+          "column": 35
+        },
+        "end": {
+          "line": 123,
+          "column": 36
+        }
+      }
+    },
+    {
+      "type": {
+        "label": ";",
+        "beforeExpr": true,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null,
+        "updateContext": null
+      },
+      "start": 3217,
+      "end": 3218,
+      "loc": {
+        "start": {
+          "line": 123,
+          "column": 36
+        },
+        "end": {
+          "line": 123,
+          "column": 37
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "}",
+        "beforeExpr": false,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "start": 3221,
+      "end": 3222,
+      "loc": {
+        "start": {
+          "line": 124,
+          "column": 2
+        },
+        "end": {
+          "line": 124,
+          "column": 3
+        }
+      }
+    },
+    {
+      "type": {
+        "label": ")",
+        "beforeExpr": false,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "start": 3222,
+      "end": 3223,
+      "loc": {
+        "start": {
+          "line": 124,
+          "column": 3
+        },
+        "end": {
+          "line": 124,
+          "column": 4
+        }
+      }
+    },
+    {
+      "type": {
+        "label": ";",
+        "beforeExpr": true,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null,
+        "updateContext": null
+      },
+      "start": 3223,
+      "end": 3224,
+      "loc": {
+        "start": {
+          "line": 124,
+          "column": 4
+        },
+        "end": {
+          "line": 124,
+          "column": 5
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "}",
+        "beforeExpr": false,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "start": 3225,
+      "end": 3226,
+      "loc": {
+        "start": {
+          "line": 125,
+          "column": 0
+        },
+        "end": {
+          "line": 125,
+          "column": 1
+        }
+      }
+    },
+    {
+      "type": {
+        "label": ";",
+        "beforeExpr": true,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null,
+        "updateContext": null
+      },
+      "start": 3226,
+      "end": 3227,
+      "loc": {
+        "start": {
+          "line": 125,
+          "column": 1
+        },
+        "end": {
+          "line": 125,
+          "column": 2
+        }
+      }
+    },
+    {
+      "type": "CommentBlock",
+      "value": "*\n * Get a single part svg from the obsolete svgs, this is for old-sketches only! the response is a svg-string\n *\n * @param  {String} src\n * @param  {String} url - The base URL of the parts api\n * @return {Promise} the fetch promise\n ",
+      "start": 3229,
+      "end": 3467,
+      "loc": {
+        "start": {
+          "line": 127,
+          "column": 0
+        },
+        "end": {
+          "line": 133,
+          "column": 3
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "const",
+        "keyword": "const",
+        "beforeExpr": false,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null,
+        "updateContext": null
+      },
+      "value": "const",
+      "start": 3468,
+      "end": 3473,
+      "loc": {
+        "start": {
+          "line": 134,
+          "column": 0
+        },
+        "end": {
+          "line": 134,
+          "column": 5
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "name",
+        "beforeExpr": false,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "value": "getSvgObsolete",
+      "start": 3474,
+      "end": 3488,
+      "loc": {
+        "start": {
+          "line": 134,
+          "column": 6
+        },
+        "end": {
+          "line": 134,
+          "column": 20
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "=",
+        "beforeExpr": true,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": true,
+        "prefix": false,
+        "postfix": false,
+        "binop": null,
+        "updateContext": null
+      },
+      "value": "=",
+      "start": 3489,
+      "end": 3490,
+      "loc": {
+        "start": {
+          "line": 134,
+          "column": 21
+        },
+        "end": {
+          "line": 134,
+          "column": 22
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "function",
+        "keyword": "function",
+        "beforeExpr": false,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "value": "function",
+      "start": 3491,
+      "end": 3499,
+      "loc": {
+        "start": {
+          "line": 134,
+          "column": 23
+        },
+        "end": {
+          "line": 134,
+          "column": 31
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "(",
+        "beforeExpr": true,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "start": 3499,
+      "end": 3500,
+      "loc": {
+        "start": {
+          "line": 134,
+          "column": 31
+        },
+        "end": {
+          "line": 134,
+          "column": 32
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "name",
+        "beforeExpr": false,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "value": "src",
+      "start": 3500,
+      "end": 3503,
+      "loc": {
+        "start": {
+          "line": 134,
+          "column": 32
+        },
+        "end": {
+          "line": 134,
+          "column": 35
+        }
+      }
+    },
+    {
+      "type": {
+        "label": ",",
+        "beforeExpr": true,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null,
+        "updateContext": null
+      },
+      "start": 3503,
+      "end": 3504,
+      "loc": {
+        "start": {
+          "line": 134,
+          "column": 35
+        },
+        "end": {
+          "line": 134,
+          "column": 36
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "name",
+        "beforeExpr": false,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "value": "url",
+      "start": 3505,
+      "end": 3508,
+      "loc": {
+        "start": {
+          "line": 134,
+          "column": 37
+        },
+        "end": {
+          "line": 134,
+          "column": 40
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "=",
+        "beforeExpr": true,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": true,
+        "prefix": false,
+        "postfix": false,
+        "binop": null,
+        "updateContext": null
+      },
+      "value": "=",
+      "start": 3509,
+      "end": 3510,
+      "loc": {
+        "start": {
+          "line": 134,
+          "column": 41
+        },
+        "end": {
+          "line": 134,
+          "column": 42
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "name",
+        "beforeExpr": false,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "value": "FritzingPartsAPI",
+      "start": 3511,
+      "end": 3527,
+      "loc": {
+        "start": {
+          "line": 134,
+          "column": 43
+        },
+        "end": {
+          "line": 134,
+          "column": 59
+        }
+      }
+    },
+    {
+      "type": {
+        "label": ")",
+        "beforeExpr": false,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "start": 3527,
+      "end": 3528,
+      "loc": {
+        "start": {
+          "line": 134,
+          "column": 59
+        },
+        "end": {
+          "line": 134,
+          "column": 60
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "{",
+        "beforeExpr": true,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "start": 3529,
+      "end": 3530,
+      "loc": {
+        "start": {
+          "line": 134,
+          "column": 61
+        },
+        "end": {
+          "line": 134,
+          "column": 62
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "return",
+        "keyword": "return",
+        "beforeExpr": true,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null,
+        "updateContext": null
+      },
+      "value": "return",
+      "start": 3533,
+      "end": 3539,
+      "loc": {
+        "start": {
+          "line": 135,
+          "column": 2
+        },
+        "end": {
+          "line": 135,
+          "column": 8
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "name",
+        "beforeExpr": false,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "value": "axios",
+      "start": 3540,
+      "end": 3545,
+      "loc": {
+        "start": {
+          "line": 135,
+          "column": 9
+        },
+        "end": {
+          "line": 135,
+          "column": 14
+        }
+      }
+    },
+    {
+      "type": {
+        "label": ".",
+        "beforeExpr": false,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null,
+        "updateContext": null
+      },
+      "start": 3545,
+      "end": 3546,
+      "loc": {
+        "start": {
+          "line": 135,
+          "column": 14
+        },
+        "end": {
+          "line": 135,
+          "column": 15
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "name",
+        "beforeExpr": false,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "value": "get",
+      "start": 3546,
+      "end": 3549,
+      "loc": {
+        "start": {
+          "line": 135,
+          "column": 15
+        },
+        "end": {
+          "line": 135,
+          "column": 18
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "(",
+        "beforeExpr": true,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "start": 3549,
+      "end": 3550,
+      "loc": {
+        "start": {
+          "line": 135,
+          "column": 18
+        },
+        "end": {
+          "line": 135,
+          "column": 19
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "`",
+        "beforeExpr": false,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "start": 3550,
+      "end": 3551,
+      "loc": {
+        "start": {
+          "line": 135,
+          "column": 19
+        },
+        "end": {
+          "line": 135,
+          "column": 20
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "template",
+        "beforeExpr": false,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null,
+        "updateContext": null
+      },
+      "value": "",
+      "start": 3551,
+      "end": 3551,
+      "loc": {
+        "start": {
+          "line": 135,
+          "column": 20
+        },
+        "end": {
+          "line": 135,
+          "column": 20
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "${",
+        "beforeExpr": true,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "start": 3551,
+      "end": 3553,
+      "loc": {
+        "start": {
+          "line": 135,
+          "column": 20
+        },
+        "end": {
+          "line": 135,
+          "column": 22
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "name",
+        "beforeExpr": false,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "value": "url",
+      "start": 3553,
+      "end": 3556,
+      "loc": {
+        "start": {
+          "line": 135,
+          "column": 22
+        },
+        "end": {
+          "line": 135,
+          "column": 25
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "}",
+        "beforeExpr": false,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "start": 3556,
+      "end": 3557,
+      "loc": {
+        "start": {
+          "line": 135,
+          "column": 25
+        },
+        "end": {
+          "line": 135,
+          "column": 26
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "template",
+        "beforeExpr": false,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null,
+        "updateContext": null
+      },
+      "value": "/svg/obsolete/",
+      "start": 3557,
+      "end": 3571,
+      "loc": {
+        "start": {
+          "line": 135,
+          "column": 26
+        },
+        "end": {
+          "line": 135,
+          "column": 40
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "${",
+        "beforeExpr": true,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "start": 3571,
+      "end": 3573,
+      "loc": {
+        "start": {
+          "line": 135,
+          "column": 40
+        },
+        "end": {
+          "line": 135,
+          "column": 42
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "name",
+        "beforeExpr": false,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "value": "src",
+      "start": 3573,
+      "end": 3576,
+      "loc": {
+        "start": {
+          "line": 135,
+          "column": 42
+        },
+        "end": {
+          "line": 135,
+          "column": 45
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "}",
+        "beforeExpr": false,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "start": 3576,
+      "end": 3577,
+      "loc": {
+        "start": {
+          "line": 135,
+          "column": 45
+        },
+        "end": {
+          "line": 135,
+          "column": 46
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "template",
+        "beforeExpr": false,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null,
+        "updateContext": null
+      },
+      "value": "",
+      "start": 3577,
+      "end": 3577,
+      "loc": {
+        "start": {
+          "line": 135,
+          "column": 46
+        },
+        "end": {
+          "line": 135,
+          "column": 46
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "`",
+        "beforeExpr": false,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "start": 3577,
+      "end": 3578,
+      "loc": {
+        "start": {
+          "line": 135,
+          "column": 46
+        },
+        "end": {
+          "line": 135,
+          "column": 47
+        }
+      }
+    },
+    {
+      "type": {
+        "label": ",",
+        "beforeExpr": true,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null,
+        "updateContext": null
+      },
+      "start": 3578,
+      "end": 3579,
+      "loc": {
+        "start": {
+          "line": 135,
+          "column": 47
+        },
+        "end": {
+          "line": 135,
+          "column": 48
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "{",
+        "beforeExpr": true,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "start": 3580,
+      "end": 3581,
+      "loc": {
+        "start": {
+          "line": 135,
+          "column": 49
+        },
+        "end": {
+          "line": 135,
+          "column": 50
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "name",
+        "beforeExpr": false,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "value": "responseType",
+      "start": 3581,
+      "end": 3593,
+      "loc": {
+        "start": {
+          "line": 135,
+          "column": 50
+        },
+        "end": {
+          "line": 135,
+          "column": 62
+        }
+      }
+    },
+    {
+      "type": {
+        "label": ":",
+        "beforeExpr": true,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null,
+        "updateContext": null
+      },
+      "start": 3593,
+      "end": 3594,
+      "loc": {
+        "start": {
+          "line": 135,
+          "column": 62
+        },
+        "end": {
+          "line": 135,
+          "column": 63
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "string",
+        "beforeExpr": false,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null,
+        "updateContext": null
+      },
+      "value": "xml",
+      "start": 3595,
+      "end": 3600,
+      "loc": {
+        "start": {
+          "line": 135,
+          "column": 64
+        },
+        "end": {
+          "line": 135,
+          "column": 69
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "}",
+        "beforeExpr": false,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "start": 3600,
+      "end": 3601,
+      "loc": {
+        "start": {
+          "line": 135,
+          "column": 69
+        },
+        "end": {
+          "line": 135,
+          "column": 70
+        }
+      }
+    },
+    {
+      "type": {
+        "label": ")",
+        "beforeExpr": false,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "start": 3601,
+      "end": 3602,
+      "loc": {
+        "start": {
+          "line": 135,
+          "column": 70
+        },
+        "end": {
+          "line": 135,
+          "column": 71
+        }
+      }
+    },
+    {
+      "type": {
+        "label": ".",
+        "beforeExpr": false,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null,
+        "updateContext": null
+      },
+      "start": 3605,
+      "end": 3606,
+      "loc": {
+        "start": {
+          "line": 136,
+          "column": 2
+        },
+        "end": {
+          "line": 136,
+          "column": 3
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "name",
+        "beforeExpr": false,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "value": "then",
+      "start": 3606,
+      "end": 3610,
+      "loc": {
+        "start": {
+          "line": 136,
+          "column": 3
+        },
+        "end": {
+          "line": 136,
+          "column": 7
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "(",
+        "beforeExpr": true,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "start": 3610,
+      "end": 3611,
+      "loc": {
+        "start": {
+          "line": 136,
+          "column": 7
+        },
+        "end": {
+          "line": 136,
+          "column": 8
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "(",
+        "beforeExpr": true,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "start": 3611,
+      "end": 3612,
+      "loc": {
+        "start": {
+          "line": 136,
+          "column": 8
+        },
+        "end": {
+          "line": 136,
+          "column": 9
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "name",
+        "beforeExpr": false,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "value": "res",
+      "start": 3612,
+      "end": 3615,
+      "loc": {
+        "start": {
+          "line": 136,
+          "column": 9
+        },
+        "end": {
+          "line": 136,
+          "column": 12
+        }
+      }
+    },
+    {
+      "type": {
+        "label": ")",
+        "beforeExpr": false,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "start": 3615,
+      "end": 3616,
+      "loc": {
+        "start": {
+          "line": 136,
+          "column": 12
+        },
+        "end": {
+          "line": 136,
+          "column": 13
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "=>",
+        "beforeExpr": true,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null,
+        "updateContext": null
+      },
+      "start": 3617,
+      "end": 3619,
+      "loc": {
+        "start": {
+          "line": 136,
+          "column": 14
+        },
+        "end": {
+          "line": 136,
+          "column": 16
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "{",
+        "beforeExpr": true,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "start": 3620,
+      "end": 3621,
+      "loc": {
+        "start": {
+          "line": 136,
+          "column": 17
+        },
+        "end": {
+          "line": 136,
+          "column": 18
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "return",
+        "keyword": "return",
+        "beforeExpr": true,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null,
+        "updateContext": null
+      },
+      "value": "return",
+      "start": 3626,
+      "end": 3632,
+      "loc": {
+        "start": {
+          "line": 137,
+          "column": 4
+        },
+        "end": {
+          "line": 137,
+          "column": 10
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "name",
+        "beforeExpr": false,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "value": "Promise",
+      "start": 3633,
+      "end": 3640,
+      "loc": {
+        "start": {
+          "line": 137,
+          "column": 11
+        },
+        "end": {
+          "line": 137,
+          "column": 18
+        }
+      }
+    },
+    {
+      "type": {
+        "label": ".",
+        "beforeExpr": false,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null,
+        "updateContext": null
+      },
+      "start": 3640,
+      "end": 3641,
+      "loc": {
+        "start": {
+          "line": 137,
+          "column": 18
+        },
+        "end": {
+          "line": 137,
+          "column": 19
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "name",
+        "beforeExpr": false,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "value": "resolve",
+      "start": 3641,
+      "end": 3648,
+      "loc": {
+        "start": {
+          "line": 137,
+          "column": 19
+        },
+        "end": {
+          "line": 137,
+          "column": 26
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "(",
+        "beforeExpr": true,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "start": 3648,
+      "end": 3649,
+      "loc": {
+        "start": {
+          "line": 137,
+          "column": 26
+        },
+        "end": {
+          "line": 137,
+          "column": 27
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "name",
+        "beforeExpr": false,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "value": "res",
+      "start": 3649,
+      "end": 3652,
+      "loc": {
+        "start": {
+          "line": 137,
+          "column": 27
+        },
+        "end": {
+          "line": 137,
+          "column": 30
+        }
+      }
+    },
+    {
+      "type": {
+        "label": ".",
+        "beforeExpr": false,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null,
+        "updateContext": null
+      },
+      "start": 3652,
+      "end": 3653,
+      "loc": {
+        "start": {
+          "line": 137,
+          "column": 30
+        },
+        "end": {
+          "line": 137,
+          "column": 31
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "name",
+        "beforeExpr": false,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "value": "data",
+      "start": 3653,
+      "end": 3657,
+      "loc": {
+        "start": {
+          "line": 137,
+          "column": 31
+        },
+        "end": {
+          "line": 137,
+          "column": 35
+        }
+      }
+    },
+    {
+      "type": {
+        "label": ")",
+        "beforeExpr": false,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "start": 3657,
+      "end": 3658,
+      "loc": {
+        "start": {
+          "line": 137,
+          "column": 35
+        },
+        "end": {
+          "line": 137,
+          "column": 36
+        }
+      }
+    },
+    {
+      "type": {
+        "label": ";",
+        "beforeExpr": true,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null,
+        "updateContext": null
+      },
+      "start": 3658,
+      "end": 3659,
+      "loc": {
+        "start": {
+          "line": 137,
+          "column": 36
+        },
+        "end": {
+          "line": 137,
+          "column": 37
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "}",
+        "beforeExpr": false,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "start": 3662,
+      "end": 3663,
+      "loc": {
+        "start": {
+          "line": 138,
+          "column": 2
+        },
+        "end": {
+          "line": 138,
+          "column": 3
+        }
+      }
+    },
+    {
+      "type": {
+        "label": ")",
+        "beforeExpr": false,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "start": 3663,
+      "end": 3664,
+      "loc": {
+        "start": {
+          "line": 138,
+          "column": 3
+        },
+        "end": {
+          "line": 138,
+          "column": 4
+        }
+      }
+    },
+    {
+      "type": {
+        "label": ";",
+        "beforeExpr": true,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null,
+        "updateContext": null
+      },
+      "start": 3664,
+      "end": 3665,
+      "loc": {
+        "start": {
+          "line": 138,
+          "column": 4
+        },
+        "end": {
+          "line": 138,
+          "column": 5
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "}",
+        "beforeExpr": false,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "start": 3666,
+      "end": 3667,
+      "loc": {
+        "start": {
+          "line": 139,
+          "column": 0
+        },
+        "end": {
+          "line": 139,
+          "column": 1
+        }
+      }
+    },
+    {
+      "type": {
+        "label": ";",
+        "beforeExpr": true,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null,
+        "updateContext": null
+      },
+      "start": 3667,
+      "end": 3668,
+      "loc": {
+        "start": {
+          "line": 139,
+          "column": 1
+        },
+        "end": {
+          "line": 139,
+          "column": 2
+        }
+      }
+    },
+    {
+      "type": "CommentBlock",
+      "value": "*\n * Get a list of all FZB files\n *\n * @param  {String} url - The base URL of the parts api\n * @return {Promise}\n ",
+      "start": 3670,
+      "end": 3788,
+      "loc": {
+        "start": {
+          "line": 141,
+          "column": 0
+        },
+        "end": {
+          "line": 146,
+          "column": 3
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "const",
+        "keyword": "const",
+        "beforeExpr": false,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null,
+        "updateContext": null
+      },
+      "value": "const",
+      "start": 3789,
+      "end": 3794,
+      "loc": {
+        "start": {
+          "line": 147,
+          "column": 0
+        },
+        "end": {
+          "line": 147,
+          "column": 5
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "name",
+        "beforeExpr": false,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "value": "getFzbs",
+      "start": 3795,
+      "end": 3802,
+      "loc": {
+        "start": {
+          "line": 147,
+          "column": 6
+        },
+        "end": {
+          "line": 147,
+          "column": 13
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "=",
+        "beforeExpr": true,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": true,
+        "prefix": false,
+        "postfix": false,
+        "binop": null,
+        "updateContext": null
+      },
+      "value": "=",
+      "start": 3803,
+      "end": 3804,
+      "loc": {
+        "start": {
+          "line": 147,
+          "column": 14
+        },
+        "end": {
+          "line": 147,
+          "column": 15
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "function",
+        "keyword": "function",
+        "beforeExpr": false,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "value": "function",
+      "start": 3805,
+      "end": 3813,
+      "loc": {
+        "start": {
+          "line": 147,
+          "column": 16
+        },
+        "end": {
+          "line": 147,
+          "column": 24
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "(",
+        "beforeExpr": true,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "start": 3813,
+      "end": 3814,
+      "loc": {
+        "start": {
+          "line": 147,
+          "column": 24
+        },
+        "end": {
+          "line": 147,
+          "column": 25
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "name",
+        "beforeExpr": false,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "value": "url",
+      "start": 3814,
+      "end": 3817,
+      "loc": {
+        "start": {
+          "line": 147,
+          "column": 25
+        },
+        "end": {
+          "line": 147,
+          "column": 28
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "=",
+        "beforeExpr": true,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": true,
+        "prefix": false,
+        "postfix": false,
+        "binop": null,
+        "updateContext": null
+      },
+      "value": "=",
+      "start": 3818,
+      "end": 3819,
+      "loc": {
+        "start": {
+          "line": 147,
+          "column": 29
+        },
+        "end": {
+          "line": 147,
+          "column": 30
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "`",
+        "beforeExpr": false,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "start": 3820,
+      "end": 3821,
+      "loc": {
+        "start": {
+          "line": 147,
+          "column": 31
+        },
+        "end": {
+          "line": 147,
+          "column": 32
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "template",
+        "beforeExpr": false,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null,
+        "updateContext": null
+      },
+      "value": "",
+      "start": 3821,
+      "end": 3821,
+      "loc": {
+        "start": {
+          "line": 147,
+          "column": 32
+        },
+        "end": {
+          "line": 147,
+          "column": 32
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "${",
+        "beforeExpr": true,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "start": 3821,
+      "end": 3823,
+      "loc": {
+        "start": {
+          "line": 147,
+          "column": 32
+        },
+        "end": {
+          "line": 147,
+          "column": 34
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "name",
+        "beforeExpr": false,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "value": "FritzingPartsAPI",
+      "start": 3823,
+      "end": 3839,
+      "loc": {
+        "start": {
+          "line": 147,
+          "column": 34
+        },
+        "end": {
+          "line": 147,
+          "column": 50
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "}",
+        "beforeExpr": false,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "start": 3839,
+      "end": 3840,
+      "loc": {
+        "start": {
+          "line": 147,
+          "column": 50
+        },
+        "end": {
+          "line": 147,
+          "column": 51
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "template",
+        "beforeExpr": false,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null,
+        "updateContext": null
+      },
+      "value": "/fzb",
+      "start": 3840,
+      "end": 3844,
+      "loc": {
+        "start": {
+          "line": 147,
+          "column": 51
+        },
+        "end": {
+          "line": 147,
+          "column": 55
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "`",
+        "beforeExpr": false,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "start": 3844,
+      "end": 3845,
+      "loc": {
+        "start": {
+          "line": 147,
+          "column": 55
+        },
+        "end": {
+          "line": 147,
+          "column": 56
+        }
+      }
+    },
+    {
+      "type": {
+        "label": ")",
+        "beforeExpr": false,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "start": 3845,
+      "end": 3846,
+      "loc": {
+        "start": {
+          "line": 147,
+          "column": 56
+        },
+        "end": {
+          "line": 147,
+          "column": 57
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "{",
+        "beforeExpr": true,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "start": 3847,
+      "end": 3848,
+      "loc": {
+        "start": {
+          "line": 147,
+          "column": 58
+        },
+        "end": {
+          "line": 147,
+          "column": 59
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "return",
+        "keyword": "return",
+        "beforeExpr": true,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null,
+        "updateContext": null
+      },
+      "value": "return",
+      "start": 3851,
+      "end": 3857,
+      "loc": {
+        "start": {
+          "line": 148,
+          "column": 2
+        },
+        "end": {
+          "line": 148,
+          "column": 8
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "name",
+        "beforeExpr": false,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "value": "axios",
+      "start": 3858,
+      "end": 3863,
+      "loc": {
+        "start": {
+          "line": 148,
+          "column": 9
+        },
+        "end": {
+          "line": 148,
+          "column": 14
+        }
+      }
+    },
+    {
+      "type": {
+        "label": ".",
+        "beforeExpr": false,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null,
+        "updateContext": null
+      },
+      "start": 3863,
+      "end": 3864,
+      "loc": {
+        "start": {
+          "line": 148,
+          "column": 14
+        },
+        "end": {
+          "line": 148,
+          "column": 15
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "name",
+        "beforeExpr": false,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "value": "get",
+      "start": 3864,
+      "end": 3867,
+      "loc": {
+        "start": {
+          "line": 148,
+          "column": 15
+        },
+        "end": {
+          "line": 148,
+          "column": 18
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "(",
+        "beforeExpr": true,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "start": 3867,
+      "end": 3868,
+      "loc": {
+        "start": {
+          "line": 148,
+          "column": 18
+        },
+        "end": {
+          "line": 148,
+          "column": 19
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "name",
+        "beforeExpr": false,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "value": "url",
+      "start": 3868,
+      "end": 3871,
+      "loc": {
+        "start": {
+          "line": 148,
+          "column": 19
+        },
+        "end": {
+          "line": 148,
+          "column": 22
+        }
+      }
+    },
+    {
+      "type": {
+        "label": ",",
+        "beforeExpr": true,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null,
+        "updateContext": null
+      },
+      "start": 3871,
+      "end": 3872,
+      "loc": {
+        "start": {
+          "line": 148,
+          "column": 22
+        },
+        "end": {
+          "line": 148,
+          "column": 23
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "{",
+        "beforeExpr": true,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "start": 3873,
+      "end": 3874,
+      "loc": {
+        "start": {
+          "line": 148,
+          "column": 24
+        },
+        "end": {
+          "line": 148,
+          "column": 25
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "name",
+        "beforeExpr": false,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "value": "responseType",
+      "start": 3874,
+      "end": 3886,
+      "loc": {
+        "start": {
+          "line": 148,
+          "column": 25
+        },
+        "end": {
+          "line": 148,
+          "column": 37
+        }
+      }
+    },
+    {
+      "type": {
+        "label": ":",
+        "beforeExpr": true,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null,
+        "updateContext": null
+      },
+      "start": 3886,
+      "end": 3887,
+      "loc": {
+        "start": {
+          "line": 148,
+          "column": 37
+        },
+        "end": {
+          "line": 148,
+          "column": 38
         }
       }
     },
@@ -16707,16 +22560,16 @@
         "updateContext": null
       },
       "value": "json",
-      "start": 2848,
-      "end": 2854,
+      "start": 3888,
+      "end": 3894,
       "loc": {
         "start": {
-          "line": 122,
-          "column": 53
+          "line": 148,
+          "column": 39
         },
         "end": {
-          "line": 122,
-          "column": 59
+          "line": 148,
+          "column": 45
         }
       }
     },
@@ -16732,16 +22585,16 @@
         "postfix": false,
         "binop": null
       },
-      "start": 2854,
-      "end": 2855,
+      "start": 3894,
+      "end": 3895,
       "loc": {
         "start": {
-          "line": 122,
-          "column": 59
+          "line": 148,
+          "column": 45
         },
         "end": {
-          "line": 122,
-          "column": 60
+          "line": 148,
+          "column": 46
         }
       }
     },
@@ -16757,16 +22610,16 @@
         "postfix": false,
         "binop": null
       },
-      "start": 2855,
-      "end": 2856,
+      "start": 3895,
+      "end": 3896,
       "loc": {
         "start": {
-          "line": 122,
-          "column": 60
+          "line": 148,
+          "column": 46
         },
         "end": {
-          "line": 122,
-          "column": 61
+          "line": 148,
+          "column": 47
         }
       }
     },
@@ -16783,16 +22636,16 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 2861,
-      "end": 2862,
+      "start": 3899,
+      "end": 3900,
       "loc": {
         "start": {
-          "line": 123,
-          "column": 4
+          "line": 149,
+          "column": 2
         },
         "end": {
-          "line": 123,
-          "column": 5
+          "line": 149,
+          "column": 3
         }
       }
     },
@@ -16809,16 +22662,16 @@
         "binop": null
       },
       "value": "then",
-      "start": 2862,
-      "end": 2866,
+      "start": 3900,
+      "end": 3904,
       "loc": {
         "start": {
-          "line": 123,
-          "column": 5
+          "line": 149,
+          "column": 3
         },
         "end": {
-          "line": 123,
-          "column": 9
+          "line": 149,
+          "column": 7
         }
       }
     },
@@ -16834,16 +22687,16 @@
         "postfix": false,
         "binop": null
       },
-      "start": 2866,
-      "end": 2867,
+      "start": 3904,
+      "end": 3905,
       "loc": {
         "start": {
-          "line": 123,
-          "column": 9
+          "line": 149,
+          "column": 7
         },
         "end": {
-          "line": 123,
-          "column": 10
+          "line": 149,
+          "column": 8
         }
       }
     },
@@ -16859,16 +22712,16 @@
         "postfix": false,
         "binop": null
       },
-      "start": 2867,
-      "end": 2868,
+      "start": 3905,
+      "end": 3906,
       "loc": {
         "start": {
-          "line": 123,
-          "column": 10
+          "line": 149,
+          "column": 8
         },
         "end": {
-          "line": 123,
-          "column": 11
+          "line": 149,
+          "column": 9
         }
       }
     },
@@ -16885,16 +22738,16 @@
         "binop": null
       },
       "value": "res",
-      "start": 2868,
-      "end": 2871,
+      "start": 3906,
+      "end": 3909,
       "loc": {
         "start": {
-          "line": 123,
-          "column": 11
+          "line": 149,
+          "column": 9
         },
         "end": {
-          "line": 123,
-          "column": 14
+          "line": 149,
+          "column": 12
         }
       }
     },
@@ -16910,16 +22763,16 @@
         "postfix": false,
         "binop": null
       },
-      "start": 2871,
-      "end": 2872,
+      "start": 3909,
+      "end": 3910,
       "loc": {
         "start": {
-          "line": 123,
-          "column": 14
+          "line": 149,
+          "column": 12
         },
         "end": {
-          "line": 123,
-          "column": 15
+          "line": 149,
+          "column": 13
         }
       }
     },
@@ -16936,16 +22789,16 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 2873,
-      "end": 2875,
+      "start": 3911,
+      "end": 3913,
       "loc": {
         "start": {
-          "line": 123,
-          "column": 16
+          "line": 149,
+          "column": 14
         },
         "end": {
-          "line": 123,
-          "column": 18
+          "line": 149,
+          "column": 16
         }
       }
     },
@@ -16961,16 +22814,16 @@
         "postfix": false,
         "binop": null
       },
-      "start": 2876,
-      "end": 2877,
+      "start": 3914,
+      "end": 3915,
       "loc": {
         "start": {
-          "line": 123,
-          "column": 19
+          "line": 149,
+          "column": 17
         },
         "end": {
-          "line": 123,
-          "column": 20
+          "line": 149,
+          "column": 18
         }
       }
     },
@@ -16989,16 +22842,119 @@
         "updateContext": null
       },
       "value": "return",
-      "start": 2884,
-      "end": 2890,
+      "start": 3920,
+      "end": 3926,
       "loc": {
         "start": {
-          "line": 124,
-          "column": 6
+          "line": 150,
+          "column": 4
         },
         "end": {
-          "line": 124,
-          "column": 12
+          "line": 150,
+          "column": 10
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "name",
+        "beforeExpr": false,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "value": "Promise",
+      "start": 3927,
+      "end": 3934,
+      "loc": {
+        "start": {
+          "line": 150,
+          "column": 11
+        },
+        "end": {
+          "line": 150,
+          "column": 18
+        }
+      }
+    },
+    {
+      "type": {
+        "label": ".",
+        "beforeExpr": false,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null,
+        "updateContext": null
+      },
+      "start": 3934,
+      "end": 3935,
+      "loc": {
+        "start": {
+          "line": 150,
+          "column": 18
+        },
+        "end": {
+          "line": 150,
+          "column": 19
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "name",
+        "beforeExpr": false,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "value": "resolve",
+      "start": 3935,
+      "end": 3942,
+      "loc": {
+        "start": {
+          "line": 150,
+          "column": 19
+        },
+        "end": {
+          "line": 150,
+          "column": 26
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "(",
+        "beforeExpr": true,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "start": 3942,
+      "end": 3943,
+      "loc": {
+        "start": {
+          "line": 150,
+          "column": 26
+        },
+        "end": {
+          "line": 150,
+          "column": 27
         }
       }
     },
@@ -17015,16 +22971,16 @@
         "binop": null
       },
       "value": "res",
-      "start": 2891,
-      "end": 2894,
+      "start": 3943,
+      "end": 3946,
       "loc": {
         "start": {
-          "line": 124,
-          "column": 13
+          "line": 150,
+          "column": 27
         },
         "end": {
-          "line": 124,
-          "column": 16
+          "line": 150,
+          "column": 30
         }
       }
     },
@@ -17041,16 +22997,16 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 2894,
-      "end": 2895,
+      "start": 3946,
+      "end": 3947,
       "loc": {
         "start": {
-          "line": 124,
-          "column": 16
+          "line": 150,
+          "column": 30
         },
         "end": {
-          "line": 124,
-          "column": 17
+          "line": 150,
+          "column": 31
         }
       }
     },
@@ -17067,67 +23023,16 @@
         "binop": null
       },
       "value": "data",
-      "start": 2895,
-      "end": 2899,
+      "start": 3947,
+      "end": 3951,
       "loc": {
         "start": {
-          "line": 124,
-          "column": 17
+          "line": 150,
+          "column": 31
         },
         "end": {
-          "line": 124,
-          "column": 21
-        }
-      }
-    },
-    {
-      "type": {
-        "label": ";",
-        "beforeExpr": true,
-        "startsExpr": false,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null,
-        "updateContext": null
-      },
-      "start": 2899,
-      "end": 2900,
-      "loc": {
-        "start": {
-          "line": 124,
-          "column": 21
-        },
-        "end": {
-          "line": 124,
-          "column": 22
-        }
-      }
-    },
-    {
-      "type": {
-        "label": "}",
-        "beforeExpr": false,
-        "startsExpr": false,
-        "rightAssociative": false,
-        "isLoop": false,
-        "isAssign": false,
-        "prefix": false,
-        "postfix": false,
-        "binop": null
-      },
-      "start": 2905,
-      "end": 2906,
-      "loc": {
-        "start": {
-          "line": 125,
-          "column": 4
-        },
-        "end": {
-          "line": 125,
-          "column": 5
+          "line": 150,
+          "column": 35
         }
       }
     },
@@ -17143,16 +23048,16 @@
         "postfix": false,
         "binop": null
       },
-      "start": 2906,
-      "end": 2907,
+      "start": 3951,
+      "end": 3952,
       "loc": {
         "start": {
-          "line": 125,
-          "column": 5
+          "line": 150,
+          "column": 35
         },
         "end": {
-          "line": 125,
-          "column": 6
+          "line": 150,
+          "column": 36
         }
       }
     },
@@ -17169,16 +23074,16 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 2907,
-      "end": 2908,
+      "start": 3952,
+      "end": 3953,
       "loc": {
         "start": {
-          "line": 125,
-          "column": 6
+          "line": 150,
+          "column": 36
         },
         "end": {
-          "line": 125,
-          "column": 7
+          "line": 150,
+          "column": 37
         }
       }
     },
@@ -17194,21 +23099,72 @@
         "postfix": false,
         "binop": null
       },
-      "start": 2911,
-      "end": 2912,
+      "start": 3956,
+      "end": 3957,
       "loc": {
         "start": {
-          "line": 126,
+          "line": 151,
           "column": 2
         },
         "end": {
-          "line": 126,
+          "line": 151,
           "column": 3
         }
       }
     },
     {
       "type": {
+        "label": ")",
+        "beforeExpr": false,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "start": 3957,
+      "end": 3958,
+      "loc": {
+        "start": {
+          "line": 151,
+          "column": 3
+        },
+        "end": {
+          "line": 151,
+          "column": 4
+        }
+      }
+    },
+    {
+      "type": {
+        "label": ";",
+        "beforeExpr": true,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null,
+        "updateContext": null
+      },
+      "start": 3958,
+      "end": 3959,
+      "loc": {
+        "start": {
+          "line": 151,
+          "column": 4
+        },
+        "end": {
+          "line": 151,
+          "column": 5
+        }
+      }
+    },
+    {
+      "type": {
         "label": "}",
         "beforeExpr": false,
         "startsExpr": false,
@@ -17219,16 +23175,735 @@
         "postfix": false,
         "binop": null
       },
-      "start": 2913,
-      "end": 2914,
+      "start": 3960,
+      "end": 3961,
       "loc": {
         "start": {
-          "line": 127,
+          "line": 152,
           "column": 0
         },
         "end": {
-          "line": 127,
+          "line": 152,
           "column": 1
+        }
+      }
+    },
+    {
+      "type": {
+        "label": ";",
+        "beforeExpr": true,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null,
+        "updateContext": null
+      },
+      "start": 3961,
+      "end": 3962,
+      "loc": {
+        "start": {
+          "line": 152,
+          "column": 1
+        },
+        "end": {
+          "line": 152,
+          "column": 2
+        }
+      }
+    },
+    {
+      "type": "CommentBlock",
+      "value": "*\n* Fritzing Parts API Client\n*\n* @example\n* const {FritzingPartsAPIClient} = require('fritzing-parts-api-client-js')\n*\n* FritzingPartsAPIClient.getFzps()\n* .then((fzpz) => {\n*   console.log(fzps)\n* })\n* .catch((err) => {\n*   console.error(err)\n* })\n",
+      "start": 3965,
+      "end": 4219,
+      "loc": {
+        "start": {
+          "line": 155,
+          "column": 0
+        },
+        "end": {
+          "line": 168,
+          "column": 2
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "const",
+        "keyword": "const",
+        "beforeExpr": false,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null,
+        "updateContext": null
+      },
+      "value": "const",
+      "start": 4220,
+      "end": 4225,
+      "loc": {
+        "start": {
+          "line": 169,
+          "column": 0
+        },
+        "end": {
+          "line": 169,
+          "column": 5
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "name",
+        "beforeExpr": false,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "value": "FritzingPartsAPIClient",
+      "start": 4226,
+      "end": 4248,
+      "loc": {
+        "start": {
+          "line": 169,
+          "column": 6
+        },
+        "end": {
+          "line": 169,
+          "column": 28
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "=",
+        "beforeExpr": true,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": true,
+        "prefix": false,
+        "postfix": false,
+        "binop": null,
+        "updateContext": null
+      },
+      "value": "=",
+      "start": 4249,
+      "end": 4250,
+      "loc": {
+        "start": {
+          "line": 169,
+          "column": 29
+        },
+        "end": {
+          "line": 169,
+          "column": 30
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "{",
+        "beforeExpr": true,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "start": 4251,
+      "end": 4252,
+      "loc": {
+        "start": {
+          "line": 169,
+          "column": 31
+        },
+        "end": {
+          "line": 169,
+          "column": 32
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "name",
+        "beforeExpr": false,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "value": "getFzps",
+      "start": 4255,
+      "end": 4262,
+      "loc": {
+        "start": {
+          "line": 170,
+          "column": 2
+        },
+        "end": {
+          "line": 170,
+          "column": 9
+        }
+      }
+    },
+    {
+      "type": {
+        "label": ",",
+        "beforeExpr": true,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null,
+        "updateContext": null
+      },
+      "start": 4262,
+      "end": 4263,
+      "loc": {
+        "start": {
+          "line": 170,
+          "column": 9
+        },
+        "end": {
+          "line": 170,
+          "column": 10
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "name",
+        "beforeExpr": false,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "value": "getFzpsCore",
+      "start": 4266,
+      "end": 4277,
+      "loc": {
+        "start": {
+          "line": 171,
+          "column": 2
+        },
+        "end": {
+          "line": 171,
+          "column": 13
+        }
+      }
+    },
+    {
+      "type": {
+        "label": ",",
+        "beforeExpr": true,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null,
+        "updateContext": null
+      },
+      "start": 4277,
+      "end": 4278,
+      "loc": {
+        "start": {
+          "line": 171,
+          "column": 13
+        },
+        "end": {
+          "line": 171,
+          "column": 14
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "name",
+        "beforeExpr": false,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "value": "getFzpsObsolete",
+      "start": 4281,
+      "end": 4296,
+      "loc": {
+        "start": {
+          "line": 172,
+          "column": 2
+        },
+        "end": {
+          "line": 172,
+          "column": 17
+        }
+      }
+    },
+    {
+      "type": {
+        "label": ",",
+        "beforeExpr": true,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null,
+        "updateContext": null
+      },
+      "start": 4296,
+      "end": 4297,
+      "loc": {
+        "start": {
+          "line": 172,
+          "column": 17
+        },
+        "end": {
+          "line": 172,
+          "column": 18
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "name",
+        "beforeExpr": false,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "value": "getFzp",
+      "start": 4300,
+      "end": 4306,
+      "loc": {
+        "start": {
+          "line": 173,
+          "column": 2
+        },
+        "end": {
+          "line": 173,
+          "column": 8
+        }
+      }
+    },
+    {
+      "type": {
+        "label": ",",
+        "beforeExpr": true,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null,
+        "updateContext": null
+      },
+      "start": 4306,
+      "end": 4307,
+      "loc": {
+        "start": {
+          "line": 173,
+          "column": 8
+        },
+        "end": {
+          "line": 173,
+          "column": 9
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "name",
+        "beforeExpr": false,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "value": "getFzpCore",
+      "start": 4310,
+      "end": 4320,
+      "loc": {
+        "start": {
+          "line": 174,
+          "column": 2
+        },
+        "end": {
+          "line": 174,
+          "column": 12
+        }
+      }
+    },
+    {
+      "type": {
+        "label": ",",
+        "beforeExpr": true,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null,
+        "updateContext": null
+      },
+      "start": 4320,
+      "end": 4321,
+      "loc": {
+        "start": {
+          "line": 174,
+          "column": 12
+        },
+        "end": {
+          "line": 174,
+          "column": 13
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "name",
+        "beforeExpr": false,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "value": "getFzpObsolete",
+      "start": 4324,
+      "end": 4338,
+      "loc": {
+        "start": {
+          "line": 175,
+          "column": 2
+        },
+        "end": {
+          "line": 175,
+          "column": 16
+        }
+      }
+    },
+    {
+      "type": {
+        "label": ",",
+        "beforeExpr": true,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null,
+        "updateContext": null
+      },
+      "start": 4338,
+      "end": 4339,
+      "loc": {
+        "start": {
+          "line": 175,
+          "column": 16
+        },
+        "end": {
+          "line": 175,
+          "column": 17
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "name",
+        "beforeExpr": false,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "value": "getSvg",
+      "start": 4342,
+      "end": 4348,
+      "loc": {
+        "start": {
+          "line": 176,
+          "column": 2
+        },
+        "end": {
+          "line": 176,
+          "column": 8
+        }
+      }
+    },
+    {
+      "type": {
+        "label": ",",
+        "beforeExpr": true,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null,
+        "updateContext": null
+      },
+      "start": 4348,
+      "end": 4349,
+      "loc": {
+        "start": {
+          "line": 176,
+          "column": 8
+        },
+        "end": {
+          "line": 176,
+          "column": 9
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "name",
+        "beforeExpr": false,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "value": "getSvgCore",
+      "start": 4352,
+      "end": 4362,
+      "loc": {
+        "start": {
+          "line": 177,
+          "column": 2
+        },
+        "end": {
+          "line": 177,
+          "column": 12
+        }
+      }
+    },
+    {
+      "type": {
+        "label": ",",
+        "beforeExpr": true,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null,
+        "updateContext": null
+      },
+      "start": 4362,
+      "end": 4363,
+      "loc": {
+        "start": {
+          "line": 177,
+          "column": 12
+        },
+        "end": {
+          "line": 177,
+          "column": 13
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "name",
+        "beforeExpr": false,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "value": "getSvgObsolete",
+      "start": 4366,
+      "end": 4380,
+      "loc": {
+        "start": {
+          "line": 178,
+          "column": 2
+        },
+        "end": {
+          "line": 178,
+          "column": 16
+        }
+      }
+    },
+    {
+      "type": {
+        "label": ",",
+        "beforeExpr": true,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null,
+        "updateContext": null
+      },
+      "start": 4380,
+      "end": 4381,
+      "loc": {
+        "start": {
+          "line": 178,
+          "column": 16
+        },
+        "end": {
+          "line": 178,
+          "column": 17
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "name",
+        "beforeExpr": false,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "value": "getFzbs",
+      "start": 4384,
+      "end": 4391,
+      "loc": {
+        "start": {
+          "line": 179,
+          "column": 2
+        },
+        "end": {
+          "line": 179,
+          "column": 9
+        }
+      }
+    },
+    {
+      "type": {
+        "label": ",",
+        "beforeExpr": true,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null,
+        "updateContext": null
+      },
+      "start": 4391,
+      "end": 4392,
+      "loc": {
+        "start": {
+          "line": 179,
+          "column": 9
+        },
+        "end": {
+          "line": 179,
+          "column": 10
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "}",
+        "beforeExpr": false,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "start": 4393,
+      "end": 4394,
+      "loc": {
+        "start": {
+          "line": 180,
+          "column": 0
+        },
+        "end": {
+          "line": 180,
+          "column": 1
+        }
+      }
+    },
+    {
+      "type": {
+        "label": ";",
+        "beforeExpr": true,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null,
+        "updateContext": null
+      },
+      "start": 4394,
+      "end": 4395,
+      "loc": {
+        "start": {
+          "line": 180,
+          "column": 1
+        },
+        "end": {
+          "line": 180,
+          "column": 2
         }
       }
     },
@@ -17245,15 +23920,15 @@
         "binop": null
       },
       "value": "module",
-      "start": 2916,
-      "end": 2922,
+      "start": 4397,
+      "end": 4403,
       "loc": {
         "start": {
-          "line": 129,
+          "line": 182,
           "column": 0
         },
         "end": {
-          "line": 129,
+          "line": 182,
           "column": 6
         }
       }
@@ -17271,15 +23946,15 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 2922,
-      "end": 2923,
+      "start": 4403,
+      "end": 4404,
       "loc": {
         "start": {
-          "line": 129,
+          "line": 182,
           "column": 6
         },
         "end": {
-          "line": 129,
+          "line": 182,
           "column": 7
         }
       }
@@ -17297,15 +23972,15 @@
         "binop": null
       },
       "value": "exports",
-      "start": 2923,
-      "end": 2930,
+      "start": 4404,
+      "end": 4411,
       "loc": {
         "start": {
-          "line": 129,
+          "line": 182,
           "column": 7
         },
         "end": {
-          "line": 129,
+          "line": 182,
           "column": 14
         }
       }
@@ -17324,16 +23999,41 @@
         "updateContext": null
       },
       "value": "=",
-      "start": 2931,
-      "end": 2932,
+      "start": 4412,
+      "end": 4413,
       "loc": {
         "start": {
-          "line": 129,
+          "line": 182,
           "column": 15
         },
         "end": {
-          "line": 129,
+          "line": 182,
           "column": 16
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "{",
+        "beforeExpr": true,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "start": 4414,
+      "end": 4415,
+      "loc": {
+        "start": {
+          "line": 182,
+          "column": 17
+        },
+        "end": {
+          "line": 182,
+          "column": 18
         }
       }
     },
@@ -17349,17 +24049,120 @@
         "postfix": false,
         "binop": null
       },
-      "value": "ApiClient",
-      "start": 2933,
-      "end": 2942,
+      "value": "FritzingPartsAPI",
+      "start": 4418,
+      "end": 4434,
       "loc": {
         "start": {
-          "line": 129,
-          "column": 17
+          "line": 183,
+          "column": 2
         },
         "end": {
-          "line": 129,
-          "column": 26
+          "line": 183,
+          "column": 18
+        }
+      }
+    },
+    {
+      "type": {
+        "label": ",",
+        "beforeExpr": true,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null,
+        "updateContext": null
+      },
+      "start": 4434,
+      "end": 4435,
+      "loc": {
+        "start": {
+          "line": 183,
+          "column": 18
+        },
+        "end": {
+          "line": 183,
+          "column": 19
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "name",
+        "beforeExpr": false,
+        "startsExpr": true,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "value": "FritzingPartsAPIClient",
+      "start": 4438,
+      "end": 4460,
+      "loc": {
+        "start": {
+          "line": 184,
+          "column": 2
+        },
+        "end": {
+          "line": 184,
+          "column": 24
+        }
+      }
+    },
+    {
+      "type": {
+        "label": ",",
+        "beforeExpr": true,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null,
+        "updateContext": null
+      },
+      "start": 4460,
+      "end": 4461,
+      "loc": {
+        "start": {
+          "line": 184,
+          "column": 24
+        },
+        "end": {
+          "line": 184,
+          "column": 25
+        }
+      }
+    },
+    {
+      "type": {
+        "label": "}",
+        "beforeExpr": false,
+        "startsExpr": false,
+        "rightAssociative": false,
+        "isLoop": false,
+        "isAssign": false,
+        "prefix": false,
+        "postfix": false,
+        "binop": null
+      },
+      "start": 4462,
+      "end": 4463,
+      "loc": {
+        "start": {
+          "line": 185,
+          "column": 0
+        },
+        "end": {
+          "line": 185,
+          "column": 1
         }
       }
     },
@@ -17376,16 +24179,16 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 2942,
-      "end": 2943,
+      "start": 4463,
+      "end": 4464,
       "loc": {
         "start": {
-          "line": 129,
-          "column": 26
+          "line": 185,
+          "column": 1
         },
         "end": {
-          "line": 129,
-          "column": 27
+          "line": 185,
+          "column": 2
         }
       }
     },
@@ -17402,15 +24205,15 @@
         "binop": null,
         "updateContext": null
       },
-      "start": 2944,
-      "end": 2944,
+      "start": 4465,
+      "end": 4465,
       "loc": {
         "start": {
-          "line": 130,
+          "line": 186,
           "column": 0
         },
         "end": {
-          "line": 130,
+          "line": 186,
           "column": 0
         }
       }

--- a/docs/badge.svg
+++ b/docs/badge.svg
@@ -5,13 +5,13 @@
     <stop offset="1" stop-opacity=".1"/>
   </linearGradient>
   <rect rx="3" width="104" height="20" fill="#555"/>
-  <rect rx="3" x="64" width="40" height="20" fill="#dab226"/>
-  <path fill="#dab226" d="M64 0h4v20h-4z"/>
+  <rect rx="3" x="64" width="40" height="20" fill="#4fc921"/>
+  <path fill="#4fc921" d="M64 0h4v20h-4z"/>
   <rect rx="3" width="104" height="20" fill="url(#a)"/>
   <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
     <text x="32" y="15" fill="#010101" fill-opacity=".3">document</text>
     <text x="32" y="14">document</text>
-    <text x="84" y="15" fill="#010101" fill-opacity=".3">85%</text>
-    <text x="84" y="14">85%</text>
+    <text x="84" y="15" fill="#010101" fill-opacity=".3">92%</text>
+    <text x="84" y="14">92%</text>
   </g>
 </svg>

--- a/docs/coverage.json
+++ b/docs/coverage.json
@@ -1,14 +1,13 @@
 {
-  "coverage": "85.71%",
-  "expectCount": 14,
+  "coverage": "92.3%",
+  "expectCount": 13,
   "actualCount": 12,
   "files": {
     "src/index.js": {
-      "expectCount": 14,
+      "expectCount": 13,
       "actualCount": 12,
       "undocumentLines": [
-        3,
-        13
+        3
       ]
     }
   }

--- a/docs/file/src/index.js.html
+++ b/docs/file/src/index.js.html
@@ -3,12 +3,12 @@
 <head>
   <meta charset="utf-8">
   <base data-ice="baseUrl" href="../../">
-  <title data-ice="title">src/index.js | fritzing-parts-api-client</title>
+  <title data-ice="title">src/index.js | fritzing-parts-api-client-js</title>
   <link type="text/css" rel="stylesheet" href="css/style.css">
   <link type="text/css" rel="stylesheet" href="css/prettify-tomorrow.css">
   <script src="script/prettify/prettify.js"></script>
   <script src="script/manual.js"></script>
-<meta name="description" content="fritzing parts api client"><meta property="og:type" content="website"><meta property="og:url" content="https://paulvollmer.net"><meta property="og:site_name" content="fritzing-parts-api-client"><meta property="og:title" content="fritzing-parts-api-client"><meta property="og:image" content="https://github.com/paulvollmer/logo.png"><meta property="og:description" content="fritzing parts api client"><meta property="og:author" content="https://github.com/paulvollmer"><meta property="twitter:card" content="summary"><meta property="twitter:title" content="fritzing-parts-api-client"><meta property="twitter:description" content="fritzing parts api client"><meta property="twitter:image" content="https://github.com/paulvollmer/logo.png"></head>
+<meta name="description" content="fritzing parts javascript api client"><meta property="twitter:card" content="summary"><meta property="twitter:title" content="fritzing-parts-api-client-js"><meta property="twitter:description" content="fritzing parts javascript api client"></head>
 <body class="layout-container" data-ice="rootContainer">
 
 <header>
@@ -24,12 +24,23 @@
   </span>
     <ul class="search-result"></ul>
   </div>
-<a style="position:relative; top:3px;" href="https://github.com/paulvollmer/fritzing-parts-api-client"><img width="20px" src="./image/github.png"></a></header>
+<a style="position:relative; top:3px;" href="https://github.com/fritzing/fritzing-parts-api-client-js"><img width="20px" src="./image/github.png"></a></header>
 
 <nav class="navigation" data-ice="nav"><div>
   <ul>
     
-  <li data-ice="doc"><span data-ice="kind" class="kind-class">C</span><span data-ice="name"><span><a href="class/src/index.js~ApiClient.html">ApiClient</a></span></span></li>
+  <li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-getFzbs">getFzbs</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-getFzp">getFzp</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-getFzpCore">getFzpCore</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-getFzpObsolete">getFzpObsolete</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-getFzps">getFzps</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-getFzpsCore">getFzpsCore</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-getFzpsObsolete">getFzpsObsolete</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-getSvg">getSvg</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-getSvgCore">getSvgCore</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-getSvgObsolete">getSvgObsolete</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-variable">V</span><span data-ice="name"><span><a href="variable/index.html#static-variable-FritzingPartsAPI">FritzingPartsAPI</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-variable">V</span><span data-ice="name"><span><a href="variable/index.html#static-variable-FritzingPartsAPIClient">FritzingPartsAPIClient</a></span></span></li>
 </ul>
 </div>
 </nav>
@@ -40,130 +51,186 @@
 const axios = require(&apos;axios&apos;);
 
 /**
- * Fritzing Parts API Client
+ * The base url of the fritzing parts api
+ *
+ * @example
+ * const {FritzingPartsAPI} = require(&apos;fritzing-parts-api-client-js&apos;)
+ *
+ * console.log(FritzingPartsAPI)
+ *
+ * @type {String}
  */
-class ApiClient {
-  /**
-   * Construct the ApiClient
-   */
-  constructor() {
-    this.url = &apos;https://fritzing.github.io/fritzing-parts&apos;;
-  }
+const FritzingPartsAPI = &apos;https://fritzing.github.io/fritzing-parts&apos;;
 
-  /**
-   * Get a list of all FZP files
-   * @return {Promise}
-   */
-  getFzps() {
-    return axios.get(this.url+&apos;/fzp&apos;, {responseType: &apos;json&apos;})
-    .then((res) =&gt; {
-      return res.data;
-    });
-  }
-  /**
-   * Get a list of all Core-FZP files
-   * @return {Promise}
-   */
-  getFzpsCore() {
-    return axios.get(this.url+&apos;/fzp/core&apos;, {responseType: &apos;json&apos;})
-    .then((res) =&gt; {
-      return res.data;
-    });
-  }
-  /**
-   * Get a list of all Obsolete-FZP files. for old sketches only!
-   * @return {Promise}
-   */
-  getFzpsObsolete() {
-    return axios.get(this.url+&apos;/fzp/obsolete&apos;, {responseType: &apos;json&apos;})
-    .then((res) =&gt; {
-      return res.data;
-    });
-  }
+/**
+ * Get a list of all FZP files
+ *
+ * @type   {Function}
+ * @param  {String} url - The base URL of the parts api
+ * @return {Promise}
+ */
+const getFzps = function(url = `${FritzingPartsAPI}/fzp`) {
+  return axios.get(url, {responseType: &apos;json&apos;})
+  .then((res) =&gt; {
+    return Promise.resolve(res.data);
+  });
+};
 
-  /**
-   * Get a single FZP and response the xml as a string
-   * @param  {String} src
-   * @return {Promise} the fetch promise
-   */
-   getFzp(src) {
-     return axios.get(this.url+&apos;/&apos;+src, {responseType: &apos;xml&apos;})
-     .then((res) =&gt; {
-       return res.data;
-     });
-   }
+/**
+ * Get a list of all Core-FZP files
+ *
+ * @param  {String} url - The base URL of the parts api
+ * @return {Promise}
+ */
+const getFzpsCore = function(url = `${FritzingPartsAPI}/fzp/core`) {
+  return axios.get(url, {responseType: &apos;json&apos;})
+  .then((res) =&gt; {
+    return Promise.resolve(res.data);
+  });
+};
 
-   /**
-    * Get a single part fzp from the core parts
-    * @param  {String} src
-    * @return {Promise} the fetch promise returns xml
-    */
-  getFzpCore(src) {
-    return axios.get(this.url+&apos;/core/&apos;+src, {responseType: &apos;xml&apos;})
-    .then((res) =&gt; {
-      return res.data;
-    });
-  }
-  /**
-   * Get a single part fzp from the obsolete parts, this is for old sketches only!
-   * @param  {String} src
-   * @return {Promise} the fetch promise returns xml
-   */
-  getFzpObsolete(src) {
-    return axios.get(this.url+&apos;/obsolete/&apos;+src, {responseType: &apos;xml&apos;})
-    .then((res) =&gt; {
-      return res.data;
-    });
-  }
+/**
+ * Get a list of all Obsolete-FZP files. for old sketches only!
+ *
+ * @param  {String} url - The base URL of the parts api
+ * @return {Promise}
+ */
+const getFzpsObsolete = function(url = `${FritzingPartsAPI}/fzp/obsolete`) {
+  return axios.get(url, {responseType: &apos;json&apos;})
+  .then((res) =&gt; {
+    return Promise.resolve(res.data);
+  });
+};
+
+/**
+ * Get a single FZP and response the xml as a string
+ *
+ * @param  {String} src
+ * @param  {String} url - The base URL of the parts api
+ * @return {Promise} the fetch promise
+ */
+const getFzp = function(src, url = FritzingPartsAPI) {
+  return axios.get(`${url}/${src}`, {responseType: &apos;xml&apos;})
+  .then((res) =&gt; {
+    return Promise.resolve(res.data);
+  });
+};
+
+ /**
+  * Get a single part fzp from the core parts
+  *
+  * @param  {String} src
+  * @param  {String} url - The base URL of the parts api
+  * @return {Promise} the fetch promise returns xml
+  */
+const getFzpCore = function(src, url = FritzingPartsAPI) {
+  return axios.get(`${url}/core/${src}`, {responseType: &apos;xml&apos;})
+  .then((res) =&gt; {
+    return Promise.resolve(res.data);
+  });
+};
+
+/**
+ * Get a single part fzp from the obsolete parts, this is for old sketches only!
+ *
+ * @param  {String} src
+ * @param  {String} url - The base URL of the parts api
+ * @return {Promise} the fetch promise returns xml
+ */
+const getFzpObsolete = function(src, url = FritzingPartsAPI) {
+  return axios.get(`${url}/obsolete/${src}`, {responseType: &apos;xml&apos;})
+  .then((res) =&gt; {
+    return Promise.resolve(res.data);
+  });
+};
+
+/**
+ * Get a single part svg and response the svg as a string
+ *
+ * @param  {String} src
+ * @param  {String} url - The base URL of the parts api
+ * @return {Promise} the fetch promise
+ */
+ const getSvg = function(src, url = FritzingPartsAPI) {
+   return axios.get(`${url}/svg/${src}`, {responseType: &apos;xml&apos;})
+   .then((res) =&gt; {
+     return Promise.resolve(res.data);
+   });
+ };
+
+ /**
+  * Get a single part svg from the core parts as svg-string
+  *
+  * @param  {String} src
+  * @param  {String} url - The base URL of the parts api
+  * @return {Promise} the fetch promise returns xml
+  */
+const getSvgCore = function(src, url = FritzingPartsAPI) {
+  return axios.get(`${url}/svg/core/${src}`, {responseType: &apos;xml&apos;})
+  .then((res) =&gt; {
+    return Promise.resolve(res.data);
+  });
+};
+
+/**
+ * Get a single part svg from the obsolete svgs, this is for old-sketches only! the response is a svg-string
+ *
+ * @param  {String} src
+ * @param  {String} url - The base URL of the parts api
+ * @return {Promise} the fetch promise
+ */
+const getSvgObsolete = function(src, url = FritzingPartsAPI) {
+  return axios.get(`${url}/svg/obsolete/${src}`, {responseType: &apos;xml&apos;})
+  .then((res) =&gt; {
+    return Promise.resolve(res.data);
+  });
+};
+
+/**
+ * Get a list of all FZB files
+ *
+ * @param  {String} url - The base URL of the parts api
+ * @return {Promise}
+ */
+const getFzbs = function(url = `${FritzingPartsAPI}/fzb`) {
+  return axios.get(url, {responseType: &apos;json&apos;})
+  .then((res) =&gt; {
+    return Promise.resolve(res.data);
+  });
+};
 
 
-  /**
-   * Get a single part svg and response the svg as a string
-   * @param  {String} src
-   * @return {Promise} the fetch promise
-   */
-   getSvg(src) {
-     return axios.get(this.url+&apos;/svg/&apos;+src, {responseType: &apos;xml&apos;})
-     .then((res) =&gt; {
-       return res.data;
-     });
-   }
-   /**
-    * Get a single part svg from the core parts as svg-string
-    * @param  {String} src
-    * @return {Promise} the fetch promise returns xml
-    */
-  getSvgCore(src) {
-    return axios.get(this.url+&apos;/svg/core/&apos;+src, {responseType: &apos;xml&apos;})
-    .then((res) =&gt; {
-      return res.data;
-    });
-  }
-  /**
-   * Get a single part svg from the obsolete svgs, this is for old-sketches only! the response is a svg-string
-   * @param  {String} src
-   * @return {Promise} the fetch promise
-   */
-  getSvgObsolete(src) {
-    return axios.get(this.url+&apos;/svg/obsolete/&apos;+src, {responseType: &apos;xml&apos;})
-    .then((res) =&gt; {
-      return res.data;
-    });
-  }
+/**
+* Fritzing Parts API Client
+*
+* @example
+* const {FritzingPartsAPIClient} = require(&apos;fritzing-parts-api-client-js&apos;)
+*
+* FritzingPartsAPIClient.getFzps()
+* .then((fzpz) =&gt; {
+*   console.log(fzps)
+* })
+* .catch((err) =&gt; {
+*   console.error(err)
+* })
+*/
+const FritzingPartsAPIClient = {
+  getFzps,
+  getFzpsCore,
+  getFzpsObsolete,
+  getFzp,
+  getFzpCore,
+  getFzpObsolete,
+  getSvg,
+  getSvgCore,
+  getSvgObsolete,
+  getFzbs,
+};
 
-  /**
-   * Get a list of all FZB files
-   * @return {Promise}
-   */
-  getFzbs() {
-    return axios.get(this.url+&apos;/fzb&apos;, {responseType: &apos;json&apos;})
-    .then((res) =&gt; {
-      return res.data;
-    });
-  }
-}
-
-module.exports = ApiClient;
+module.exports = {
+  FritzingPartsAPI,
+  FritzingPartsAPIClient,
+};
 </code></pre>
 
 </div>

--- a/docs/function/index.html
+++ b/docs/function/index.html
@@ -1,0 +1,1135 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <base data-ice="baseUrl" href="../">
+  <title data-ice="title">Function | fritzing-parts-api-client-js</title>
+  <link type="text/css" rel="stylesheet" href="css/style.css">
+  <link type="text/css" rel="stylesheet" href="css/prettify-tomorrow.css">
+  <script src="script/prettify/prettify.js"></script>
+  <script src="script/manual.js"></script>
+<meta name="description" content="fritzing parts javascript api client"><meta property="twitter:card" content="summary"><meta property="twitter:title" content="fritzing-parts-api-client-js"><meta property="twitter:description" content="fritzing parts javascript api client"></head>
+<body class="layout-container" data-ice="rootContainer">
+
+<header>
+  <a href="./">Home</a>
+  
+  <a href="identifiers.html">Reference</a>
+  <a href="source.html">Source</a>
+  <a href="test.html" data-ice="testLink">Test</a>
+  <div class="search-box">
+  <span>
+    <img src="./image/search.png">
+    <span class="search-input-edge"></span><input class="search-input"><span class="search-input-edge"></span>
+  </span>
+    <ul class="search-result"></ul>
+  </div>
+<a style="position:relative; top:3px;" href="https://github.com/fritzing/fritzing-parts-api-client-js"><img width="20px" src="./image/github.png"></a></header>
+
+<nav class="navigation" data-ice="nav"><div>
+  <ul>
+    
+  <li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-getFzbs">getFzbs</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-getFzp">getFzp</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-getFzpCore">getFzpCore</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-getFzpObsolete">getFzpObsolete</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-getFzps">getFzps</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-getFzpsCore">getFzpsCore</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-getFzpsObsolete">getFzpsObsolete</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-getSvg">getSvg</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-getSvgCore">getSvgCore</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-getSvgObsolete">getSvgObsolete</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-variable">V</span><span data-ice="name"><span><a href="variable/index.html#static-variable-FritzingPartsAPI">FritzingPartsAPI</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-variable">V</span><span data-ice="name"><span><a href="variable/index.html#static-variable-FritzingPartsAPIClient">FritzingPartsAPIClient</a></span></span></li>
+</ul>
+</div>
+</nav>
+
+<div class="content" data-ice="content"><h1 data-ice="title">Function</h1>
+<div data-ice="summaries"><table class="summary" data-ice="summary">
+  <thead><tr><td data-ice="title" colspan="3">Static Public Summary</td></tr></thead>
+  <tbody>
+  
+  <tr data-ice="target">
+    <td>
+      <span class="access" data-ice="access">public</span>
+      
+      
+      
+      <span class="override" data-ice="override"></span>
+    </td>
+    <td>
+      <div>
+        <p>
+          
+          
+          
+          <span class="code" data-ice="name"><span><a href="function/index.html#static-function-getFzbs">getFzbs</a></span></span><span class="code" data-ice="signature">(url: <span><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">String</a></span>): <span><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a></span></span>
+        </p>
+      </div>
+      <div>
+        
+        
+        <div data-ice="description"><p>Get a list of all FZB files</p>
+</div>
+      </div>
+    </td>
+    <td>
+      
+      
+    </td>
+  </tr>
+<tr data-ice="target">
+    <td>
+      <span class="access" data-ice="access">public</span>
+      
+      
+      
+      <span class="override" data-ice="override"></span>
+    </td>
+    <td>
+      <div>
+        <p>
+          
+          
+          
+          <span class="code" data-ice="name"><span><a href="function/index.html#static-function-getFzp">getFzp</a></span></span><span class="code" data-ice="signature">(src: <span><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">String</a></span>, url: <span><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">String</a></span>): <span><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a></span></span>
+        </p>
+      </div>
+      <div>
+        
+        
+        <div data-ice="description"><p>Get a single FZP and response the xml as a string</p>
+</div>
+      </div>
+    </td>
+    <td>
+      
+      
+    </td>
+  </tr>
+<tr data-ice="target">
+    <td>
+      <span class="access" data-ice="access">public</span>
+      
+      
+      
+      <span class="override" data-ice="override"></span>
+    </td>
+    <td>
+      <div>
+        <p>
+          
+          
+          
+          <span class="code" data-ice="name"><span><a href="function/index.html#static-function-getFzpCore">getFzpCore</a></span></span><span class="code" data-ice="signature">(src: <span><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">String</a></span>, url: <span><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">String</a></span>): <span><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a></span></span>
+        </p>
+      </div>
+      <div>
+        
+        
+        <div data-ice="description"><p>Get a single part fzp from the core parts</p>
+</div>
+      </div>
+    </td>
+    <td>
+      
+      
+    </td>
+  </tr>
+<tr data-ice="target">
+    <td>
+      <span class="access" data-ice="access">public</span>
+      
+      
+      
+      <span class="override" data-ice="override"></span>
+    </td>
+    <td>
+      <div>
+        <p>
+          
+          
+          
+          <span class="code" data-ice="name"><span><a href="function/index.html#static-function-getFzpObsolete">getFzpObsolete</a></span></span><span class="code" data-ice="signature">(src: <span><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">String</a></span>, url: <span><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">String</a></span>): <span><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a></span></span>
+        </p>
+      </div>
+      <div>
+        
+        
+        <div data-ice="description"><p>Get a single part fzp from the obsolete parts, this is for old sketches only!</p>
+</div>
+      </div>
+    </td>
+    <td>
+      
+      
+    </td>
+  </tr>
+<tr data-ice="target">
+    <td>
+      <span class="access" data-ice="access">public</span>
+      
+      
+      
+      <span class="override" data-ice="override"></span>
+    </td>
+    <td>
+      <div>
+        <p>
+          
+          
+          
+          <span class="code" data-ice="name"><span><a href="function/index.html#static-function-getFzps">getFzps</a></span></span><span class="code" data-ice="signature">(url: <span><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">String</a></span>): <span><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a></span></span>
+        </p>
+      </div>
+      <div>
+        
+        
+        <div data-ice="description"><p>Get a list of all FZP files</p>
+</div>
+      </div>
+    </td>
+    <td>
+      
+      
+    </td>
+  </tr>
+<tr data-ice="target">
+    <td>
+      <span class="access" data-ice="access">public</span>
+      
+      
+      
+      <span class="override" data-ice="override"></span>
+    </td>
+    <td>
+      <div>
+        <p>
+          
+          
+          
+          <span class="code" data-ice="name"><span><a href="function/index.html#static-function-getFzpsCore">getFzpsCore</a></span></span><span class="code" data-ice="signature">(url: <span><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">String</a></span>): <span><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a></span></span>
+        </p>
+      </div>
+      <div>
+        
+        
+        <div data-ice="description"><p>Get a list of all Core-FZP files</p>
+</div>
+      </div>
+    </td>
+    <td>
+      
+      
+    </td>
+  </tr>
+<tr data-ice="target">
+    <td>
+      <span class="access" data-ice="access">public</span>
+      
+      
+      
+      <span class="override" data-ice="override"></span>
+    </td>
+    <td>
+      <div>
+        <p>
+          
+          
+          
+          <span class="code" data-ice="name"><span><a href="function/index.html#static-function-getFzpsObsolete">getFzpsObsolete</a></span></span><span class="code" data-ice="signature">(url: <span><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">String</a></span>): <span><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a></span></span>
+        </p>
+      </div>
+      <div>
+        
+        
+        <div data-ice="description"><p>Get a list of all Obsolete-FZP files.</p>
+</div>
+      </div>
+    </td>
+    <td>
+      
+      
+    </td>
+  </tr>
+<tr data-ice="target">
+    <td>
+      <span class="access" data-ice="access">public</span>
+      
+      
+      
+      <span class="override" data-ice="override"></span>
+    </td>
+    <td>
+      <div>
+        <p>
+          
+          
+          
+          <span class="code" data-ice="name"><span><a href="function/index.html#static-function-getSvg">getSvg</a></span></span><span class="code" data-ice="signature">(src: <span><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">String</a></span>, url: <span><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">String</a></span>): <span><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a></span></span>
+        </p>
+      </div>
+      <div>
+        
+        
+        <div data-ice="description"><p>Get a single part svg and response the svg as a string</p>
+</div>
+      </div>
+    </td>
+    <td>
+      
+      
+    </td>
+  </tr>
+<tr data-ice="target">
+    <td>
+      <span class="access" data-ice="access">public</span>
+      
+      
+      
+      <span class="override" data-ice="override"></span>
+    </td>
+    <td>
+      <div>
+        <p>
+          
+          
+          
+          <span class="code" data-ice="name"><span><a href="function/index.html#static-function-getSvgCore">getSvgCore</a></span></span><span class="code" data-ice="signature">(src: <span><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">String</a></span>, url: <span><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">String</a></span>): <span><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a></span></span>
+        </p>
+      </div>
+      <div>
+        
+        
+        <div data-ice="description"><p>Get a single part svg from the core parts as svg-string</p>
+</div>
+      </div>
+    </td>
+    <td>
+      
+      
+    </td>
+  </tr>
+<tr data-ice="target">
+    <td>
+      <span class="access" data-ice="access">public</span>
+      
+      
+      
+      <span class="override" data-ice="override"></span>
+    </td>
+    <td>
+      <div>
+        <p>
+          
+          
+          
+          <span class="code" data-ice="name"><span><a href="function/index.html#static-function-getSvgObsolete">getSvgObsolete</a></span></span><span class="code" data-ice="signature">(src: <span><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">String</a></span>, url: <span><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">String</a></span>): <span><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a></span></span>
+        </p>
+      </div>
+      <div>
+        
+        
+        <div data-ice="description"><p>Get a single part svg from the obsolete svgs, this is for old-sketches only! the response is a svg-string</p>
+</div>
+      </div>
+    </td>
+    <td>
+      
+      
+    </td>
+  </tr>
+</tbody>
+</table>
+</div>
+<div data-ice="details"><h2 data-ice="title">Static Public </h2>
+
+<div class="detail" data-ice="detail">
+  <h3 data-ice="anchor" id="static-function-getFzbs">
+    <span class="access" data-ice="access">public</span>
+    
+    
+    
+    
+    
+    <span class="code" data-ice="name">getFzbs</span><span class="code" data-ice="signature">(url: <span><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">String</a></span>): <span><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a></span></span>
+    <span class="right-info">
+      
+      
+      <span data-ice="source"><span><a href="file/src/index.js.html#lineNumber147">source</a></span></span>
+    </span>
+  </h3>
+
+  
+  
+  
+  <div data-ice="description"><p>Get a list of all FZB files</p>
+</div>
+
+  
+
+  <div data-ice="properties"><div data-ice="properties">
+  <h4 data-ice="title">Params:</h4>
+  <table class="params">
+    <thead>
+    <tr><td>Name</td><td>Type</td><td>Attribute</td><td>Description</td></tr>
+    </thead>
+    <tbody>
+    
+    <tr data-ice="property" data-depth="0">
+      <td data-ice="name" class="code" data-depth="0">url</td>
+      <td data-ice="type" class="code"><span><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">String</a></span></td>
+      <td data-ice="appendix"></td>
+      <td data-ice="description"><p>The base URL of the parts api</p>
+</td>
+    </tr>
+</tbody>
+  </table>
+</div>
+</div>
+
+  <div class="return-params" data-ice="returnParams">
+    <h4>Return:</h4>
+    <table>
+      <tbody>
+        <tr>
+          <td class="return-type code" data-ice="returnType"><span><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a></span></td>
+          
+        </tr>
+      </tbody>
+    </table>
+    <div data-ice="returnProperties">
+</div>
+  </div>
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+  
+</div>
+<div class="detail" data-ice="detail">
+  <h3 data-ice="anchor" id="static-function-getFzp">
+    <span class="access" data-ice="access">public</span>
+    
+    
+    
+    
+    
+    <span class="code" data-ice="name">getFzp</span><span class="code" data-ice="signature">(src: <span><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">String</a></span>, url: <span><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">String</a></span>): <span><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a></span></span>
+    <span class="right-info">
+      
+      
+      <span data-ice="source"><span><a href="file/src/index.js.html#lineNumber64">source</a></span></span>
+    </span>
+  </h3>
+
+  
+  
+  
+  <div data-ice="description"><p>Get a single FZP and response the xml as a string</p>
+</div>
+
+  
+
+  <div data-ice="properties"><div data-ice="properties">
+  <h4 data-ice="title">Params:</h4>
+  <table class="params">
+    <thead>
+    <tr><td>Name</td><td>Type</td><td>Attribute</td><td>Description</td></tr>
+    </thead>
+    <tbody>
+    
+    <tr data-ice="property" data-depth="0">
+      <td data-ice="name" class="code" data-depth="0">src</td>
+      <td data-ice="type" class="code"><span><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">String</a></span></td>
+      <td data-ice="appendix"></td>
+      <td data-ice="description"></td>
+    </tr>
+<tr data-ice="property" data-depth="0">
+      <td data-ice="name" class="code" data-depth="0">url</td>
+      <td data-ice="type" class="code"><span><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">String</a></span></td>
+      <td data-ice="appendix"></td>
+      <td data-ice="description"><p>The base URL of the parts api</p>
+</td>
+    </tr>
+</tbody>
+  </table>
+</div>
+</div>
+
+  <div class="return-params" data-ice="returnParams">
+    <h4>Return:</h4>
+    <table>
+      <tbody>
+        <tr>
+          <td class="return-type code" data-ice="returnType"><span><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a></span></td>
+          <td class="return-desc" data-ice="returnDescription"><p>the fetch promise</p>
+</td>
+        </tr>
+      </tbody>
+    </table>
+    <div data-ice="returnProperties">
+</div>
+  </div>
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+  
+</div>
+<div class="detail" data-ice="detail">
+  <h3 data-ice="anchor" id="static-function-getFzpCore">
+    <span class="access" data-ice="access">public</span>
+    
+    
+    
+    
+    
+    <span class="code" data-ice="name">getFzpCore</span><span class="code" data-ice="signature">(src: <span><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">String</a></span>, url: <span><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">String</a></span>): <span><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a></span></span>
+    <span class="right-info">
+      
+      
+      <span data-ice="source"><span><a href="file/src/index.js.html#lineNumber78">source</a></span></span>
+    </span>
+  </h3>
+
+  
+  
+  
+  <div data-ice="description"><p>Get a single part fzp from the core parts</p>
+</div>
+
+  
+
+  <div data-ice="properties"><div data-ice="properties">
+  <h4 data-ice="title">Params:</h4>
+  <table class="params">
+    <thead>
+    <tr><td>Name</td><td>Type</td><td>Attribute</td><td>Description</td></tr>
+    </thead>
+    <tbody>
+    
+    <tr data-ice="property" data-depth="0">
+      <td data-ice="name" class="code" data-depth="0">src</td>
+      <td data-ice="type" class="code"><span><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">String</a></span></td>
+      <td data-ice="appendix"></td>
+      <td data-ice="description"></td>
+    </tr>
+<tr data-ice="property" data-depth="0">
+      <td data-ice="name" class="code" data-depth="0">url</td>
+      <td data-ice="type" class="code"><span><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">String</a></span></td>
+      <td data-ice="appendix"></td>
+      <td data-ice="description"><p>The base URL of the parts api</p>
+</td>
+    </tr>
+</tbody>
+  </table>
+</div>
+</div>
+
+  <div class="return-params" data-ice="returnParams">
+    <h4>Return:</h4>
+    <table>
+      <tbody>
+        <tr>
+          <td class="return-type code" data-ice="returnType"><span><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a></span></td>
+          <td class="return-desc" data-ice="returnDescription"><p>the fetch promise returns xml</p>
+</td>
+        </tr>
+      </tbody>
+    </table>
+    <div data-ice="returnProperties">
+</div>
+  </div>
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+  
+</div>
+<div class="detail" data-ice="detail">
+  <h3 data-ice="anchor" id="static-function-getFzpObsolete">
+    <span class="access" data-ice="access">public</span>
+    
+    
+    
+    
+    
+    <span class="code" data-ice="name">getFzpObsolete</span><span class="code" data-ice="signature">(src: <span><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">String</a></span>, url: <span><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">String</a></span>): <span><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a></span></span>
+    <span class="right-info">
+      
+      
+      <span data-ice="source"><span><a href="file/src/index.js.html#lineNumber92">source</a></span></span>
+    </span>
+  </h3>
+
+  
+  
+  
+  <div data-ice="description"><p>Get a single part fzp from the obsolete parts, this is for old sketches only!</p>
+</div>
+
+  
+
+  <div data-ice="properties"><div data-ice="properties">
+  <h4 data-ice="title">Params:</h4>
+  <table class="params">
+    <thead>
+    <tr><td>Name</td><td>Type</td><td>Attribute</td><td>Description</td></tr>
+    </thead>
+    <tbody>
+    
+    <tr data-ice="property" data-depth="0">
+      <td data-ice="name" class="code" data-depth="0">src</td>
+      <td data-ice="type" class="code"><span><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">String</a></span></td>
+      <td data-ice="appendix"></td>
+      <td data-ice="description"></td>
+    </tr>
+<tr data-ice="property" data-depth="0">
+      <td data-ice="name" class="code" data-depth="0">url</td>
+      <td data-ice="type" class="code"><span><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">String</a></span></td>
+      <td data-ice="appendix"></td>
+      <td data-ice="description"><p>The base URL of the parts api</p>
+</td>
+    </tr>
+</tbody>
+  </table>
+</div>
+</div>
+
+  <div class="return-params" data-ice="returnParams">
+    <h4>Return:</h4>
+    <table>
+      <tbody>
+        <tr>
+          <td class="return-type code" data-ice="returnType"><span><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a></span></td>
+          <td class="return-desc" data-ice="returnDescription"><p>the fetch promise returns xml</p>
+</td>
+        </tr>
+      </tbody>
+    </table>
+    <div data-ice="returnProperties">
+</div>
+  </div>
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+  
+</div>
+<div class="detail" data-ice="detail">
+  <h3 data-ice="anchor" id="static-function-getFzps">
+    <span class="access" data-ice="access">public</span>
+    
+    
+    
+    
+    
+    <span class="code" data-ice="name">getFzps</span><span class="code" data-ice="signature">(url: <span><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">String</a></span>): <span><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a></span></span>
+    <span class="right-info">
+      
+      
+      <span data-ice="source"><span><a href="file/src/index.js.html#lineNumber24">source</a></span></span>
+    </span>
+  </h3>
+
+  
+  
+  
+  <div data-ice="description"><p>Get a list of all FZP files</p>
+</div>
+
+  
+
+  <div data-ice="properties"><div data-ice="properties">
+  <h4 data-ice="title">Params:</h4>
+  <table class="params">
+    <thead>
+    <tr><td>Name</td><td>Type</td><td>Attribute</td><td>Description</td></tr>
+    </thead>
+    <tbody>
+    
+    <tr data-ice="property" data-depth="0">
+      <td data-ice="name" class="code" data-depth="0">url</td>
+      <td data-ice="type" class="code"><span><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">String</a></span></td>
+      <td data-ice="appendix"></td>
+      <td data-ice="description"><p>The base URL of the parts api</p>
+</td>
+    </tr>
+</tbody>
+  </table>
+</div>
+</div>
+
+  <div class="return-params" data-ice="returnParams">
+    <h4>Return:</h4>
+    <table>
+      <tbody>
+        <tr>
+          <td class="return-type code" data-ice="returnType"><span><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a></span></td>
+          
+        </tr>
+      </tbody>
+    </table>
+    <div data-ice="returnProperties">
+</div>
+  </div>
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+  
+</div>
+<div class="detail" data-ice="detail">
+  <h3 data-ice="anchor" id="static-function-getFzpsCore">
+    <span class="access" data-ice="access">public</span>
+    
+    
+    
+    
+    
+    <span class="code" data-ice="name">getFzpsCore</span><span class="code" data-ice="signature">(url: <span><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">String</a></span>): <span><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a></span></span>
+    <span class="right-info">
+      
+      
+      <span data-ice="source"><span><a href="file/src/index.js.html#lineNumber37">source</a></span></span>
+    </span>
+  </h3>
+
+  
+  
+  
+  <div data-ice="description"><p>Get a list of all Core-FZP files</p>
+</div>
+
+  
+
+  <div data-ice="properties"><div data-ice="properties">
+  <h4 data-ice="title">Params:</h4>
+  <table class="params">
+    <thead>
+    <tr><td>Name</td><td>Type</td><td>Attribute</td><td>Description</td></tr>
+    </thead>
+    <tbody>
+    
+    <tr data-ice="property" data-depth="0">
+      <td data-ice="name" class="code" data-depth="0">url</td>
+      <td data-ice="type" class="code"><span><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">String</a></span></td>
+      <td data-ice="appendix"></td>
+      <td data-ice="description"><p>The base URL of the parts api</p>
+</td>
+    </tr>
+</tbody>
+  </table>
+</div>
+</div>
+
+  <div class="return-params" data-ice="returnParams">
+    <h4>Return:</h4>
+    <table>
+      <tbody>
+        <tr>
+          <td class="return-type code" data-ice="returnType"><span><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a></span></td>
+          
+        </tr>
+      </tbody>
+    </table>
+    <div data-ice="returnProperties">
+</div>
+  </div>
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+  
+</div>
+<div class="detail" data-ice="detail">
+  <h3 data-ice="anchor" id="static-function-getFzpsObsolete">
+    <span class="access" data-ice="access">public</span>
+    
+    
+    
+    
+    
+    <span class="code" data-ice="name">getFzpsObsolete</span><span class="code" data-ice="signature">(url: <span><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">String</a></span>): <span><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a></span></span>
+    <span class="right-info">
+      
+      
+      <span data-ice="source"><span><a href="file/src/index.js.html#lineNumber50">source</a></span></span>
+    </span>
+  </h3>
+
+  
+  
+  
+  <div data-ice="description"><p>Get a list of all Obsolete-FZP files. for old sketches only!</p>
+</div>
+
+  
+
+  <div data-ice="properties"><div data-ice="properties">
+  <h4 data-ice="title">Params:</h4>
+  <table class="params">
+    <thead>
+    <tr><td>Name</td><td>Type</td><td>Attribute</td><td>Description</td></tr>
+    </thead>
+    <tbody>
+    
+    <tr data-ice="property" data-depth="0">
+      <td data-ice="name" class="code" data-depth="0">url</td>
+      <td data-ice="type" class="code"><span><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">String</a></span></td>
+      <td data-ice="appendix"></td>
+      <td data-ice="description"><p>The base URL of the parts api</p>
+</td>
+    </tr>
+</tbody>
+  </table>
+</div>
+</div>
+
+  <div class="return-params" data-ice="returnParams">
+    <h4>Return:</h4>
+    <table>
+      <tbody>
+        <tr>
+          <td class="return-type code" data-ice="returnType"><span><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a></span></td>
+          
+        </tr>
+      </tbody>
+    </table>
+    <div data-ice="returnProperties">
+</div>
+  </div>
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+  
+</div>
+<div class="detail" data-ice="detail">
+  <h3 data-ice="anchor" id="static-function-getSvg">
+    <span class="access" data-ice="access">public</span>
+    
+    
+    
+    
+    
+    <span class="code" data-ice="name">getSvg</span><span class="code" data-ice="signature">(src: <span><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">String</a></span>, url: <span><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">String</a></span>): <span><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a></span></span>
+    <span class="right-info">
+      
+      
+      <span data-ice="source"><span><a href="file/src/index.js.html#lineNumber106">source</a></span></span>
+    </span>
+  </h3>
+
+  
+  
+  
+  <div data-ice="description"><p>Get a single part svg and response the svg as a string</p>
+</div>
+
+  
+
+  <div data-ice="properties"><div data-ice="properties">
+  <h4 data-ice="title">Params:</h4>
+  <table class="params">
+    <thead>
+    <tr><td>Name</td><td>Type</td><td>Attribute</td><td>Description</td></tr>
+    </thead>
+    <tbody>
+    
+    <tr data-ice="property" data-depth="0">
+      <td data-ice="name" class="code" data-depth="0">src</td>
+      <td data-ice="type" class="code"><span><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">String</a></span></td>
+      <td data-ice="appendix"></td>
+      <td data-ice="description"></td>
+    </tr>
+<tr data-ice="property" data-depth="0">
+      <td data-ice="name" class="code" data-depth="0">url</td>
+      <td data-ice="type" class="code"><span><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">String</a></span></td>
+      <td data-ice="appendix"></td>
+      <td data-ice="description"><p>The base URL of the parts api</p>
+</td>
+    </tr>
+</tbody>
+  </table>
+</div>
+</div>
+
+  <div class="return-params" data-ice="returnParams">
+    <h4>Return:</h4>
+    <table>
+      <tbody>
+        <tr>
+          <td class="return-type code" data-ice="returnType"><span><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a></span></td>
+          <td class="return-desc" data-ice="returnDescription"><p>the fetch promise</p>
+</td>
+        </tr>
+      </tbody>
+    </table>
+    <div data-ice="returnProperties">
+</div>
+  </div>
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+  
+</div>
+<div class="detail" data-ice="detail">
+  <h3 data-ice="anchor" id="static-function-getSvgCore">
+    <span class="access" data-ice="access">public</span>
+    
+    
+    
+    
+    
+    <span class="code" data-ice="name">getSvgCore</span><span class="code" data-ice="signature">(src: <span><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">String</a></span>, url: <span><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">String</a></span>): <span><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a></span></span>
+    <span class="right-info">
+      
+      
+      <span data-ice="source"><span><a href="file/src/index.js.html#lineNumber120">source</a></span></span>
+    </span>
+  </h3>
+
+  
+  
+  
+  <div data-ice="description"><p>Get a single part svg from the core parts as svg-string</p>
+</div>
+
+  
+
+  <div data-ice="properties"><div data-ice="properties">
+  <h4 data-ice="title">Params:</h4>
+  <table class="params">
+    <thead>
+    <tr><td>Name</td><td>Type</td><td>Attribute</td><td>Description</td></tr>
+    </thead>
+    <tbody>
+    
+    <tr data-ice="property" data-depth="0">
+      <td data-ice="name" class="code" data-depth="0">src</td>
+      <td data-ice="type" class="code"><span><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">String</a></span></td>
+      <td data-ice="appendix"></td>
+      <td data-ice="description"></td>
+    </tr>
+<tr data-ice="property" data-depth="0">
+      <td data-ice="name" class="code" data-depth="0">url</td>
+      <td data-ice="type" class="code"><span><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">String</a></span></td>
+      <td data-ice="appendix"></td>
+      <td data-ice="description"><p>The base URL of the parts api</p>
+</td>
+    </tr>
+</tbody>
+  </table>
+</div>
+</div>
+
+  <div class="return-params" data-ice="returnParams">
+    <h4>Return:</h4>
+    <table>
+      <tbody>
+        <tr>
+          <td class="return-type code" data-ice="returnType"><span><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a></span></td>
+          <td class="return-desc" data-ice="returnDescription"><p>the fetch promise returns xml</p>
+</td>
+        </tr>
+      </tbody>
+    </table>
+    <div data-ice="returnProperties">
+</div>
+  </div>
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+  
+</div>
+<div class="detail" data-ice="detail">
+  <h3 data-ice="anchor" id="static-function-getSvgObsolete">
+    <span class="access" data-ice="access">public</span>
+    
+    
+    
+    
+    
+    <span class="code" data-ice="name">getSvgObsolete</span><span class="code" data-ice="signature">(src: <span><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">String</a></span>, url: <span><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">String</a></span>): <span><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a></span></span>
+    <span class="right-info">
+      
+      
+      <span data-ice="source"><span><a href="file/src/index.js.html#lineNumber134">source</a></span></span>
+    </span>
+  </h3>
+
+  
+  
+  
+  <div data-ice="description"><p>Get a single part svg from the obsolete svgs, this is for old-sketches only! the response is a svg-string</p>
+</div>
+
+  
+
+  <div data-ice="properties"><div data-ice="properties">
+  <h4 data-ice="title">Params:</h4>
+  <table class="params">
+    <thead>
+    <tr><td>Name</td><td>Type</td><td>Attribute</td><td>Description</td></tr>
+    </thead>
+    <tbody>
+    
+    <tr data-ice="property" data-depth="0">
+      <td data-ice="name" class="code" data-depth="0">src</td>
+      <td data-ice="type" class="code"><span><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">String</a></span></td>
+      <td data-ice="appendix"></td>
+      <td data-ice="description"></td>
+    </tr>
+<tr data-ice="property" data-depth="0">
+      <td data-ice="name" class="code" data-depth="0">url</td>
+      <td data-ice="type" class="code"><span><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">String</a></span></td>
+      <td data-ice="appendix"></td>
+      <td data-ice="description"><p>The base URL of the parts api</p>
+</td>
+    </tr>
+</tbody>
+  </table>
+</div>
+</div>
+
+  <div class="return-params" data-ice="returnParams">
+    <h4>Return:</h4>
+    <table>
+      <tbody>
+        <tr>
+          <td class="return-type code" data-ice="returnType"><span><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a></span></td>
+          <td class="return-desc" data-ice="returnDescription"><p>the fetch promise</p>
+</td>
+        </tr>
+      </tbody>
+    </table>
+    <div data-ice="returnProperties">
+</div>
+  </div>
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  
+  
+</div>
+</div>
+</div>
+
+<footer class="footer">
+  Generated by <a href="https://esdoc.org">ESDoc<span data-ice="esdocVersion">(1.0.4)</span><img src="./image/esdoc-logo-mini-black.png"></a>
+</footer>
+
+<script src="script/search_index.js"></script>
+<script src="script/search.js"></script>
+<script src="script/pretty-print.js"></script>
+<script src="script/inherited-summary.js"></script>
+<script src="script/test-summary.js"></script>
+<script src="script/inner-link.js"></script>
+<script src="script/patch-for-local.js"></script>
+</body>
+</html>

--- a/docs/identifiers.html
+++ b/docs/identifiers.html
@@ -3,12 +3,12 @@
 <head>
   <meta charset="utf-8">
   <base data-ice="baseUrl">
-  <title data-ice="title">Reference | fritzing-parts-api-client</title>
+  <title data-ice="title">Reference | fritzing-parts-api-client-js</title>
   <link type="text/css" rel="stylesheet" href="css/style.css">
   <link type="text/css" rel="stylesheet" href="css/prettify-tomorrow.css">
   <script src="script/prettify/prettify.js"></script>
   <script src="script/manual.js"></script>
-<meta name="description" content="fritzing parts api client"><meta property="og:type" content="website"><meta property="og:url" content="https://paulvollmer.net"><meta property="og:site_name" content="fritzing-parts-api-client"><meta property="og:title" content="fritzing-parts-api-client"><meta property="og:image" content="https://github.com/paulvollmer/logo.png"><meta property="og:description" content="fritzing parts api client"><meta property="og:author" content="https://github.com/paulvollmer"><meta property="twitter:card" content="summary"><meta property="twitter:title" content="fritzing-parts-api-client"><meta property="twitter:description" content="fritzing parts api client"><meta property="twitter:image" content="https://github.com/paulvollmer/logo.png"></head>
+<meta name="description" content="fritzing parts javascript api client"><meta property="twitter:card" content="summary"><meta property="twitter:title" content="fritzing-parts-api-client-js"><meta property="twitter:description" content="fritzing parts javascript api client"></head>
 <body class="layout-container" data-ice="rootContainer">
 
 <header>
@@ -24,12 +24,23 @@
   </span>
     <ul class="search-result"></ul>
   </div>
-<a style="position:relative; top:3px;" href="https://github.com/paulvollmer/fritzing-parts-api-client"><img width="20px" src="./image/github.png"></a></header>
+<a style="position:relative; top:3px;" href="https://github.com/fritzing/fritzing-parts-api-client-js"><img width="20px" src="./image/github.png"></a></header>
 
 <nav class="navigation" data-ice="nav"><div>
   <ul>
     
-  <li data-ice="doc"><span data-ice="kind" class="kind-class">C</span><span data-ice="name"><span><a href="class/src/index.js~ApiClient.html">ApiClient</a></span></span></li>
+  <li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-getFzbs">getFzbs</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-getFzp">getFzp</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-getFzpCore">getFzpCore</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-getFzpObsolete">getFzpObsolete</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-getFzps">getFzps</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-getFzpsCore">getFzpsCore</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-getFzpsObsolete">getFzpsObsolete</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-getSvg">getSvg</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-getSvgCore">getSvgCore</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-getSvgObsolete">getSvgObsolete</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-variable">V</span><span data-ice="name"><span><a href="variable/index.html#static-variable-FritzingPartsAPI">FritzingPartsAPI</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-variable">V</span><span data-ice="name"><span><a href="variable/index.html#static-variable-FritzingPartsAPIClient">FritzingPartsAPIClient</a></span></span></li>
 </ul>
 </div>
 </nav>
@@ -56,10 +67,329 @@
     <td>
       <div>
         <p>
-          <span data-ice="kind-icon" class="kind-class">C</span>
+          <span data-ice="kind-icon" class="kind-function">F</span>
           
           
-          <span class="code" data-ice="name"><span><a href="class/src/index.js~ApiClient.html">ApiClient</a></span></span>
+          <span class="code" data-ice="name"><span><a href="function/index.html#static-function-getFzbs">getFzbs</a></span></span><span class="code" data-ice="signature">(url: <span><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">String</a></span>): <span><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a></span></span>
+        </p>
+      </div>
+      <div>
+        
+        
+        <div data-ice="description"><p>Get a list of all FZB files</p>
+</div>
+      </div>
+    </td>
+    <td>
+      
+      
+    </td>
+  </tr>
+<tr data-ice="target">
+    <td>
+      <span class="access" data-ice="access">public</span>
+      
+      
+      
+      <span class="override" data-ice="override"></span>
+    </td>
+    <td>
+      <div>
+        <p>
+          <span data-ice="kind-icon" class="kind-function">F</span>
+          
+          
+          <span class="code" data-ice="name"><span><a href="function/index.html#static-function-getFzp">getFzp</a></span></span><span class="code" data-ice="signature">(src: <span><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">String</a></span>, url: <span><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">String</a></span>): <span><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a></span></span>
+        </p>
+      </div>
+      <div>
+        
+        
+        <div data-ice="description"><p>Get a single FZP and response the xml as a string</p>
+</div>
+      </div>
+    </td>
+    <td>
+      
+      
+    </td>
+  </tr>
+<tr data-ice="target">
+    <td>
+      <span class="access" data-ice="access">public</span>
+      
+      
+      
+      <span class="override" data-ice="override"></span>
+    </td>
+    <td>
+      <div>
+        <p>
+          <span data-ice="kind-icon" class="kind-function">F</span>
+          
+          
+          <span class="code" data-ice="name"><span><a href="function/index.html#static-function-getFzpCore">getFzpCore</a></span></span><span class="code" data-ice="signature">(src: <span><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">String</a></span>, url: <span><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">String</a></span>): <span><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a></span></span>
+        </p>
+      </div>
+      <div>
+        
+        
+        <div data-ice="description"><p>Get a single part fzp from the core parts</p>
+</div>
+      </div>
+    </td>
+    <td>
+      
+      
+    </td>
+  </tr>
+<tr data-ice="target">
+    <td>
+      <span class="access" data-ice="access">public</span>
+      
+      
+      
+      <span class="override" data-ice="override"></span>
+    </td>
+    <td>
+      <div>
+        <p>
+          <span data-ice="kind-icon" class="kind-function">F</span>
+          
+          
+          <span class="code" data-ice="name"><span><a href="function/index.html#static-function-getFzpObsolete">getFzpObsolete</a></span></span><span class="code" data-ice="signature">(src: <span><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">String</a></span>, url: <span><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">String</a></span>): <span><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a></span></span>
+        </p>
+      </div>
+      <div>
+        
+        
+        <div data-ice="description"><p>Get a single part fzp from the obsolete parts, this is for old sketches only!</p>
+</div>
+      </div>
+    </td>
+    <td>
+      
+      
+    </td>
+  </tr>
+<tr data-ice="target">
+    <td>
+      <span class="access" data-ice="access">public</span>
+      
+      
+      
+      <span class="override" data-ice="override"></span>
+    </td>
+    <td>
+      <div>
+        <p>
+          <span data-ice="kind-icon" class="kind-function">F</span>
+          
+          
+          <span class="code" data-ice="name"><span><a href="function/index.html#static-function-getFzps">getFzps</a></span></span><span class="code" data-ice="signature">(url: <span><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">String</a></span>): <span><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a></span></span>
+        </p>
+      </div>
+      <div>
+        
+        
+        <div data-ice="description"><p>Get a list of all FZP files</p>
+</div>
+      </div>
+    </td>
+    <td>
+      
+      
+    </td>
+  </tr>
+<tr data-ice="target">
+    <td>
+      <span class="access" data-ice="access">public</span>
+      
+      
+      
+      <span class="override" data-ice="override"></span>
+    </td>
+    <td>
+      <div>
+        <p>
+          <span data-ice="kind-icon" class="kind-function">F</span>
+          
+          
+          <span class="code" data-ice="name"><span><a href="function/index.html#static-function-getFzpsCore">getFzpsCore</a></span></span><span class="code" data-ice="signature">(url: <span><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">String</a></span>): <span><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a></span></span>
+        </p>
+      </div>
+      <div>
+        
+        
+        <div data-ice="description"><p>Get a list of all Core-FZP files</p>
+</div>
+      </div>
+    </td>
+    <td>
+      
+      
+    </td>
+  </tr>
+<tr data-ice="target">
+    <td>
+      <span class="access" data-ice="access">public</span>
+      
+      
+      
+      <span class="override" data-ice="override"></span>
+    </td>
+    <td>
+      <div>
+        <p>
+          <span data-ice="kind-icon" class="kind-function">F</span>
+          
+          
+          <span class="code" data-ice="name"><span><a href="function/index.html#static-function-getFzpsObsolete">getFzpsObsolete</a></span></span><span class="code" data-ice="signature">(url: <span><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">String</a></span>): <span><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a></span></span>
+        </p>
+      </div>
+      <div>
+        
+        
+        <div data-ice="description"><p>Get a list of all Obsolete-FZP files.</p>
+</div>
+      </div>
+    </td>
+    <td>
+      
+      
+    </td>
+  </tr>
+<tr data-ice="target">
+    <td>
+      <span class="access" data-ice="access">public</span>
+      
+      
+      
+      <span class="override" data-ice="override"></span>
+    </td>
+    <td>
+      <div>
+        <p>
+          <span data-ice="kind-icon" class="kind-function">F</span>
+          
+          
+          <span class="code" data-ice="name"><span><a href="function/index.html#static-function-getSvg">getSvg</a></span></span><span class="code" data-ice="signature">(src: <span><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">String</a></span>, url: <span><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">String</a></span>): <span><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a></span></span>
+        </p>
+      </div>
+      <div>
+        
+        
+        <div data-ice="description"><p>Get a single part svg and response the svg as a string</p>
+</div>
+      </div>
+    </td>
+    <td>
+      
+      
+    </td>
+  </tr>
+<tr data-ice="target">
+    <td>
+      <span class="access" data-ice="access">public</span>
+      
+      
+      
+      <span class="override" data-ice="override"></span>
+    </td>
+    <td>
+      <div>
+        <p>
+          <span data-ice="kind-icon" class="kind-function">F</span>
+          
+          
+          <span class="code" data-ice="name"><span><a href="function/index.html#static-function-getSvgCore">getSvgCore</a></span></span><span class="code" data-ice="signature">(src: <span><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">String</a></span>, url: <span><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">String</a></span>): <span><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a></span></span>
+        </p>
+      </div>
+      <div>
+        
+        
+        <div data-ice="description"><p>Get a single part svg from the core parts as svg-string</p>
+</div>
+      </div>
+    </td>
+    <td>
+      
+      
+    </td>
+  </tr>
+<tr data-ice="target">
+    <td>
+      <span class="access" data-ice="access">public</span>
+      
+      
+      
+      <span class="override" data-ice="override"></span>
+    </td>
+    <td>
+      <div>
+        <p>
+          <span data-ice="kind-icon" class="kind-function">F</span>
+          
+          
+          <span class="code" data-ice="name"><span><a href="function/index.html#static-function-getSvgObsolete">getSvgObsolete</a></span></span><span class="code" data-ice="signature">(src: <span><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">String</a></span>, url: <span><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">String</a></span>): <span><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</a></span></span>
+        </p>
+      </div>
+      <div>
+        
+        
+        <div data-ice="description"><p>Get a single part svg from the obsolete svgs, this is for old-sketches only! the response is a svg-string</p>
+</div>
+      </div>
+    </td>
+    <td>
+      
+      
+    </td>
+  </tr>
+<tr data-ice="target">
+    <td>
+      <span class="access" data-ice="access">public</span>
+      
+      
+      
+      <span class="override" data-ice="override"></span>
+    </td>
+    <td>
+      <div>
+        <p>
+          <span data-ice="kind-icon" class="kind-variable">V</span>
+          
+          
+          <span class="code" data-ice="name"><span><a href="variable/index.html#static-variable-FritzingPartsAPI">FritzingPartsAPI</a></span></span><span class="code" data-ice="signature">: <span><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">String</a></span></span>
+        </p>
+      </div>
+      <div>
+        
+        
+        <div data-ice="description"><p>The base url of the fritzing parts api</p>
+</div>
+      </div>
+    </td>
+    <td>
+      
+      
+    </td>
+  </tr>
+<tr data-ice="target">
+    <td>
+      <span class="access" data-ice="access">public</span>
+      
+      
+      
+      <span class="override" data-ice="override"></span>
+    </td>
+    <td>
+      <div>
+        <p>
+          <span data-ice="kind-icon" class="kind-variable">V</span>
+          
+          
+          <span class="code" data-ice="name"><span><a href="variable/index.html#static-variable-FritzingPartsAPIClient">FritzingPartsAPIClient</a></span></span><span class="code" data-ice="signature">: {&quot;getFzps&quot;: <span>*</span>, &quot;getFzpsCore&quot;: <span>*</span>, &quot;getFzpsObsolete&quot;: <span>*</span>, &quot;getFzp&quot;: <span>*</span>, &quot;getFzpCore&quot;: <span>*</span>, &quot;getFzpObsolete&quot;: <span>*</span>, &quot;getSvg&quot;: <span>*</span>, &quot;getSvgCore&quot;: <span>*</span>, &quot;getSvgObsolete&quot;: <span>*</span>, &quot;getFzbs&quot;: <span>*</span>}</span>
         </p>
       </div>
       <div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -3,12 +3,12 @@
 <head>
   <meta charset="utf-8">
   <base data-ice="baseUrl">
-  <title data-ice="title">Home | fritzing-parts-api-client</title>
+  <title data-ice="title">Home | fritzing-parts-api-client-js</title>
   <link type="text/css" rel="stylesheet" href="css/style.css">
   <link type="text/css" rel="stylesheet" href="css/prettify-tomorrow.css">
   <script src="script/prettify/prettify.js"></script>
   <script src="script/manual.js"></script>
-<meta name="description" content="fritzing parts api client"><meta property="og:type" content="website"><meta property="og:url" content="https://paulvollmer.net"><meta property="og:site_name" content="fritzing-parts-api-client"><meta property="og:title" content="fritzing-parts-api-client"><meta property="og:image" content="https://github.com/paulvollmer/logo.png"><meta property="og:description" content="fritzing parts api client"><meta property="og:author" content="https://github.com/paulvollmer"><meta property="twitter:card" content="summary"><meta property="twitter:title" content="fritzing-parts-api-client"><meta property="twitter:description" content="fritzing parts api client"><meta property="twitter:image" content="https://github.com/paulvollmer/logo.png"></head>
+<meta name="description" content="fritzing parts javascript api client"><meta property="twitter:card" content="summary"><meta property="twitter:title" content="fritzing-parts-api-client-js"><meta property="twitter:description" content="fritzing parts javascript api client"></head>
 <body class="layout-container" data-ice="rootContainer">
 
 <header>
@@ -24,17 +24,28 @@
   </span>
     <ul class="search-result"></ul>
   </div>
-<a style="position:relative; top:3px;" href="https://github.com/paulvollmer/fritzing-parts-api-client"><img width="20px" src="./image/github.png"></a></header>
+<a style="position:relative; top:3px;" href="https://github.com/fritzing/fritzing-parts-api-client-js"><img width="20px" src="./image/github.png"></a></header>
 
 <nav class="navigation" data-ice="nav"><div>
   <ul>
     
-  <li data-ice="doc"><span data-ice="kind" class="kind-class">C</span><span data-ice="name"><span><a href="class/src/index.js~ApiClient.html">ApiClient</a></span></span></li>
+  <li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-getFzbs">getFzbs</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-getFzp">getFzp</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-getFzpCore">getFzpCore</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-getFzpObsolete">getFzpObsolete</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-getFzps">getFzps</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-getFzpsCore">getFzpsCore</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-getFzpsObsolete">getFzpsObsolete</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-getSvg">getSvg</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-getSvgCore">getSvgCore</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-getSvgObsolete">getSvgObsolete</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-variable">V</span><span data-ice="name"><span><a href="variable/index.html#static-variable-FritzingPartsAPI">FritzingPartsAPI</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-variable">V</span><span data-ice="name"><span><a href="variable/index.html#static-variable-FritzingPartsAPIClient">FritzingPartsAPIClient</a></span></span></li>
 </ul>
 </div>
 </nav>
 
-<div class="content" data-ice="content"><div data-ice="index" class="github-markdown"><h1 id="fritzing-parts-api-client-js--a-href--https---fritzing-github-io-fritzing-parts-api-client-js----img-src--https---fritzing-github-io-fritzing-parts-api-client-js-badge-svg--alt------a-">fritzing-parts-api-client-js <a href="https://fritzing.github.io/fritzing-parts-api-client-js/"><img src="https://fritzing.github.io/fritzing-parts-api-client-js/badge.svg" alt=""></a></h1><p>This is a super simple <a href="https://nodejs.org">nodejs</a> Api-Client. It connects to the <a href="fritzing.github.io/fritzing-parts">fritzing-parts-server</a> and fetches <a href="http://fritzing.org/home/">fritzing</a> parts.  </p>
+<div class="content" data-ice="content"><div data-ice="index" class="github-markdown"><h1 id="fritzing-parts-api-client-js--a-href--https---travis-ci-org-fritzing-fritzing-parts-api-client-js---img-src--https---travis-ci-org-fritzing-fritzing-parts-api-client-js-svg-branch-master--alt--build-status----a---a-href--https---fritzing-github-io-fritzing-parts-api-client-js----img-src--https---fritzing-github-io-fritzing-parts-api-client-js-badge-svg--alt------a-">fritzing-parts-api-client-js <a href="https://travis-ci.org/fritzing/fritzing-parts-api-client-js"><img src="https://travis-ci.org/fritzing/fritzing-parts-api-client-js.svg?branch=master" alt="Build Status"></a> <a href="https://fritzing.github.io/fritzing-parts-api-client-js/"><img src="https://fritzing.github.io/fritzing-parts-api-client-js/badge.svg" alt=""></a></h1><p>This is a super simple <a href="https://nodejs.org">nodejs</a> Api-Client. It connects to the <a href="fritzing.github.io/fritzing-parts">fritzing-parts-server</a> and fetches <a href="http://fritzing.org/home/">fritzing</a> parts.  </p>
 <h2 id="file-structure">File Structure</h2><ul>
 <li><code>docs</code> generated esdoc artifact</li>
 <li><code>lib</code> generated babel artifact</li>
@@ -48,13 +59,14 @@
 <pre><code class="lang-sh"><code class="source-code prettyprint">npm install fritzing/fritzing-parts-api-client-js --save</code>
 </code></pre>
 <h2 id="usage">Usage</h2><p>initialize an api client and fetch /fzps endpoint</p>
-<pre><code class="lang-javascript"><code class="source-code prettyprint">import ApiClient from &apos;fritzing-parts-api-client-js&apos;
+<pre><code class="lang-javascript"><code class="source-code prettyprint">import {FritzingPartsAPIClient} from &apos;fritzing-parts-api-client-js&apos;
 
-const apiclient = new ApiClient()
-apiclient.getFzps().then(data =&gt; {
-  // do something with the data
-}).catch(err =&gt; {
-  // do something with the error catch
+FritzingPartsAPIClient.getFzps()
+.then((fzpz) =&gt; {
+  console.log(fzps)
+})
+.catch((err) =&gt; {
+  console.error(err)
 })</code>
 </code></pre>
 <h2 id="api-documentation">Api Documentation</h2><p>The complete Api Documentation can be found here:

--- a/docs/index.json
+++ b/docs/index.json
@@ -567,7 +567,7 @@
     "__docId__": 48,
     "kind": "file",
     "name": "src/index.js",
-    "content": "'use strict';\n\nconst axios = require('axios');\n\n/**\n * Fritzing Parts API Client\n */\nclass ApiClient {\n  /**\n   * Construct the ApiClient\n   */\n  constructor() {\n    this.url = 'https://fritzing.github.io/fritzing-parts';\n  }\n\n  /**\n   * Get a list of all FZP files\n   * @return {Promise}\n   */\n  getFzps() {\n    return axios.get(this.url+'/fzp', {responseType: 'json'})\n    .then((res) => {\n      return res.data;\n    });\n  }\n  /**\n   * Get a list of all Core-FZP files\n   * @return {Promise}\n   */\n  getFzpsCore() {\n    return axios.get(this.url+'/fzp/core', {responseType: 'json'})\n    .then((res) => {\n      return res.data;\n    });\n  }\n  /**\n   * Get a list of all Obsolete-FZP files. for old sketches only!\n   * @return {Promise}\n   */\n  getFzpsObsolete() {\n    return axios.get(this.url+'/fzp/obsolete', {responseType: 'json'})\n    .then((res) => {\n      return res.data;\n    });\n  }\n\n  /**\n   * Get a single FZP and response the xml as a string\n   * @param  {String} src\n   * @return {Promise} the fetch promise\n   */\n   getFzp(src) {\n     return axios.get(this.url+'/'+src, {responseType: 'xml'})\n     .then((res) => {\n       return res.data;\n     });\n   }\n\n   /**\n    * Get a single part fzp from the core parts\n    * @param  {String} src\n    * @return {Promise} the fetch promise returns xml\n    */\n  getFzpCore(src) {\n    return axios.get(this.url+'/core/'+src, {responseType: 'xml'})\n    .then((res) => {\n      return res.data;\n    });\n  }\n  /**\n   * Get a single part fzp from the obsolete parts, this is for old sketches only!\n   * @param  {String} src\n   * @return {Promise} the fetch promise returns xml\n   */\n  getFzpObsolete(src) {\n    return axios.get(this.url+'/obsolete/'+src, {responseType: 'xml'})\n    .then((res) => {\n      return res.data;\n    });\n  }\n\n\n  /**\n   * Get a single part svg and response the svg as a string\n   * @param  {String} src\n   * @return {Promise} the fetch promise\n   */\n   getSvg(src) {\n     return axios.get(this.url+'/svg/'+src, {responseType: 'xml'})\n     .then((res) => {\n       return res.data;\n     });\n   }\n   /**\n    * Get a single part svg from the core parts as svg-string\n    * @param  {String} src\n    * @return {Promise} the fetch promise returns xml\n    */\n  getSvgCore(src) {\n    return axios.get(this.url+'/svg/core/'+src, {responseType: 'xml'})\n    .then((res) => {\n      return res.data;\n    });\n  }\n  /**\n   * Get a single part svg from the obsolete svgs, this is for old-sketches only! the response is a svg-string\n   * @param  {String} src\n   * @return {Promise} the fetch promise\n   */\n  getSvgObsolete(src) {\n    return axios.get(this.url+'/svg/obsolete/'+src, {responseType: 'xml'})\n    .then((res) => {\n      return res.data;\n    });\n  }\n\n  /**\n   * Get a list of all FZB files\n   * @return {Promise}\n   */\n  getFzbs() {\n    return axios.get(this.url+'/fzb', {responseType: 'json'})\n    .then((res) => {\n      return res.data;\n    });\n  }\n}\n\nmodule.exports = ApiClient;\n",
+    "content": "'use strict';\n\nconst axios = require('axios');\n\n/**\n * The base url of the fritzing parts api\n *\n * @example\n * const {FritzingPartsAPI} = require('fritzing-parts-api-client-js')\n *\n * console.log(FritzingPartsAPI)\n *\n * @type {String}\n */\nconst FritzingPartsAPI = 'https://fritzing.github.io/fritzing-parts';\n\n/**\n * Get a list of all FZP files\n *\n * @type   {Function}\n * @param  {String} url - The base URL of the parts api\n * @return {Promise}\n */\nconst getFzps = function(url = `${FritzingPartsAPI}/fzp`) {\n  return axios.get(url, {responseType: 'json'})\n  .then((res) => {\n    return Promise.resolve(res.data);\n  });\n};\n\n/**\n * Get a list of all Core-FZP files\n *\n * @param  {String} url - The base URL of the parts api\n * @return {Promise}\n */\nconst getFzpsCore = function(url = `${FritzingPartsAPI}/fzp/core`) {\n  return axios.get(url, {responseType: 'json'})\n  .then((res) => {\n    return Promise.resolve(res.data);\n  });\n};\n\n/**\n * Get a list of all Obsolete-FZP files. for old sketches only!\n *\n * @param  {String} url - The base URL of the parts api\n * @return {Promise}\n */\nconst getFzpsObsolete = function(url = `${FritzingPartsAPI}/fzp/obsolete`) {\n  return axios.get(url, {responseType: 'json'})\n  .then((res) => {\n    return Promise.resolve(res.data);\n  });\n};\n\n/**\n * Get a single FZP and response the xml as a string\n *\n * @param  {String} src\n * @param  {String} url - The base URL of the parts api\n * @return {Promise} the fetch promise\n */\nconst getFzp = function(src, url = FritzingPartsAPI) {\n  return axios.get(`${url}/${src}`, {responseType: 'xml'})\n  .then((res) => {\n    return Promise.resolve(res.data);\n  });\n};\n\n /**\n  * Get a single part fzp from the core parts\n  *\n  * @param  {String} src\n  * @param  {String} url - The base URL of the parts api\n  * @return {Promise} the fetch promise returns xml\n  */\nconst getFzpCore = function(src, url = FritzingPartsAPI) {\n  return axios.get(`${url}/core/${src}`, {responseType: 'xml'})\n  .then((res) => {\n    return Promise.resolve(res.data);\n  });\n};\n\n/**\n * Get a single part fzp from the obsolete parts, this is for old sketches only!\n *\n * @param  {String} src\n * @param  {String} url - The base URL of the parts api\n * @return {Promise} the fetch promise returns xml\n */\nconst getFzpObsolete = function(src, url = FritzingPartsAPI) {\n  return axios.get(`${url}/obsolete/${src}`, {responseType: 'xml'})\n  .then((res) => {\n    return Promise.resolve(res.data);\n  });\n};\n\n/**\n * Get a single part svg and response the svg as a string\n *\n * @param  {String} src\n * @param  {String} url - The base URL of the parts api\n * @return {Promise} the fetch promise\n */\n const getSvg = function(src, url = FritzingPartsAPI) {\n   return axios.get(`${url}/svg/${src}`, {responseType: 'xml'})\n   .then((res) => {\n     return Promise.resolve(res.data);\n   });\n };\n\n /**\n  * Get a single part svg from the core parts as svg-string\n  *\n  * @param  {String} src\n  * @param  {String} url - The base URL of the parts api\n  * @return {Promise} the fetch promise returns xml\n  */\nconst getSvgCore = function(src, url = FritzingPartsAPI) {\n  return axios.get(`${url}/svg/core/${src}`, {responseType: 'xml'})\n  .then((res) => {\n    return Promise.resolve(res.data);\n  });\n};\n\n/**\n * Get a single part svg from the obsolete svgs, this is for old-sketches only! the response is a svg-string\n *\n * @param  {String} src\n * @param  {String} url - The base URL of the parts api\n * @return {Promise} the fetch promise\n */\nconst getSvgObsolete = function(src, url = FritzingPartsAPI) {\n  return axios.get(`${url}/svg/obsolete/${src}`, {responseType: 'xml'})\n  .then((res) => {\n    return Promise.resolve(res.data);\n  });\n};\n\n/**\n * Get a list of all FZB files\n *\n * @param  {String} url - The base URL of the parts api\n * @return {Promise}\n */\nconst getFzbs = function(url = `${FritzingPartsAPI}/fzb`) {\n  return axios.get(url, {responseType: 'json'})\n  .then((res) => {\n    return Promise.resolve(res.data);\n  });\n};\n\n\n/**\n* Fritzing Parts API Client\n*\n* @example\n* const {FritzingPartsAPIClient} = require('fritzing-parts-api-client-js')\n*\n* FritzingPartsAPIClient.getFzps()\n* .then((fzpz) => {\n*   console.log(fzps)\n* })\n* .catch((err) => {\n*   console.error(err)\n* })\n*/\nconst FritzingPartsAPIClient = {\n  getFzps,\n  getFzpsCore,\n  getFzpsObsolete,\n  getFzp,\n  getFzpCore,\n  getFzpObsolete,\n  getSvg,\n  getSvgCore,\n  getSvgObsolete,\n  getFzbs,\n};\n\nmodule.exports = {\n  FritzingPartsAPI,\n  FritzingPartsAPIClient,\n};\n",
     "static": true,
     "longname": "/Users/paul/code/src/github.com/fritzing/fritzing-parts-api-client-js/src/index.js",
     "access": "public",
@@ -597,62 +597,136 @@
   },
   {
     "__docId__": 50,
-    "kind": "class",
-    "name": "ApiClient",
+    "kind": "variable",
+    "name": "FritzingPartsAPI",
     "memberof": "src/index.js",
     "static": true,
-    "longname": "src/index.js~ApiClient",
+    "longname": "src/index.js~FritzingPartsAPI",
     "access": "public",
     "export": false,
     "importPath": "fritzing-parts-api-client-js/src/index.js",
     "importStyle": null,
-    "description": "Fritzing Parts API Client",
-    "lineNumber": 8,
-    "interface": false
+    "description": "The base url of the fritzing parts api",
+    "examples": [
+      "const {FritzingPartsAPI} = require('fritzing-parts-api-client-js')\n\nconsole.log(FritzingPartsAPI)"
+    ],
+    "lineNumber": 15,
+    "type": {
+      "nullable": null,
+      "types": [
+        "String"
+      ],
+      "spread": false,
+      "description": null
+    }
   },
   {
     "__docId__": 51,
-    "kind": "constructor",
-    "name": "constructor",
-    "memberof": "src/index.js~ApiClient",
+    "kind": "function",
+    "name": "getFzps",
+    "memberof": "src/index.js",
     "generator": false,
     "async": false,
-    "static": false,
-    "longname": "src/index.js~ApiClient#constructor",
+    "static": true,
+    "longname": "src/index.js~getFzps",
     "access": "public",
-    "description": "Construct the ApiClient",
-    "lineNumber": 12
+    "export": false,
+    "importPath": "fritzing-parts-api-client-js/src/index.js",
+    "importStyle": null,
+    "description": "Get a list of all FZP files",
+    "lineNumber": 24,
+    "params": [
+      {
+        "nullable": null,
+        "types": [
+          "String"
+        ],
+        "spread": false,
+        "optional": false,
+        "name": "url",
+        "description": "The base URL of the parts api"
+      }
+    ],
+    "return": {
+      "nullable": null,
+      "types": [
+        "Promise"
+      ],
+      "spread": false,
+      "description": ""
+    },
+    "type": {
+      "nullable": null,
+      "types": [
+        "Function"
+      ],
+      "spread": false,
+      "description": null
+    }
   },
   {
     "__docId__": 52,
-    "kind": "member",
-    "name": "url",
-    "memberof": "src/index.js~ApiClient",
-    "static": false,
-    "longname": "src/index.js~ApiClient#url",
+    "kind": "function",
+    "name": "getFzpsCore",
+    "memberof": "src/index.js",
+    "generator": false,
+    "async": false,
+    "static": true,
+    "longname": "src/index.js~getFzpsCore",
     "access": "public",
-    "description": null,
-    "lineNumber": 13,
-    "undocument": true,
-    "type": {
+    "export": false,
+    "importPath": "fritzing-parts-api-client-js/src/index.js",
+    "importStyle": null,
+    "description": "Get a list of all Core-FZP files",
+    "lineNumber": 37,
+    "params": [
+      {
+        "nullable": null,
+        "types": [
+          "String"
+        ],
+        "spread": false,
+        "optional": false,
+        "name": "url",
+        "description": "The base URL of the parts api"
+      }
+    ],
+    "return": {
+      "nullable": null,
       "types": [
-        "string"
-      ]
-    },
-    "ignore": true
+        "Promise"
+      ],
+      "spread": false,
+      "description": ""
+    }
   },
   {
     "__docId__": 53,
-    "kind": "method",
-    "name": "getFzps",
-    "memberof": "src/index.js~ApiClient",
+    "kind": "function",
+    "name": "getFzpsObsolete",
+    "memberof": "src/index.js",
     "generator": false,
     "async": false,
-    "static": false,
-    "longname": "src/index.js~ApiClient#getFzps",
+    "static": true,
+    "longname": "src/index.js~getFzpsObsolete",
     "access": "public",
-    "description": "Get a list of all FZP files",
-    "lineNumber": 20,
+    "export": false,
+    "importPath": "fritzing-parts-api-client-js/src/index.js",
+    "importStyle": null,
+    "description": "Get a list of all Obsolete-FZP files. for old sketches only!",
+    "lineNumber": 50,
+    "params": [
+      {
+        "nullable": null,
+        "types": [
+          "String"
+        ],
+        "spread": false,
+        "optional": false,
+        "name": "url",
+        "description": "The base URL of the parts api"
+      }
+    ],
     "return": {
       "nullable": null,
       "types": [
@@ -660,65 +734,23 @@
       ],
       "spread": false,
       "description": ""
-    },
-    "params": []
+    }
   },
   {
     "__docId__": 54,
-    "kind": "method",
-    "name": "getFzpsCore",
-    "memberof": "src/index.js~ApiClient",
-    "generator": false,
-    "async": false,
-    "static": false,
-    "longname": "src/index.js~ApiClient#getFzpsCore",
-    "access": "public",
-    "description": "Get a list of all Core-FZP files",
-    "lineNumber": 30,
-    "return": {
-      "nullable": null,
-      "types": [
-        "Promise"
-      ],
-      "spread": false,
-      "description": ""
-    },
-    "params": []
-  },
-  {
-    "__docId__": 55,
-    "kind": "method",
-    "name": "getFzpsObsolete",
-    "memberof": "src/index.js~ApiClient",
-    "generator": false,
-    "async": false,
-    "static": false,
-    "longname": "src/index.js~ApiClient#getFzpsObsolete",
-    "access": "public",
-    "description": "Get a list of all Obsolete-FZP files. for old sketches only!",
-    "lineNumber": 40,
-    "return": {
-      "nullable": null,
-      "types": [
-        "Promise"
-      ],
-      "spread": false,
-      "description": ""
-    },
-    "params": []
-  },
-  {
-    "__docId__": 56,
-    "kind": "method",
+    "kind": "function",
     "name": "getFzp",
-    "memberof": "src/index.js~ApiClient",
+    "memberof": "src/index.js",
     "generator": false,
     "async": false,
-    "static": false,
-    "longname": "src/index.js~ApiClient#getFzp",
+    "static": true,
+    "longname": "src/index.js~getFzp",
     "access": "public",
+    "export": false,
+    "importPath": "fritzing-parts-api-client-js/src/index.js",
+    "importStyle": null,
     "description": "Get a single FZP and response the xml as a string",
-    "lineNumber": 52,
+    "lineNumber": 64,
     "params": [
       {
         "nullable": null,
@@ -729,6 +761,16 @@
         "optional": false,
         "name": "src",
         "description": ""
+      },
+      {
+        "nullable": null,
+        "types": [
+          "String"
+        ],
+        "spread": false,
+        "optional": false,
+        "name": "url",
+        "description": "The base URL of the parts api"
       }
     ],
     "return": {
@@ -741,17 +783,20 @@
     }
   },
   {
-    "__docId__": 57,
-    "kind": "method",
+    "__docId__": 55,
+    "kind": "function",
     "name": "getFzpCore",
-    "memberof": "src/index.js~ApiClient",
+    "memberof": "src/index.js",
     "generator": false,
     "async": false,
-    "static": false,
-    "longname": "src/index.js~ApiClient#getFzpCore",
+    "static": true,
+    "longname": "src/index.js~getFzpCore",
     "access": "public",
+    "export": false,
+    "importPath": "fritzing-parts-api-client-js/src/index.js",
+    "importStyle": null,
     "description": "Get a single part fzp from the core parts",
-    "lineNumber": 64,
+    "lineNumber": 78,
     "params": [
       {
         "nullable": null,
@@ -762,6 +807,16 @@
         "optional": false,
         "name": "src",
         "description": ""
+      },
+      {
+        "nullable": null,
+        "types": [
+          "String"
+        ],
+        "spread": false,
+        "optional": false,
+        "name": "url",
+        "description": "The base URL of the parts api"
       }
     ],
     "return": {
@@ -774,17 +829,20 @@
     }
   },
   {
-    "__docId__": 58,
-    "kind": "method",
+    "__docId__": 56,
+    "kind": "function",
     "name": "getFzpObsolete",
-    "memberof": "src/index.js~ApiClient",
+    "memberof": "src/index.js",
     "generator": false,
     "async": false,
-    "static": false,
-    "longname": "src/index.js~ApiClient#getFzpObsolete",
+    "static": true,
+    "longname": "src/index.js~getFzpObsolete",
     "access": "public",
+    "export": false,
+    "importPath": "fritzing-parts-api-client-js/src/index.js",
+    "importStyle": null,
     "description": "Get a single part fzp from the obsolete parts, this is for old sketches only!",
-    "lineNumber": 75,
+    "lineNumber": 92,
     "params": [
       {
         "nullable": null,
@@ -795,6 +853,108 @@
         "optional": false,
         "name": "src",
         "description": ""
+      },
+      {
+        "nullable": null,
+        "types": [
+          "String"
+        ],
+        "spread": false,
+        "optional": false,
+        "name": "url",
+        "description": "The base URL of the parts api"
+      }
+    ],
+    "return": {
+      "nullable": null,
+      "types": [
+        "Promise"
+      ],
+      "spread": false,
+      "description": "the fetch promise returns xml"
+    }
+  },
+  {
+    "__docId__": 57,
+    "kind": "function",
+    "name": "getSvg",
+    "memberof": "src/index.js",
+    "generator": false,
+    "async": false,
+    "static": true,
+    "longname": "src/index.js~getSvg",
+    "access": "public",
+    "export": false,
+    "importPath": "fritzing-parts-api-client-js/src/index.js",
+    "importStyle": null,
+    "description": "Get a single part svg and response the svg as a string",
+    "lineNumber": 106,
+    "params": [
+      {
+        "nullable": null,
+        "types": [
+          "String"
+        ],
+        "spread": false,
+        "optional": false,
+        "name": "src",
+        "description": ""
+      },
+      {
+        "nullable": null,
+        "types": [
+          "String"
+        ],
+        "spread": false,
+        "optional": false,
+        "name": "url",
+        "description": "The base URL of the parts api"
+      }
+    ],
+    "return": {
+      "nullable": null,
+      "types": [
+        "Promise"
+      ],
+      "spread": false,
+      "description": "the fetch promise"
+    }
+  },
+  {
+    "__docId__": 58,
+    "kind": "function",
+    "name": "getSvgCore",
+    "memberof": "src/index.js",
+    "generator": false,
+    "async": false,
+    "static": true,
+    "longname": "src/index.js~getSvgCore",
+    "access": "public",
+    "export": false,
+    "importPath": "fritzing-parts-api-client-js/src/index.js",
+    "importStyle": null,
+    "description": "Get a single part svg from the core parts as svg-string",
+    "lineNumber": 120,
+    "params": [
+      {
+        "nullable": null,
+        "types": [
+          "String"
+        ],
+        "spread": false,
+        "optional": false,
+        "name": "src",
+        "description": ""
+      },
+      {
+        "nullable": null,
+        "types": [
+          "String"
+        ],
+        "spread": false,
+        "optional": false,
+        "name": "url",
+        "description": "The base URL of the parts api"
       }
     ],
     "return": {
@@ -808,16 +968,19 @@
   },
   {
     "__docId__": 59,
-    "kind": "method",
-    "name": "getSvg",
-    "memberof": "src/index.js~ApiClient",
+    "kind": "function",
+    "name": "getSvgObsolete",
+    "memberof": "src/index.js",
     "generator": false,
     "async": false,
-    "static": false,
-    "longname": "src/index.js~ApiClient#getSvg",
+    "static": true,
+    "longname": "src/index.js~getSvgObsolete",
     "access": "public",
-    "description": "Get a single part svg and response the svg as a string",
-    "lineNumber": 88,
+    "export": false,
+    "importPath": "fritzing-parts-api-client-js/src/index.js",
+    "importStyle": null,
+    "description": "Get a single part svg from the obsolete svgs, this is for old-sketches only! the response is a svg-string",
+    "lineNumber": 134,
     "params": [
       {
         "nullable": null,
@@ -828,6 +991,16 @@
         "optional": false,
         "name": "src",
         "description": ""
+      },
+      {
+        "nullable": null,
+        "types": [
+          "String"
+        ],
+        "spread": false,
+        "optional": false,
+        "name": "url",
+        "description": "The base URL of the parts api"
       }
     ],
     "return": {
@@ -841,82 +1014,31 @@
   },
   {
     "__docId__": 60,
-    "kind": "method",
-    "name": "getSvgCore",
-    "memberof": "src/index.js~ApiClient",
-    "generator": false,
-    "async": false,
-    "static": false,
-    "longname": "src/index.js~ApiClient#getSvgCore",
-    "access": "public",
-    "description": "Get a single part svg from the core parts as svg-string",
-    "lineNumber": 99,
-    "params": [
-      {
-        "nullable": null,
-        "types": [
-          "String"
-        ],
-        "spread": false,
-        "optional": false,
-        "name": "src",
-        "description": ""
-      }
-    ],
-    "return": {
-      "nullable": null,
-      "types": [
-        "Promise"
-      ],
-      "spread": false,
-      "description": "the fetch promise returns xml"
-    }
-  },
-  {
-    "__docId__": 61,
-    "kind": "method",
-    "name": "getSvgObsolete",
-    "memberof": "src/index.js~ApiClient",
-    "generator": false,
-    "async": false,
-    "static": false,
-    "longname": "src/index.js~ApiClient#getSvgObsolete",
-    "access": "public",
-    "description": "Get a single part svg from the obsolete svgs, this is for old-sketches only! the response is a svg-string",
-    "lineNumber": 110,
-    "params": [
-      {
-        "nullable": null,
-        "types": [
-          "String"
-        ],
-        "spread": false,
-        "optional": false,
-        "name": "src",
-        "description": ""
-      }
-    ],
-    "return": {
-      "nullable": null,
-      "types": [
-        "Promise"
-      ],
-      "spread": false,
-      "description": "the fetch promise"
-    }
-  },
-  {
-    "__docId__": 62,
-    "kind": "method",
+    "kind": "function",
     "name": "getFzbs",
-    "memberof": "src/index.js~ApiClient",
+    "memberof": "src/index.js",
     "generator": false,
     "async": false,
-    "static": false,
-    "longname": "src/index.js~ApiClient#getFzbs",
+    "static": true,
+    "longname": "src/index.js~getFzbs",
     "access": "public",
+    "export": false,
+    "importPath": "fritzing-parts-api-client-js/src/index.js",
+    "importStyle": null,
     "description": "Get a list of all FZB files",
-    "lineNumber": 121,
+    "lineNumber": 147,
+    "params": [
+      {
+        "nullable": null,
+        "types": [
+          "String"
+        ],
+        "spread": false,
+        "optional": false,
+        "name": "url",
+        "description": "The base URL of the parts api"
+      }
+    ],
     "return": {
       "nullable": null,
       "types": [
@@ -924,12 +1046,33 @@
       ],
       "spread": false,
       "description": ""
-    },
-    "params": []
+    }
+  },
+  {
+    "__docId__": 61,
+    "kind": "variable",
+    "name": "FritzingPartsAPIClient",
+    "memberof": "src/index.js",
+    "static": true,
+    "longname": "src/index.js~FritzingPartsAPIClient",
+    "access": "public",
+    "export": false,
+    "importPath": "fritzing-parts-api-client-js/src/index.js",
+    "importStyle": null,
+    "description": "Fritzing Parts API Client",
+    "examples": [
+      "const {FritzingPartsAPIClient} = require('fritzing-parts-api-client-js')\n\nFritzingPartsAPIClient.getFzps()\n.then((fzpz) => {\n  console.log(fzps)\n})\n.catch((err) => {\n  console.error(err)\n})"
+    ],
+    "lineNumber": 169,
+    "type": {
+      "types": [
+        "{\"getFzps\": *, \"getFzpsCore\": *, \"getFzpsObsolete\": *, \"getFzp\": *, \"getFzpCore\": *, \"getFzpObsolete\": *, \"getSvg\": *, \"getSvgCore\": *, \"getSvgObsolete\": *, \"getFzbs\": *}"
+      ]
+    }
   },
   {
     "kind": "index",
-    "content": "# fritzing-parts-api-client-js [![](https://fritzing.github.io/fritzing-parts-api-client-js/badge.svg)](https://fritzing.github.io/fritzing-parts-api-client-js/)\n\nThis is a super simple [nodejs](https://nodejs.org) Api-Client. It connects to the [fritzing-parts-server](fritzing.github.io/fritzing-parts) and fetches [fritzing](http://fritzing.org/home/) parts.  \n\n## File Structure\n\n- `docs` generated esdoc artifact\n- `lib` generated babel artifact\n- `src` the main sourcecode\n- `test` jest test code\n\n## Install\n\ninstall with yarn\n```sh\nyarn add fritzing/fritzing-parts-api-client-js\n```\n\nor use npm\n```sh\nnpm install fritzing/fritzing-parts-api-client-js --save\n```\n\n## Usage\ninitialize an api client and fetch /fzps endpoint\n```javascript\nimport ApiClient from 'fritzing-parts-api-client-js'\n\nconst apiclient = new ApiClient()\napiclient.getFzps().then(data => {\n  // do something with the data\n}).catch(err => {\n  // do something with the error catch\n})\n```\n\n## Api Documentation\n\nThe complete Api Documentation can be found here:\n[Api Docs](https://fritzing.github.io/fritzing-parts-api-client-js/)\n\n## Development\n\nclone the repository\n```sh\ngit clone git@github.com:fritzing/fritzing-parts-api-client-js.git\n```\n\n```sh\nmake test\nmake lint\n```\n\nif you have lint errors you can try running `make lint-fix` to fix the errors\n\nto build an es5 compatible version run\n```sh\nmake build\n```\n\nto generate the docs, run\n```sh\nmake docs\n```\nif you want to open the docs after generating in your browser, run\n```sh\nmake docs-open\n```\n\n\n## License\n[MIT License](LICENSE)\n",
+    "content": "# fritzing-parts-api-client-js [![Build Status](https://travis-ci.org/fritzing/fritzing-parts-api-client-js.svg?branch=master)](https://travis-ci.org/fritzing/fritzing-parts-api-client-js) [![](https://fritzing.github.io/fritzing-parts-api-client-js/badge.svg)](https://fritzing.github.io/fritzing-parts-api-client-js/)\n\nThis is a super simple [nodejs](https://nodejs.org) Api-Client. It connects to the [fritzing-parts-server](fritzing.github.io/fritzing-parts) and fetches [fritzing](http://fritzing.org/home/) parts.  \n\n## File Structure\n\n- `docs` generated esdoc artifact\n- `lib` generated babel artifact\n- `src` the main sourcecode\n- `test` jest test code\n\n## Install\n\ninstall with yarn\n```sh\nyarn add fritzing/fritzing-parts-api-client-js\n```\n\nor use npm\n```sh\nnpm install fritzing/fritzing-parts-api-client-js --save\n```\n\n## Usage\ninitialize an api client and fetch /fzps endpoint\n```javascript\nimport {FritzingPartsAPIClient} from 'fritzing-parts-api-client-js'\n\nFritzingPartsAPIClient.getFzps()\n.then((fzpz) => {\n  console.log(fzps)\n})\n.catch((err) => {\n  console.error(err)\n})\n```\n\n## Api Documentation\n\nThe complete Api Documentation can be found here:\n[Api Docs](https://fritzing.github.io/fritzing-parts-api-client-js/)\n\n## Development\n\nclone the repository\n```sh\ngit clone git@github.com:fritzing/fritzing-parts-api-client-js.git\n```\n\n```sh\nmake test\nmake lint\n```\n\nif you have lint errors you can try running `make lint-fix` to fix the errors\n\nto build an es5 compatible version run\n```sh\nmake build\n```\n\nto generate the docs, run\n```sh\nmake docs\n```\nif you want to open the docs after generating in your browser, run\n```sh\nmake docs-open\n```\n\n\n## License\n[MIT License](LICENSE)\n",
     "longname": "/Users/paul/code/src/github.com/fritzing/fritzing-parts-api-client-js/README.md",
     "name": "./README.md",
     "static": true,
@@ -937,17 +1080,17 @@
   },
   {
     "kind": "packageJSON",
-    "content": "{\n  \"name\": \"fritzing-parts-api-client-js\",\n  \"version\": \"0.1.0\",\n  \"description\": \"fritzing-parts api client for frontend side\",\n  \"contributors\": [\n    {\n      \"name\": \"paulvollmer\",\n      \"email\": \"code@paulvollmer.net\",\n      \"url\": \"https://paulvollmer.net\"\n    },\n    {\n      \"name\": \"el-j\",\n      \"email\": \"info@fabianalthaus.de\",\n      \"url\": \"https://fabianalthaus.de\"\n    }\n  ],\n  \"license\": \"MIT\",\n  \"main\": \"lib/index.js\",\n  \"scripts\": {\n    \"pretest\": \"make lint\",\n    \"test\": \"make test\",\n    \"precommit\": \"make lint\",\n    \"prepush\": \"make lint\"\n  },\n  \"homepage\": \"https://github.com/fritzing/fritzing-parts-api-client-js#readme\",\n  \"repository\": {\n    \"type\": \"git\",\n    \"url\": \"git+https://github.com/fritzing/fritzing-parts-api-client-js.git\"\n  },\n  \"bugs\": {\n    \"url\": \"https://github.com/fritzing/fritzing-parts-api-client-js/issues\"\n  },\n  \"keywords\": [\n    \"fritzing\",\n    \"fritzing-parts\",\n    \"api-client\"\n  ],\n  \"jest\": {\n    \"verbose\": true,\n    \"collectCoverage\": true\n  },\n  \"devDependencies\": {\n    \"babel-cli\": \"^6.26.0\",\n    \"babel-preset-env\": \"^1.6.1\",\n    \"esdoc\": \"^1.0.4\",\n    \"esdoc-ecmascript-proposal-plugin\": \"^1.0.0\",\n    \"esdoc-standard-plugin\": \"^1.0.0\",\n    \"eslint\": \"^4.18.0\",\n    \"eslint-config-google\": \"^0.9.1\",\n    \"husky\": \"^0.14.3\",\n    \"jest\": \"^22.4.0\"\n  },\n  \"dependencies\": {\n    \"axios\": \"^0.18.0\"\n  }\n}\n",
+    "content": "{\n  \"name\": \"fritzing-parts-api-client-js\",\n  \"version\": \"0.2.0\",\n  \"description\": \"fritzing-parts api client for frontend side\",\n  \"contributors\": [\n    {\n      \"name\": \"paulvollmer\",\n      \"email\": \"code@paulvollmer.net\",\n      \"url\": \"https://paulvollmer.net\"\n    },\n    {\n      \"name\": \"el-j\",\n      \"email\": \"info@fabianalthaus.de\",\n      \"url\": \"https://fabianalthaus.de\"\n    }\n  ],\n  \"license\": \"MIT\",\n  \"main\": \"lib/index.js\",\n  \"scripts\": {\n    \"pretest\": \"make lint\",\n    \"test\": \"make test\",\n    \"precommit\": \"make lint\",\n    \"prepush\": \"make lint && make test\"\n  },\n  \"homepage\": \"https://github.com/fritzing/fritzing-parts-api-client-js#readme\",\n  \"repository\": {\n    \"type\": \"git\",\n    \"url\": \"git+https://github.com/fritzing/fritzing-parts-api-client-js.git\"\n  },\n  \"bugs\": {\n    \"url\": \"https://github.com/fritzing/fritzing-parts-api-client-js/issues\"\n  },\n  \"keywords\": [\n    \"fritzing\",\n    \"fritzing-parts\",\n    \"api-client\"\n  ],\n  \"jest\": {\n    \"verbose\": true,\n    \"collectCoverage\": true\n  },\n  \"devDependencies\": {\n    \"babel-cli\": \"^6.26.0\",\n    \"babel-plugin-minify-dead-code-elimination\": \"^0.3.0\",\n    \"babel-preset-env\": \"^1.6.1\",\n    \"esdoc\": \"^1.0.4\",\n    \"esdoc-ecmascript-proposal-plugin\": \"^1.0.0\",\n    \"esdoc-standard-plugin\": \"^1.0.0\",\n    \"eslint\": \"^4.18.0\",\n    \"eslint-config-google\": \"^0.9.1\",\n    \"husky\": \"^0.14.3\",\n    \"jest\": \"^22.4.0\"\n  },\n  \"dependencies\": {\n    \"axios\": \"^0.18.0\"\n  }\n}\n",
     "longname": "/Users/paul/code/src/github.com/fritzing/fritzing-parts-api-client-js/package.json",
     "name": "package.json",
     "static": true,
     "access": "public"
   },
   {
-    "__docId__": 63,
+    "__docId__": 62,
     "kind": "testFile",
     "name": "test/index.test.js",
-    "content": "'use strict';\n\nconst ApiClient = require('../src');\nlet client = new ApiClient();\n\n// test for the lists of fritzing parts\ndescribe('ApiClient getFzps', () => {\n  test('Status 200', (done) => {\n    client.getFzps()\n    .then((data) => {\n      expect(typeof data).toEqual('object');\n      done();\n    })\n    .catch((err) => {\n      done(err);\n    });\n  });\n});\n\ndescribe('ApiClient getFzpsCore', () => {\n  test('Status 200', (done) => {\n    client.getFzpsCore()\n    .then((data) => {\n      expect(typeof data).toEqual('object');\n      done();\n    })\n    .catch((err) => {\n      done(err);\n    });\n  });\n});\n\ndescribe('ApiClient getFzpsObsolete', () => {\n  test('Status 200', (done) => {\n    client.getFzpsObsolete()\n    .then((data) => {\n      expect(typeof data).toEqual('object');\n      done();\n    })\n    .catch((err) => {\n      done(err);\n    });\n  });\n});\n\n\n// test for the fritzing parts api routes\ndescribe('ApiClient getFzp', () => {\n  test('Status 200', (done) => {\n    client.getFzp('core/teensy_3.1.fzp')\n    .then((data) => {\n      expect(typeof data).toEqual('string');\n      done();\n    })\n    .catch((err) => {\n      done(err);\n    });\n  });\n\n  test('Status 404', (done) => {\n    client.getFzp('not/found.fzp')\n    .then((data) => {\n      throw new Error('should be 404');\n      done();\n    })\n    .catch((err) => {\n      expect(err.message).toEqual('Request failed with status code 404');\n      done();\n    });\n  });\n});\n\ndescribe('ApiClient getFzpCore', () => {\n  test('Status 200', (done) => {\n    client.getFzpCore('teensy_3.1.fzp')\n    .then((data) => {\n      expect(typeof data).toEqual('string');\n      done();\n    })\n    .catch((err) => {\n      done(err);\n    });\n  });\n\n  test('Status 404', (done) => {\n    client.getFzpCore('not/found.fzp')\n    .then((data) => {\n      throw new Error('should be 404');\n      done();\n    })\n    .catch((err) => {\n      expect(err.message).toEqual('Request failed with status code 404');\n      done();\n    });\n  });\n});\n\ndescribe('ApiClient getFzpObsolete', () => {\n  test('Status 200', (done) => {\n    client.getFzpObsolete('Arduino_Leonardo_Rev3.fzp')\n    .then((data) => {\n      expect(typeof data).toEqual('string');\n      done();\n    })\n    .catch((err) => {\n      done(err);\n    });\n  });\n\n  test('Status 404', (done) => {\n    client.getFzpObsolete('not/found.fzp')\n    .then((data) => {\n      throw new Error('should be 404');\n      done();\n    })\n    .catch((err) => {\n      expect(err.message).toEqual('Request failed with status code 404');\n      done();\n    });\n  });\n});\n\n// test for the fritzing parts svg api routes\ndescribe('ApiClient getSvg', () => {\n  test('Status 200', (done) => {\n    client.getSvg('core/breadboard/teensy_3.1_breadboard.svg')\n    .then((data) => {\n      expect(typeof data).toEqual('string');\n      done();\n    })\n    .catch((err) => {\n      done(err);\n    });\n  });\n\n  test('Status 404', (done) => {\n    client.getSvg('not/found.svg')\n    .then((data) => {\n      throw new Error('should be 404');\n      done();\n    })\n    .catch((err) => {\n      expect(err.message).toEqual('Request failed with status code 404');\n      done();\n    });\n  });\n});\n\ndescribe('ApiClient getSvgCore', () => {\n  test('Status 200', (done) => {\n    client.getSvgCore('breadboard/teensy_3.1_breadboard.svg')\n    .then((data) => {\n      expect(typeof data).toEqual('string');\n      done();\n    })\n    .catch((err) => {\n      done(err);\n    });\n  });\n\n  test('Status 404', (done) => {\n    client.getSvgCore('not/found.svg')\n    .then((data) => {\n      throw new Error('should be 404');\n      done();\n    })\n    .catch((err) => {\n      expect(err.message).toEqual('Request failed with status code 404');\n      done();\n    });\n  });\n});\n\ndescribe('ApiClient getSvgObsolete', () => {\n  test('Status 200', (done) => {\n    client.getSvgObsolete('breadboard/Arduino_Fio.svg')\n    .then((data) => {\n      expect(typeof data).toEqual('string');\n      done();\n    })\n    .catch((err) => {\n      done(err);\n    });\n  });\n\n  test('Status 404', (done) => {\n    client.getSvgObsolete('not/found.svg')\n    .then((data) => {\n      throw new Error('should be 404');\n      done();\n    })\n    .catch((err) => {\n      expect(err.message).toEqual('Request failed with status code 404');\n      done();\n    });\n  });\n});\n\n\n// test for the fritzing parts binary api routes\ndescribe('ApiClient getFzbs', () => {\n  test('Status 200', (done) => {\n    client.getFzbs()\n    .then((data) => {\n      expect(typeof data).toEqual('object');\n      done();\n    })\n    .catch((err) => {\n      done(err);\n    });\n  });\n});\n",
+    "content": "'use strict';\n\nconst {FritzingPartsAPIClient} = require('../src');\n\n// test for the lists of fritzing parts\ndescribe('ApiClient getFzps', () => {\n  test('Status 200', (done) => {\n    FritzingPartsAPIClient.getFzps()\n    .then((data) => {\n      expect(typeof data).toEqual('object');\n      done();\n    })\n    .catch((err) => {\n      done(err);\n    });\n  });\n});\n\ndescribe('ApiClient getFzpsCore', () => {\n  test('Status 200', (done) => {\n    FritzingPartsAPIClient.getFzpsCore()\n    .then((data) => {\n      expect(typeof data).toEqual('object');\n      done();\n    })\n    .catch((err) => {\n      done(err);\n    });\n  });\n});\n\ndescribe('ApiClient getFzpsObsolete', () => {\n  test('Status 200', (done) => {\n    FritzingPartsAPIClient.getFzpsObsolete()\n    .then((data) => {\n      expect(typeof data).toEqual('object');\n      done();\n    })\n    .catch((err) => {\n      done(err);\n    });\n  });\n});\n\n\n// test for the fritzing parts api routes\ndescribe('ApiClient getFzp', () => {\n  test('Status 200', (done) => {\n    FritzingPartsAPIClient.getFzp('core/teensy_3.1.fzp')\n    .then((data) => {\n      expect(typeof data).toEqual('string');\n      done();\n    })\n    .catch((err) => {\n      done(err);\n    });\n  });\n\n  test('Status 404', (done) => {\n    FritzingPartsAPIClient.getFzp('not/found.fzp')\n    .then(() => {\n      throw new Error('should be 404');\n      done();\n    })\n    .catch((err) => {\n      expect(err.message).toEqual('Request failed with status code 404');\n      done();\n    });\n  });\n});\n\ndescribe('ApiClient getFzpCore', () => {\n  test('Status 200', (done) => {\n    FritzingPartsAPIClient.getFzpCore('teensy_3.1.fzp')\n    .then((data) => {\n      expect(typeof data).toEqual('string');\n      done();\n    })\n    .catch((err) => {\n      done(err);\n    });\n  });\n\n  test('Status 404', (done) => {\n    FritzingPartsAPIClient.getFzpCore('not/found.fzp')\n    .then(() => {\n      throw new Error('should be 404');\n      done();\n    })\n    .catch((err) => {\n      expect(err.message).toEqual('Request failed with status code 404');\n      done();\n    });\n  });\n});\n\ndescribe('ApiClient getFzpObsolete', () => {\n  test('Status 200', (done) => {\n    FritzingPartsAPIClient.getFzpObsolete('Arduino_Leonardo_Rev3.fzp')\n    .then((data) => {\n      expect(typeof data).toEqual('string');\n      done();\n    })\n    .catch((err) => {\n      done(err);\n    });\n  });\n\n  test('Status 404', (done) => {\n    FritzingPartsAPIClient.getFzpObsolete('not/found.fzp')\n    .then(() => {\n      throw new Error('should be 404');\n      done();\n    })\n    .catch((err) => {\n      expect(err.message).toEqual('Request failed with status code 404');\n      done();\n    });\n  });\n});\n\n// test for the fritzing parts svg api routes\ndescribe('ApiClient getSvg', () => {\n  test('Status 200', (done) => {\n    FritzingPartsAPIClient.getSvg('core/breadboard/teensy_3.1_breadboard.svg')\n    .then((data) => {\n      expect(typeof data).toEqual('string');\n      done();\n    })\n    .catch((err) => {\n      done(err);\n    });\n  });\n\n  test('Status 404', (done) => {\n    FritzingPartsAPIClient.getSvg('not/found.svg')\n    .then(() => {\n      throw new Error('should be 404');\n      done();\n    })\n    .catch((err) => {\n      expect(err.message).toEqual('Request failed with status code 404');\n      done();\n    });\n  });\n});\n\ndescribe('ApiClient getSvgCore', () => {\n  test('Status 200', (done) => {\n    FritzingPartsAPIClient.getSvgCore('breadboard/teensy_3.1_breadboard.svg')\n    .then((data) => {\n      expect(typeof data).toEqual('string');\n      done();\n    })\n    .catch((err) => {\n      done(err);\n    });\n  });\n\n  test('Status 404', (done) => {\n    FritzingPartsAPIClient.getSvgCore('not/found.svg')\n    .then(() => {\n      throw new Error('should be 404');\n      done();\n    })\n    .catch((err) => {\n      expect(err.message).toEqual('Request failed with status code 404');\n      done();\n    });\n  });\n});\n\ndescribe('ApiClient getSvgObsolete', () => {\n  test('Status 200', (done) => {\n    FritzingPartsAPIClient.getSvgObsolete('breadboard/Arduino_Fio.svg')\n    .then((data) => {\n      expect(typeof data).toEqual('string');\n      done();\n    })\n    .catch((err) => {\n      done(err);\n    });\n  });\n\n  test('Status 404', (done) => {\n    FritzingPartsAPIClient.getSvgObsolete('not/found.svg')\n    .then(() => {\n      throw new Error('should be 404');\n      done();\n    })\n    .catch((err) => {\n      expect(err.message).toEqual('Request failed with status code 404');\n      done();\n    });\n  });\n});\n\n\n// test for the fritzing parts binary api routes\ndescribe('ApiClient getFzbs', () => {\n  test('Status 200', (done) => {\n    FritzingPartsAPIClient.getFzbs()\n    .then((data) => {\n      expect(typeof data).toEqual('object');\n      done();\n    })\n    .catch((err) => {\n      done(err);\n    });\n  });\n});\n",
     "static": true,
     "longname": "/Users/paul/code/src/github.com/fritzing/fritzing-parts-api-client-js/test/index.test.js",
     "access": null,
@@ -955,7 +1098,7 @@
     "lineNumber": 1
   },
   {
-    "__docId__": 64,
+    "__docId__": 63,
     "kind": "test",
     "name": "describe0",
     "testId": 0,
@@ -965,10 +1108,10 @@
     "longname": "test/index.test.js~describe0",
     "access": null,
     "description": "ApiClient getFzps",
-    "lineNumber": 7
+    "lineNumber": 6
   },
   {
-    "__docId__": 65,
+    "__docId__": 64,
     "kind": "test",
     "name": "test1",
     "testId": 1,
@@ -978,10 +1121,10 @@
     "longname": "test/index.test.js~describe0.test1",
     "access": null,
     "description": "Status 200",
-    "lineNumber": 8
+    "lineNumber": 7
   },
   {
-    "__docId__": 66,
+    "__docId__": 65,
     "kind": "test",
     "name": "describe2",
     "testId": 2,
@@ -991,10 +1134,10 @@
     "longname": "test/index.test.js~describe2",
     "access": null,
     "description": "ApiClient getFzpsCore",
-    "lineNumber": 20
+    "lineNumber": 19
   },
   {
-    "__docId__": 67,
+    "__docId__": 66,
     "kind": "test",
     "name": "test3",
     "testId": 3,
@@ -1004,10 +1147,10 @@
     "longname": "test/index.test.js~describe2.test3",
     "access": null,
     "description": "Status 200",
-    "lineNumber": 21
+    "lineNumber": 20
   },
   {
-    "__docId__": 68,
+    "__docId__": 67,
     "kind": "test",
     "name": "describe4",
     "testId": 4,
@@ -1017,10 +1160,10 @@
     "longname": "test/index.test.js~describe4",
     "access": null,
     "description": "ApiClient getFzpsObsolete",
-    "lineNumber": 33
+    "lineNumber": 32
   },
   {
-    "__docId__": 69,
+    "__docId__": 68,
     "kind": "test",
     "name": "test5",
     "testId": 5,
@@ -1030,10 +1173,10 @@
     "longname": "test/index.test.js~describe4.test5",
     "access": null,
     "description": "Status 200",
-    "lineNumber": 34
+    "lineNumber": 33
   },
   {
-    "__docId__": 70,
+    "__docId__": 69,
     "kind": "test",
     "name": "describe6",
     "testId": 6,
@@ -1043,10 +1186,10 @@
     "longname": "test/index.test.js~describe6",
     "access": null,
     "description": "ApiClient getFzp",
-    "lineNumber": 48
+    "lineNumber": 47
   },
   {
-    "__docId__": 71,
+    "__docId__": 70,
     "kind": "test",
     "name": "test7",
     "testId": 7,
@@ -1056,10 +1199,10 @@
     "longname": "test/index.test.js~describe6.test7",
     "access": null,
     "description": "Status 200",
-    "lineNumber": 49
+    "lineNumber": 48
   },
   {
-    "__docId__": 72,
+    "__docId__": 71,
     "kind": "test",
     "name": "test8",
     "testId": 8,
@@ -1069,10 +1212,10 @@
     "longname": "test/index.test.js~describe6.test8",
     "access": null,
     "description": "Status 404",
-    "lineNumber": 60
+    "lineNumber": 59
   },
   {
-    "__docId__": 73,
+    "__docId__": 72,
     "kind": "test",
     "name": "describe9",
     "testId": 9,
@@ -1082,10 +1225,10 @@
     "longname": "test/index.test.js~describe9",
     "access": null,
     "description": "ApiClient getFzpCore",
-    "lineNumber": 73
+    "lineNumber": 72
   },
   {
-    "__docId__": 74,
+    "__docId__": 73,
     "kind": "test",
     "name": "test10",
     "testId": 10,
@@ -1095,10 +1238,10 @@
     "longname": "test/index.test.js~describe9.test10",
     "access": null,
     "description": "Status 200",
-    "lineNumber": 74
+    "lineNumber": 73
   },
   {
-    "__docId__": 75,
+    "__docId__": 74,
     "kind": "test",
     "name": "test11",
     "testId": 11,
@@ -1108,10 +1251,10 @@
     "longname": "test/index.test.js~describe9.test11",
     "access": null,
     "description": "Status 404",
-    "lineNumber": 85
+    "lineNumber": 84
   },
   {
-    "__docId__": 76,
+    "__docId__": 75,
     "kind": "test",
     "name": "describe12",
     "testId": 12,
@@ -1121,10 +1264,10 @@
     "longname": "test/index.test.js~describe12",
     "access": null,
     "description": "ApiClient getFzpObsolete",
-    "lineNumber": 98
+    "lineNumber": 97
   },
   {
-    "__docId__": 77,
+    "__docId__": 76,
     "kind": "test",
     "name": "test13",
     "testId": 13,
@@ -1134,10 +1277,10 @@
     "longname": "test/index.test.js~describe12.test13",
     "access": null,
     "description": "Status 200",
-    "lineNumber": 99
+    "lineNumber": 98
   },
   {
-    "__docId__": 78,
+    "__docId__": 77,
     "kind": "test",
     "name": "test14",
     "testId": 14,
@@ -1147,10 +1290,10 @@
     "longname": "test/index.test.js~describe12.test14",
     "access": null,
     "description": "Status 404",
-    "lineNumber": 110
+    "lineNumber": 109
   },
   {
-    "__docId__": 79,
+    "__docId__": 78,
     "kind": "test",
     "name": "describe15",
     "testId": 15,
@@ -1160,10 +1303,10 @@
     "longname": "test/index.test.js~describe15",
     "access": null,
     "description": "ApiClient getSvg",
-    "lineNumber": 124
+    "lineNumber": 123
   },
   {
-    "__docId__": 80,
+    "__docId__": 79,
     "kind": "test",
     "name": "test16",
     "testId": 16,
@@ -1173,10 +1316,10 @@
     "longname": "test/index.test.js~describe15.test16",
     "access": null,
     "description": "Status 200",
-    "lineNumber": 125
+    "lineNumber": 124
   },
   {
-    "__docId__": 81,
+    "__docId__": 80,
     "kind": "test",
     "name": "test17",
     "testId": 17,
@@ -1186,10 +1329,10 @@
     "longname": "test/index.test.js~describe15.test17",
     "access": null,
     "description": "Status 404",
-    "lineNumber": 136
+    "lineNumber": 135
   },
   {
-    "__docId__": 82,
+    "__docId__": 81,
     "kind": "test",
     "name": "describe18",
     "testId": 18,
@@ -1199,10 +1342,10 @@
     "longname": "test/index.test.js~describe18",
     "access": null,
     "description": "ApiClient getSvgCore",
-    "lineNumber": 149
+    "lineNumber": 148
   },
   {
-    "__docId__": 83,
+    "__docId__": 82,
     "kind": "test",
     "name": "test19",
     "testId": 19,
@@ -1212,10 +1355,10 @@
     "longname": "test/index.test.js~describe18.test19",
     "access": null,
     "description": "Status 200",
-    "lineNumber": 150
+    "lineNumber": 149
   },
   {
-    "__docId__": 84,
+    "__docId__": 83,
     "kind": "test",
     "name": "test20",
     "testId": 20,
@@ -1225,10 +1368,10 @@
     "longname": "test/index.test.js~describe18.test20",
     "access": null,
     "description": "Status 404",
-    "lineNumber": 161
+    "lineNumber": 160
   },
   {
-    "__docId__": 85,
+    "__docId__": 84,
     "kind": "test",
     "name": "describe21",
     "testId": 21,
@@ -1238,10 +1381,10 @@
     "longname": "test/index.test.js~describe21",
     "access": null,
     "description": "ApiClient getSvgObsolete",
-    "lineNumber": 174
+    "lineNumber": 173
   },
   {
-    "__docId__": 86,
+    "__docId__": 85,
     "kind": "test",
     "name": "test22",
     "testId": 22,
@@ -1251,10 +1394,10 @@
     "longname": "test/index.test.js~describe21.test22",
     "access": null,
     "description": "Status 200",
-    "lineNumber": 175
+    "lineNumber": 174
   },
   {
-    "__docId__": 87,
+    "__docId__": 86,
     "kind": "test",
     "name": "test23",
     "testId": 23,
@@ -1264,10 +1407,10 @@
     "longname": "test/index.test.js~describe21.test23",
     "access": null,
     "description": "Status 404",
-    "lineNumber": 186
+    "lineNumber": 185
   },
   {
-    "__docId__": 88,
+    "__docId__": 87,
     "kind": "test",
     "name": "describe24",
     "testId": 24,
@@ -1277,10 +1420,10 @@
     "longname": "test/index.test.js~describe24",
     "access": null,
     "description": "ApiClient getFzbs",
-    "lineNumber": 201
+    "lineNumber": 200
   },
   {
-    "__docId__": 89,
+    "__docId__": 88,
     "kind": "test",
     "name": "test25",
     "testId": 25,
@@ -1290,6 +1433,6 @@
     "longname": "test/index.test.js~describe24.test25",
     "access": null,
     "description": "Status 200",
-    "lineNumber": 202
+    "lineNumber": 201
   }
 ]

--- a/docs/script/search_index.js
+++ b/docs/script/search_index.js
@@ -1,163 +1,229 @@
 window.esdocSearchIndex = [
   [
-    "fritzing-parts-api-client-js/src/index.js~apiclient",
-    "class/src/index.js~ApiClient.html",
-    "<span>ApiClient</span> <span class=\"search-result-import-path\">fritzing-parts-api-client-js/src/index.js</span>",
-    "class"
+    "fritzing-parts-api-client-js/src/index.js~fritzingpartsapi",
+    "variable/index.html#static-variable-FritzingPartsAPI",
+    "<span>FritzingPartsAPI</span> <span class=\"search-result-import-path\">fritzing-parts-api-client-js/src/index.js</span>",
+    "variable"
+  ],
+  [
+    "fritzing-parts-api-client-js/src/index.js~fritzingpartsapiclient",
+    "variable/index.html#static-variable-FritzingPartsAPIClient",
+    "<span>FritzingPartsAPIClient</span> <span class=\"search-result-import-path\">fritzing-parts-api-client-js/src/index.js</span>",
+    "variable"
+  ],
+  [
+    "fritzing-parts-api-client-js/src/index.js~getfzbs",
+    "function/index.html#static-function-getFzbs",
+    "<span>getFzbs</span> <span class=\"search-result-import-path\">fritzing-parts-api-client-js/src/index.js</span>",
+    "function"
+  ],
+  [
+    "fritzing-parts-api-client-js/src/index.js~getfzp",
+    "function/index.html#static-function-getFzp",
+    "<span>getFzp</span> <span class=\"search-result-import-path\">fritzing-parts-api-client-js/src/index.js</span>",
+    "function"
+  ],
+  [
+    "fritzing-parts-api-client-js/src/index.js~getfzpcore",
+    "function/index.html#static-function-getFzpCore",
+    "<span>getFzpCore</span> <span class=\"search-result-import-path\">fritzing-parts-api-client-js/src/index.js</span>",
+    "function"
+  ],
+  [
+    "fritzing-parts-api-client-js/src/index.js~getfzpobsolete",
+    "function/index.html#static-function-getFzpObsolete",
+    "<span>getFzpObsolete</span> <span class=\"search-result-import-path\">fritzing-parts-api-client-js/src/index.js</span>",
+    "function"
+  ],
+  [
+    "fritzing-parts-api-client-js/src/index.js~getfzps",
+    "function/index.html#static-function-getFzps",
+    "<span>getFzps</span> <span class=\"search-result-import-path\">fritzing-parts-api-client-js/src/index.js</span>",
+    "function"
+  ],
+  [
+    "fritzing-parts-api-client-js/src/index.js~getfzpscore",
+    "function/index.html#static-function-getFzpsCore",
+    "<span>getFzpsCore</span> <span class=\"search-result-import-path\">fritzing-parts-api-client-js/src/index.js</span>",
+    "function"
+  ],
+  [
+    "fritzing-parts-api-client-js/src/index.js~getfzpsobsolete",
+    "function/index.html#static-function-getFzpsObsolete",
+    "<span>getFzpsObsolete</span> <span class=\"search-result-import-path\">fritzing-parts-api-client-js/src/index.js</span>",
+    "function"
+  ],
+  [
+    "fritzing-parts-api-client-js/src/index.js~getsvg",
+    "function/index.html#static-function-getSvg",
+    "<span>getSvg</span> <span class=\"search-result-import-path\">fritzing-parts-api-client-js/src/index.js</span>",
+    "function"
+  ],
+  [
+    "fritzing-parts-api-client-js/src/index.js~getsvgcore",
+    "function/index.html#static-function-getSvgCore",
+    "<span>getSvgCore</span> <span class=\"search-result-import-path\">fritzing-parts-api-client-js/src/index.js</span>",
+    "function"
+  ],
+  [
+    "fritzing-parts-api-client-js/src/index.js~getsvgobsolete",
+    "function/index.html#static-function-getSvgObsolete",
+    "<span>getSvgObsolete</span> <span class=\"search-result-import-path\">fritzing-parts-api-client-js/src/index.js</span>",
+    "function"
   ],
   [
     "",
-    "test-file/test/index.test.js.html#lineNumber201",
+    "test-file/test/index.test.js.html#lineNumber200",
     "ApiClient getFzbs",
     "test"
   ],
   [
     "",
-    "test-file/test/index.test.js.html#lineNumber202",
+    "test-file/test/index.test.js.html#lineNumber201",
     "ApiClient getFzbs Status 200",
     "test"
   ],
   [
     "",
-    "test-file/test/index.test.js.html#lineNumber48",
+    "test-file/test/index.test.js.html#lineNumber47",
     "ApiClient getFzp",
     "test"
   ],
   [
     "",
-    "test-file/test/index.test.js.html#lineNumber49",
+    "test-file/test/index.test.js.html#lineNumber48",
     "ApiClient getFzp Status 200",
     "test"
   ],
   [
     "",
-    "test-file/test/index.test.js.html#lineNumber60",
+    "test-file/test/index.test.js.html#lineNumber59",
     "ApiClient getFzp Status 404",
     "test"
   ],
   [
     "",
-    "test-file/test/index.test.js.html#lineNumber73",
+    "test-file/test/index.test.js.html#lineNumber72",
     "ApiClient getFzpCore",
     "test"
   ],
   [
     "",
-    "test-file/test/index.test.js.html#lineNumber74",
+    "test-file/test/index.test.js.html#lineNumber73",
     "ApiClient getFzpCore Status 200",
     "test"
   ],
   [
     "",
-    "test-file/test/index.test.js.html#lineNumber85",
+    "test-file/test/index.test.js.html#lineNumber84",
     "ApiClient getFzpCore Status 404",
     "test"
   ],
   [
     "",
-    "test-file/test/index.test.js.html#lineNumber98",
+    "test-file/test/index.test.js.html#lineNumber97",
     "ApiClient getFzpObsolete",
     "test"
   ],
   [
     "",
-    "test-file/test/index.test.js.html#lineNumber99",
+    "test-file/test/index.test.js.html#lineNumber98",
     "ApiClient getFzpObsolete Status 200",
     "test"
   ],
   [
     "",
-    "test-file/test/index.test.js.html#lineNumber110",
+    "test-file/test/index.test.js.html#lineNumber109",
     "ApiClient getFzpObsolete Status 404",
     "test"
   ],
   [
     "",
-    "test-file/test/index.test.js.html#lineNumber7",
+    "test-file/test/index.test.js.html#lineNumber6",
     "ApiClient getFzps",
     "test"
   ],
   [
     "",
-    "test-file/test/index.test.js.html#lineNumber8",
+    "test-file/test/index.test.js.html#lineNumber7",
     "ApiClient getFzps Status 200",
     "test"
   ],
   [
     "",
-    "test-file/test/index.test.js.html#lineNumber20",
+    "test-file/test/index.test.js.html#lineNumber19",
     "ApiClient getFzpsCore",
     "test"
   ],
   [
     "",
-    "test-file/test/index.test.js.html#lineNumber21",
+    "test-file/test/index.test.js.html#lineNumber20",
     "ApiClient getFzpsCore Status 200",
     "test"
   ],
   [
     "",
-    "test-file/test/index.test.js.html#lineNumber33",
+    "test-file/test/index.test.js.html#lineNumber32",
     "ApiClient getFzpsObsolete",
     "test"
   ],
   [
     "",
-    "test-file/test/index.test.js.html#lineNumber34",
+    "test-file/test/index.test.js.html#lineNumber33",
     "ApiClient getFzpsObsolete Status 200",
     "test"
   ],
   [
     "",
-    "test-file/test/index.test.js.html#lineNumber124",
+    "test-file/test/index.test.js.html#lineNumber123",
     "ApiClient getSvg",
     "test"
   ],
   [
     "",
-    "test-file/test/index.test.js.html#lineNumber125",
+    "test-file/test/index.test.js.html#lineNumber124",
     "ApiClient getSvg Status 200",
     "test"
   ],
   [
     "",
-    "test-file/test/index.test.js.html#lineNumber136",
+    "test-file/test/index.test.js.html#lineNumber135",
     "ApiClient getSvg Status 404",
     "test"
   ],
   [
     "",
-    "test-file/test/index.test.js.html#lineNumber149",
+    "test-file/test/index.test.js.html#lineNumber148",
     "ApiClient getSvgCore",
     "test"
   ],
   [
     "",
-    "test-file/test/index.test.js.html#lineNumber150",
+    "test-file/test/index.test.js.html#lineNumber149",
     "ApiClient getSvgCore Status 200",
     "test"
   ],
   [
     "",
-    "test-file/test/index.test.js.html#lineNumber161",
+    "test-file/test/index.test.js.html#lineNumber160",
     "ApiClient getSvgCore Status 404",
     "test"
   ],
   [
     "",
-    "test-file/test/index.test.js.html#lineNumber174",
+    "test-file/test/index.test.js.html#lineNumber173",
     "ApiClient getSvgObsolete",
     "test"
   ],
   [
     "",
-    "test-file/test/index.test.js.html#lineNumber175",
+    "test-file/test/index.test.js.html#lineNumber174",
     "ApiClient getSvgObsolete Status 200",
     "test"
   ],
   [
     "",
-    "test-file/test/index.test.js.html#lineNumber186",
+    "test-file/test/index.test.js.html#lineNumber185",
     "ApiClient getSvgObsolete Status 404",
     "test"
   ],
@@ -448,72 +514,6 @@ window.esdocSearchIndex = [
     "file/src/index.js.html",
     "src/index.js",
     "file"
-  ],
-  [
-    "src/index.js~apiclient#constructor",
-    "class/src/index.js~ApiClient.html#instance-constructor-constructor",
-    "src/index.js~ApiClient#constructor",
-    "method"
-  ],
-  [
-    "src/index.js~apiclient#getfzbs",
-    "class/src/index.js~ApiClient.html#instance-method-getFzbs",
-    "src/index.js~ApiClient#getFzbs",
-    "method"
-  ],
-  [
-    "src/index.js~apiclient#getfzp",
-    "class/src/index.js~ApiClient.html#instance-method-getFzp",
-    "src/index.js~ApiClient#getFzp",
-    "method"
-  ],
-  [
-    "src/index.js~apiclient#getfzpcore",
-    "class/src/index.js~ApiClient.html#instance-method-getFzpCore",
-    "src/index.js~ApiClient#getFzpCore",
-    "method"
-  ],
-  [
-    "src/index.js~apiclient#getfzpobsolete",
-    "class/src/index.js~ApiClient.html#instance-method-getFzpObsolete",
-    "src/index.js~ApiClient#getFzpObsolete",
-    "method"
-  ],
-  [
-    "src/index.js~apiclient#getfzps",
-    "class/src/index.js~ApiClient.html#instance-method-getFzps",
-    "src/index.js~ApiClient#getFzps",
-    "method"
-  ],
-  [
-    "src/index.js~apiclient#getfzpscore",
-    "class/src/index.js~ApiClient.html#instance-method-getFzpsCore",
-    "src/index.js~ApiClient#getFzpsCore",
-    "method"
-  ],
-  [
-    "src/index.js~apiclient#getfzpsobsolete",
-    "class/src/index.js~ApiClient.html#instance-method-getFzpsObsolete",
-    "src/index.js~ApiClient#getFzpsObsolete",
-    "method"
-  ],
-  [
-    "src/index.js~apiclient#getsvg",
-    "class/src/index.js~ApiClient.html#instance-method-getSvg",
-    "src/index.js~ApiClient#getSvg",
-    "method"
-  ],
-  [
-    "src/index.js~apiclient#getsvgcore",
-    "class/src/index.js~ApiClient.html#instance-method-getSvgCore",
-    "src/index.js~ApiClient#getSvgCore",
-    "method"
-  ],
-  [
-    "src/index.js~apiclient#getsvgobsolete",
-    "class/src/index.js~ApiClient.html#instance-method-getSvgObsolete",
-    "src/index.js~ApiClient#getSvgObsolete",
-    "method"
   ],
   [
     "test/index.test.js",

--- a/docs/source.html
+++ b/docs/source.html
@@ -3,12 +3,12 @@
 <head>
   <meta charset="utf-8">
   <base data-ice="baseUrl" href="">
-  <title data-ice="title">Source | fritzing-parts-api-client</title>
+  <title data-ice="title">Source | fritzing-parts-api-client-js</title>
   <link type="text/css" rel="stylesheet" href="css/style.css">
   <link type="text/css" rel="stylesheet" href="css/prettify-tomorrow.css">
   <script src="script/prettify/prettify.js"></script>
   <script src="script/manual.js"></script>
-<meta name="description" content="fritzing parts api client"><meta property="og:type" content="website"><meta property="og:url" content="https://paulvollmer.net"><meta property="og:site_name" content="fritzing-parts-api-client"><meta property="og:title" content="fritzing-parts-api-client"><meta property="og:image" content="https://github.com/paulvollmer/logo.png"><meta property="og:description" content="fritzing parts api client"><meta property="og:author" content="https://github.com/paulvollmer"><meta property="twitter:card" content="summary"><meta property="twitter:title" content="fritzing-parts-api-client"><meta property="twitter:description" content="fritzing parts api client"><meta property="twitter:image" content="https://github.com/paulvollmer/logo.png"></head>
+<meta name="description" content="fritzing parts javascript api client"><meta property="twitter:card" content="summary"><meta property="twitter:title" content="fritzing-parts-api-client-js"><meta property="twitter:description" content="fritzing parts javascript api client"></head>
 <body class="layout-container" data-ice="rootContainer">
 
 <header>
@@ -24,17 +24,28 @@
   </span>
     <ul class="search-result"></ul>
   </div>
-<a style="position:relative; top:3px;" href="https://github.com/paulvollmer/fritzing-parts-api-client"><img width="20px" src="./image/github.png"></a></header>
+<a style="position:relative; top:3px;" href="https://github.com/fritzing/fritzing-parts-api-client-js"><img width="20px" src="./image/github.png"></a></header>
 
 <nav class="navigation" data-ice="nav"><div>
   <ul>
     
-  <li data-ice="doc"><span data-ice="kind" class="kind-class">C</span><span data-ice="name"><span><a href="class/src/index.js~ApiClient.html">ApiClient</a></span></span></li>
+  <li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-getFzbs">getFzbs</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-getFzp">getFzp</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-getFzpCore">getFzpCore</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-getFzpObsolete">getFzpObsolete</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-getFzps">getFzps</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-getFzpsCore">getFzpsCore</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-getFzpsObsolete">getFzpsObsolete</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-getSvg">getSvg</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-getSvgCore">getSvgCore</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-getSvgObsolete">getSvgObsolete</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-variable">V</span><span data-ice="name"><span><a href="variable/index.html#static-variable-FritzingPartsAPI">FritzingPartsAPI</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-variable">V</span><span data-ice="name"><span><a href="variable/index.html#static-variable-FritzingPartsAPIClient">FritzingPartsAPIClient</a></span></span></li>
 </ul>
 </div>
 </nav>
 
-<div class="content" data-ice="content"><h1>Source <img data-ice="coverageBadge" src="./badge.svg"><span data-ice="totalCoverageCount" class="total-coverage-count">12/14</span></h1>
+<div class="content" data-ice="content"><h1>Source <img data-ice="coverageBadge" src="./badge.svg"><span data-ice="totalCoverageCount" class="total-coverage-count">12/13</span></h1>
 
 <table class="files-summary" data-ice="files" data-use-coverage="true">
   <thead>
@@ -50,12 +61,23 @@
   <tbody>
     
   <tr data-ice="file">
-      <td data-ice="filePath"><span><a href="file/src/index.js.html#errorLines=13,3">src/index.js</a></span></td>
-      <td data-ice="identifier" class="identifiers"><span><a href="class/src/index.js~ApiClient.html">ApiClient</a></span></td>
-      <td class="coverage"><span data-ice="coverage">85 %</span><span data-ice="coverageCount" class="coverage-count">12/14</span></td>
-      <td style="display: none;" data-ice="size">2944 byte</td>
-      <td style="display: none;" data-ice="lines">129</td>
-      <td style="display: none;" data-ice="updated">2018-03-03 20:45:02 (UTC)</td>
+      <td data-ice="filePath"><span><a href="file/src/index.js.html#errorLines=3">src/index.js</a></span></td>
+      <td data-ice="identifier" class="identifiers"><span><a href="variable/index.html#static-variable-FritzingPartsAPI">FritzingPartsAPI</a></span>
+<span><a href="variable/index.html#static-variable-FritzingPartsAPIClient">FritzingPartsAPIClient</a></span>
+<span><a href="function/index.html#static-function-getFzbs">getFzbs</a></span>
+<span><a href="function/index.html#static-function-getFzp">getFzp</a></span>
+<span><a href="function/index.html#static-function-getFzpCore">getFzpCore</a></span>
+<span><a href="function/index.html#static-function-getFzpObsolete">getFzpObsolete</a></span>
+<span><a href="function/index.html#static-function-getFzps">getFzps</a></span>
+<span><a href="function/index.html#static-function-getFzpsCore">getFzpsCore</a></span>
+<span><a href="function/index.html#static-function-getFzpsObsolete">getFzpsObsolete</a></span>
+<span><a href="function/index.html#static-function-getSvg">getSvg</a></span>
+<span><a href="function/index.html#static-function-getSvgCore">getSvgCore</a></span>
+<span><a href="function/index.html#static-function-getSvgObsolete">getSvgObsolete</a></span></td>
+      <td class="coverage"><span data-ice="coverage">92 %</span><span data-ice="coverageCount" class="coverage-count">12/13</span></td>
+      <td style="display: none;" data-ice="size">4465 byte</td>
+      <td style="display: none;" data-ice="lines">185</td>
+      <td style="display: none;" data-ice="updated">2018-03-07 22:17:58 (UTC)</td>
     </tr>
 </tbody>
 </table>

--- a/docs/test-file/test/index.test.js.html
+++ b/docs/test-file/test/index.test.js.html
@@ -3,12 +3,12 @@
 <head>
   <meta charset="utf-8">
   <base data-ice="baseUrl" href="../../">
-  <title data-ice="title">test/index.test.js | fritzing-parts-api-client</title>
+  <title data-ice="title">test/index.test.js | fritzing-parts-api-client-js</title>
   <link type="text/css" rel="stylesheet" href="css/style.css">
   <link type="text/css" rel="stylesheet" href="css/prettify-tomorrow.css">
   <script src="script/prettify/prettify.js"></script>
   <script src="script/manual.js"></script>
-<meta name="description" content="fritzing parts api client"><meta property="og:type" content="website"><meta property="og:url" content="https://paulvollmer.net"><meta property="og:site_name" content="fritzing-parts-api-client"><meta property="og:title" content="fritzing-parts-api-client"><meta property="og:image" content="https://github.com/paulvollmer/logo.png"><meta property="og:description" content="fritzing parts api client"><meta property="og:author" content="https://github.com/paulvollmer"><meta property="twitter:card" content="summary"><meta property="twitter:title" content="fritzing-parts-api-client"><meta property="twitter:description" content="fritzing parts api client"><meta property="twitter:image" content="https://github.com/paulvollmer/logo.png"></head>
+<meta name="description" content="fritzing parts javascript api client"><meta property="twitter:card" content="summary"><meta property="twitter:title" content="fritzing-parts-api-client-js"><meta property="twitter:description" content="fritzing parts javascript api client"></head>
 <body class="layout-container" data-ice="rootContainer">
 
 <header>
@@ -24,12 +24,23 @@
   </span>
     <ul class="search-result"></ul>
   </div>
-<a style="position:relative; top:3px;" href="https://github.com/paulvollmer/fritzing-parts-api-client"><img width="20px" src="./image/github.png"></a></header>
+<a style="position:relative; top:3px;" href="https://github.com/fritzing/fritzing-parts-api-client-js"><img width="20px" src="./image/github.png"></a></header>
 
 <nav class="navigation" data-ice="nav"><div>
   <ul>
     
-  <li data-ice="doc"><span data-ice="kind" class="kind-class">C</span><span data-ice="name"><span><a href="class/src/index.js~ApiClient.html">ApiClient</a></span></span></li>
+  <li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-getFzbs">getFzbs</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-getFzp">getFzp</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-getFzpCore">getFzpCore</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-getFzpObsolete">getFzpObsolete</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-getFzps">getFzps</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-getFzpsCore">getFzpsCore</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-getFzpsObsolete">getFzpsObsolete</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-getSvg">getSvg</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-getSvgCore">getSvgCore</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-getSvgObsolete">getSvgObsolete</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-variable">V</span><span data-ice="name"><span><a href="variable/index.html#static-variable-FritzingPartsAPI">FritzingPartsAPI</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-variable">V</span><span data-ice="name"><span><a href="variable/index.html#static-variable-FritzingPartsAPIClient">FritzingPartsAPIClient</a></span></span></li>
 </ul>
 </div>
 </nav>
@@ -37,13 +48,12 @@
 <div class="content" data-ice="content"><h1 data-ice="title">test/index.test.js</h1>
 <pre class="source-code line-number raw-source-code"><code class="prettyprint linenums" data-ice="content">&apos;use strict&apos;;
 
-const ApiClient = require(&apos;../src&apos;);
-let client = new ApiClient();
+const {FritzingPartsAPIClient} = require(&apos;../src&apos;);
 
 // test for the lists of fritzing parts
 describe(&apos;ApiClient getFzps&apos;, () =&gt; {
   test(&apos;Status 200&apos;, (done) =&gt; {
-    client.getFzps()
+    FritzingPartsAPIClient.getFzps()
     .then((data) =&gt; {
       expect(typeof data).toEqual(&apos;object&apos;);
       done();
@@ -56,7 +66,7 @@ describe(&apos;ApiClient getFzps&apos;, () =&gt; {
 
 describe(&apos;ApiClient getFzpsCore&apos;, () =&gt; {
   test(&apos;Status 200&apos;, (done) =&gt; {
-    client.getFzpsCore()
+    FritzingPartsAPIClient.getFzpsCore()
     .then((data) =&gt; {
       expect(typeof data).toEqual(&apos;object&apos;);
       done();
@@ -69,7 +79,7 @@ describe(&apos;ApiClient getFzpsCore&apos;, () =&gt; {
 
 describe(&apos;ApiClient getFzpsObsolete&apos;, () =&gt; {
   test(&apos;Status 200&apos;, (done) =&gt; {
-    client.getFzpsObsolete()
+    FritzingPartsAPIClient.getFzpsObsolete()
     .then((data) =&gt; {
       expect(typeof data).toEqual(&apos;object&apos;);
       done();
@@ -84,7 +94,7 @@ describe(&apos;ApiClient getFzpsObsolete&apos;, () =&gt; {
 // test for the fritzing parts api routes
 describe(&apos;ApiClient getFzp&apos;, () =&gt; {
   test(&apos;Status 200&apos;, (done) =&gt; {
-    client.getFzp(&apos;core/teensy_3.1.fzp&apos;)
+    FritzingPartsAPIClient.getFzp(&apos;core/teensy_3.1.fzp&apos;)
     .then((data) =&gt; {
       expect(typeof data).toEqual(&apos;string&apos;);
       done();
@@ -95,8 +105,8 @@ describe(&apos;ApiClient getFzp&apos;, () =&gt; {
   });
 
   test(&apos;Status 404&apos;, (done) =&gt; {
-    client.getFzp(&apos;not/found.fzp&apos;)
-    .then((data) =&gt; {
+    FritzingPartsAPIClient.getFzp(&apos;not/found.fzp&apos;)
+    .then(() =&gt; {
       throw new Error(&apos;should be 404&apos;);
       done();
     })
@@ -109,7 +119,7 @@ describe(&apos;ApiClient getFzp&apos;, () =&gt; {
 
 describe(&apos;ApiClient getFzpCore&apos;, () =&gt; {
   test(&apos;Status 200&apos;, (done) =&gt; {
-    client.getFzpCore(&apos;teensy_3.1.fzp&apos;)
+    FritzingPartsAPIClient.getFzpCore(&apos;teensy_3.1.fzp&apos;)
     .then((data) =&gt; {
       expect(typeof data).toEqual(&apos;string&apos;);
       done();
@@ -120,8 +130,8 @@ describe(&apos;ApiClient getFzpCore&apos;, () =&gt; {
   });
 
   test(&apos;Status 404&apos;, (done) =&gt; {
-    client.getFzpCore(&apos;not/found.fzp&apos;)
-    .then((data) =&gt; {
+    FritzingPartsAPIClient.getFzpCore(&apos;not/found.fzp&apos;)
+    .then(() =&gt; {
       throw new Error(&apos;should be 404&apos;);
       done();
     })
@@ -134,7 +144,7 @@ describe(&apos;ApiClient getFzpCore&apos;, () =&gt; {
 
 describe(&apos;ApiClient getFzpObsolete&apos;, () =&gt; {
   test(&apos;Status 200&apos;, (done) =&gt; {
-    client.getFzpObsolete(&apos;Arduino_Leonardo_Rev3.fzp&apos;)
+    FritzingPartsAPIClient.getFzpObsolete(&apos;Arduino_Leonardo_Rev3.fzp&apos;)
     .then((data) =&gt; {
       expect(typeof data).toEqual(&apos;string&apos;);
       done();
@@ -145,8 +155,8 @@ describe(&apos;ApiClient getFzpObsolete&apos;, () =&gt; {
   });
 
   test(&apos;Status 404&apos;, (done) =&gt; {
-    client.getFzpObsolete(&apos;not/found.fzp&apos;)
-    .then((data) =&gt; {
+    FritzingPartsAPIClient.getFzpObsolete(&apos;not/found.fzp&apos;)
+    .then(() =&gt; {
       throw new Error(&apos;should be 404&apos;);
       done();
     })
@@ -160,7 +170,7 @@ describe(&apos;ApiClient getFzpObsolete&apos;, () =&gt; {
 // test for the fritzing parts svg api routes
 describe(&apos;ApiClient getSvg&apos;, () =&gt; {
   test(&apos;Status 200&apos;, (done) =&gt; {
-    client.getSvg(&apos;core/breadboard/teensy_3.1_breadboard.svg&apos;)
+    FritzingPartsAPIClient.getSvg(&apos;core/breadboard/teensy_3.1_breadboard.svg&apos;)
     .then((data) =&gt; {
       expect(typeof data).toEqual(&apos;string&apos;);
       done();
@@ -171,8 +181,8 @@ describe(&apos;ApiClient getSvg&apos;, () =&gt; {
   });
 
   test(&apos;Status 404&apos;, (done) =&gt; {
-    client.getSvg(&apos;not/found.svg&apos;)
-    .then((data) =&gt; {
+    FritzingPartsAPIClient.getSvg(&apos;not/found.svg&apos;)
+    .then(() =&gt; {
       throw new Error(&apos;should be 404&apos;);
       done();
     })
@@ -185,7 +195,7 @@ describe(&apos;ApiClient getSvg&apos;, () =&gt; {
 
 describe(&apos;ApiClient getSvgCore&apos;, () =&gt; {
   test(&apos;Status 200&apos;, (done) =&gt; {
-    client.getSvgCore(&apos;breadboard/teensy_3.1_breadboard.svg&apos;)
+    FritzingPartsAPIClient.getSvgCore(&apos;breadboard/teensy_3.1_breadboard.svg&apos;)
     .then((data) =&gt; {
       expect(typeof data).toEqual(&apos;string&apos;);
       done();
@@ -196,8 +206,8 @@ describe(&apos;ApiClient getSvgCore&apos;, () =&gt; {
   });
 
   test(&apos;Status 404&apos;, (done) =&gt; {
-    client.getSvgCore(&apos;not/found.svg&apos;)
-    .then((data) =&gt; {
+    FritzingPartsAPIClient.getSvgCore(&apos;not/found.svg&apos;)
+    .then(() =&gt; {
       throw new Error(&apos;should be 404&apos;);
       done();
     })
@@ -210,7 +220,7 @@ describe(&apos;ApiClient getSvgCore&apos;, () =&gt; {
 
 describe(&apos;ApiClient getSvgObsolete&apos;, () =&gt; {
   test(&apos;Status 200&apos;, (done) =&gt; {
-    client.getSvgObsolete(&apos;breadboard/Arduino_Fio.svg&apos;)
+    FritzingPartsAPIClient.getSvgObsolete(&apos;breadboard/Arduino_Fio.svg&apos;)
     .then((data) =&gt; {
       expect(typeof data).toEqual(&apos;string&apos;);
       done();
@@ -221,8 +231,8 @@ describe(&apos;ApiClient getSvgObsolete&apos;, () =&gt; {
   });
 
   test(&apos;Status 404&apos;, (done) =&gt; {
-    client.getSvgObsolete(&apos;not/found.svg&apos;)
-    .then((data) =&gt; {
+    FritzingPartsAPIClient.getSvgObsolete(&apos;not/found.svg&apos;)
+    .then(() =&gt; {
       throw new Error(&apos;should be 404&apos;);
       done();
     })
@@ -237,7 +247,7 @@ describe(&apos;ApiClient getSvgObsolete&apos;, () =&gt; {
 // test for the fritzing parts binary api routes
 describe(&apos;ApiClient getFzbs&apos;, () =&gt; {
   test(&apos;Status 200&apos;, (done) =&gt; {
-    client.getFzbs()
+    FritzingPartsAPIClient.getFzbs()
     .then((data) =&gt; {
       expect(typeof data).toEqual(&apos;object&apos;);
       done();

--- a/docs/test.html
+++ b/docs/test.html
@@ -3,12 +3,12 @@
 <head>
   <meta charset="utf-8">
   <base data-ice="baseUrl" href="">
-  <title data-ice="title">Test | fritzing-parts-api-client</title>
+  <title data-ice="title">Test | fritzing-parts-api-client-js</title>
   <link type="text/css" rel="stylesheet" href="css/style.css">
   <link type="text/css" rel="stylesheet" href="css/prettify-tomorrow.css">
   <script src="script/prettify/prettify.js"></script>
   <script src="script/manual.js"></script>
-<meta name="description" content="fritzing parts api client"><meta property="og:type" content="website"><meta property="og:url" content="https://paulvollmer.net"><meta property="og:site_name" content="fritzing-parts-api-client"><meta property="og:title" content="fritzing-parts-api-client"><meta property="og:image" content="https://github.com/paulvollmer/logo.png"><meta property="og:description" content="fritzing parts api client"><meta property="og:author" content="https://github.com/paulvollmer"><meta property="twitter:card" content="summary"><meta property="twitter:title" content="fritzing-parts-api-client"><meta property="twitter:description" content="fritzing parts api client"><meta property="twitter:image" content="https://github.com/paulvollmer/logo.png"></head>
+<meta name="description" content="fritzing parts javascript api client"><meta property="twitter:card" content="summary"><meta property="twitter:title" content="fritzing-parts-api-client-js"><meta property="twitter:description" content="fritzing parts javascript api client"></head>
 <body class="layout-container" data-ice="rootContainer">
 
 <header>
@@ -24,12 +24,23 @@
   </span>
     <ul class="search-result"></ul>
   </div>
-<a style="position:relative; top:3px;" href="https://github.com/paulvollmer/fritzing-parts-api-client"><img width="20px" src="./image/github.png"></a></header>
+<a style="position:relative; top:3px;" href="https://github.com/fritzing/fritzing-parts-api-client-js"><img width="20px" src="./image/github.png"></a></header>
 
 <nav class="navigation" data-ice="nav"><div>
   <ul>
     
-  <li data-ice="doc"><span data-ice="kind" class="kind-class">C</span><span data-ice="name"><span><a href="class/src/index.js~ApiClient.html">ApiClient</a></span></span></li>
+  <li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-getFzbs">getFzbs</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-getFzp">getFzp</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-getFzpCore">getFzpCore</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-getFzpObsolete">getFzpObsolete</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-getFzps">getFzps</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-getFzpsCore">getFzpsCore</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-getFzpsObsolete">getFzpsObsolete</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-getSvg">getSvg</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-getSvgCore">getSvgCore</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-getSvgObsolete">getSvgObsolete</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-variable">V</span><span data-ice="name"><span><a href="variable/index.html#static-variable-FritzingPartsAPI">FritzingPartsAPI</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-variable">V</span><span data-ice="name"><span><a href="variable/index.html#static-variable-FritzingPartsAPIClient">FritzingPartsAPIClient</a></span></span></li>
 </ul>
 </div>
 </nav>
@@ -44,157 +55,157 @@
   </thead>
 
   <tbody data-ice="tests"><tr class="test-interface" data-ice="testInterface" style="display: none;" data-test-depth="0">
-  <td data-ice="testDescription" style="padding-left: 10px"><span data-ice="testInterfaceToggle" class="toggle closed"></span><span><a href="test-file/test/index.test.js.html#lineNumber7"><p>ApiClient getFzps</p>
+  <td data-ice="testDescription" style="padding-left: 10px"><span data-ice="testInterfaceToggle" class="toggle closed"></span><span><a href="test-file/test/index.test.js.html#lineNumber6"><p>ApiClient getFzps</p>
 </a></span></td>
   <td data-ice="testTarget" class="test-target">-</td>
 </tr>
 
 <tr class="test-interface" data-ice="testInterface" style="display: none;" data-test-depth="1">
-  <td data-ice="testDescription" style="padding-left: 20px"><span><a href="test-file/test/index.test.js.html#lineNumber8"><p>Status 200</p>
+  <td data-ice="testDescription" style="padding-left: 20px"><span><a href="test-file/test/index.test.js.html#lineNumber7"><p>Status 200</p>
 </a></span></td>
   <td data-ice="testTarget" class="test-target">-</td>
 </tr>
 
 <tr class="test-interface" data-ice="testInterface" style="display: none;" data-test-depth="0">
-  <td data-ice="testDescription" style="padding-left: 10px"><span data-ice="testInterfaceToggle" class="toggle closed"></span><span><a href="test-file/test/index.test.js.html#lineNumber20"><p>ApiClient getFzpsCore</p>
+  <td data-ice="testDescription" style="padding-left: 10px"><span data-ice="testInterfaceToggle" class="toggle closed"></span><span><a href="test-file/test/index.test.js.html#lineNumber19"><p>ApiClient getFzpsCore</p>
 </a></span></td>
   <td data-ice="testTarget" class="test-target">-</td>
 </tr>
 
 <tr class="test-interface" data-ice="testInterface" style="display: none;" data-test-depth="1">
-  <td data-ice="testDescription" style="padding-left: 20px"><span><a href="test-file/test/index.test.js.html#lineNumber21"><p>Status 200</p>
+  <td data-ice="testDescription" style="padding-left: 20px"><span><a href="test-file/test/index.test.js.html#lineNumber20"><p>Status 200</p>
 </a></span></td>
   <td data-ice="testTarget" class="test-target">-</td>
 </tr>
 
 <tr class="test-interface" data-ice="testInterface" style="display: none;" data-test-depth="0">
-  <td data-ice="testDescription" style="padding-left: 10px"><span data-ice="testInterfaceToggle" class="toggle closed"></span><span><a href="test-file/test/index.test.js.html#lineNumber33"><p>ApiClient getFzpsObsolete</p>
+  <td data-ice="testDescription" style="padding-left: 10px"><span data-ice="testInterfaceToggle" class="toggle closed"></span><span><a href="test-file/test/index.test.js.html#lineNumber32"><p>ApiClient getFzpsObsolete</p>
 </a></span></td>
   <td data-ice="testTarget" class="test-target">-</td>
 </tr>
 
 <tr class="test-interface" data-ice="testInterface" style="display: none;" data-test-depth="1">
-  <td data-ice="testDescription" style="padding-left: 20px"><span><a href="test-file/test/index.test.js.html#lineNumber34"><p>Status 200</p>
+  <td data-ice="testDescription" style="padding-left: 20px"><span><a href="test-file/test/index.test.js.html#lineNumber33"><p>Status 200</p>
 </a></span></td>
   <td data-ice="testTarget" class="test-target">-</td>
 </tr>
 
 <tr class="test-interface" data-ice="testInterface" style="display: none;" data-test-depth="0">
-  <td data-ice="testDescription" style="padding-left: 10px"><span data-ice="testInterfaceToggle" class="toggle closed"></span><span><a href="test-file/test/index.test.js.html#lineNumber48"><p>ApiClient getFzp</p>
+  <td data-ice="testDescription" style="padding-left: 10px"><span data-ice="testInterfaceToggle" class="toggle closed"></span><span><a href="test-file/test/index.test.js.html#lineNumber47"><p>ApiClient getFzp</p>
 </a></span></td>
   <td data-ice="testTarget" class="test-target">-</td>
 </tr>
 
 <tr class="test-interface" data-ice="testInterface" style="display: none;" data-test-depth="1">
-  <td data-ice="testDescription" style="padding-left: 20px"><span><a href="test-file/test/index.test.js.html#lineNumber49"><p>Status 200</p>
+  <td data-ice="testDescription" style="padding-left: 20px"><span><a href="test-file/test/index.test.js.html#lineNumber48"><p>Status 200</p>
 </a></span></td>
   <td data-ice="testTarget" class="test-target">-</td>
 </tr>
 
 <tr class="test-interface" data-ice="testInterface" style="display: none;" data-test-depth="1">
-  <td data-ice="testDescription" style="padding-left: 20px"><span><a href="test-file/test/index.test.js.html#lineNumber60"><p>Status 404</p>
+  <td data-ice="testDescription" style="padding-left: 20px"><span><a href="test-file/test/index.test.js.html#lineNumber59"><p>Status 404</p>
 </a></span></td>
   <td data-ice="testTarget" class="test-target">-</td>
 </tr>
 
 <tr class="test-interface" data-ice="testInterface" style="display: none;" data-test-depth="0">
-  <td data-ice="testDescription" style="padding-left: 10px"><span data-ice="testInterfaceToggle" class="toggle closed"></span><span><a href="test-file/test/index.test.js.html#lineNumber73"><p>ApiClient getFzpCore</p>
+  <td data-ice="testDescription" style="padding-left: 10px"><span data-ice="testInterfaceToggle" class="toggle closed"></span><span><a href="test-file/test/index.test.js.html#lineNumber72"><p>ApiClient getFzpCore</p>
 </a></span></td>
   <td data-ice="testTarget" class="test-target">-</td>
 </tr>
 
 <tr class="test-interface" data-ice="testInterface" style="display: none;" data-test-depth="1">
-  <td data-ice="testDescription" style="padding-left: 20px"><span><a href="test-file/test/index.test.js.html#lineNumber74"><p>Status 200</p>
+  <td data-ice="testDescription" style="padding-left: 20px"><span><a href="test-file/test/index.test.js.html#lineNumber73"><p>Status 200</p>
 </a></span></td>
   <td data-ice="testTarget" class="test-target">-</td>
 </tr>
 
 <tr class="test-interface" data-ice="testInterface" style="display: none;" data-test-depth="1">
-  <td data-ice="testDescription" style="padding-left: 20px"><span><a href="test-file/test/index.test.js.html#lineNumber85"><p>Status 404</p>
+  <td data-ice="testDescription" style="padding-left: 20px"><span><a href="test-file/test/index.test.js.html#lineNumber84"><p>Status 404</p>
 </a></span></td>
   <td data-ice="testTarget" class="test-target">-</td>
 </tr>
 
 <tr class="test-interface" data-ice="testInterface" style="display: none;" data-test-depth="0">
-  <td data-ice="testDescription" style="padding-left: 10px"><span data-ice="testInterfaceToggle" class="toggle closed"></span><span><a href="test-file/test/index.test.js.html#lineNumber98"><p>ApiClient getFzpObsolete</p>
+  <td data-ice="testDescription" style="padding-left: 10px"><span data-ice="testInterfaceToggle" class="toggle closed"></span><span><a href="test-file/test/index.test.js.html#lineNumber97"><p>ApiClient getFzpObsolete</p>
 </a></span></td>
   <td data-ice="testTarget" class="test-target">-</td>
 </tr>
 
 <tr class="test-interface" data-ice="testInterface" style="display: none;" data-test-depth="1">
-  <td data-ice="testDescription" style="padding-left: 20px"><span><a href="test-file/test/index.test.js.html#lineNumber99"><p>Status 200</p>
+  <td data-ice="testDescription" style="padding-left: 20px"><span><a href="test-file/test/index.test.js.html#lineNumber98"><p>Status 200</p>
 </a></span></td>
   <td data-ice="testTarget" class="test-target">-</td>
 </tr>
 
 <tr class="test-interface" data-ice="testInterface" style="display: none;" data-test-depth="1">
-  <td data-ice="testDescription" style="padding-left: 20px"><span><a href="test-file/test/index.test.js.html#lineNumber110"><p>Status 404</p>
+  <td data-ice="testDescription" style="padding-left: 20px"><span><a href="test-file/test/index.test.js.html#lineNumber109"><p>Status 404</p>
 </a></span></td>
   <td data-ice="testTarget" class="test-target">-</td>
 </tr>
 
 <tr class="test-interface" data-ice="testInterface" style="display: none;" data-test-depth="0">
-  <td data-ice="testDescription" style="padding-left: 10px"><span data-ice="testInterfaceToggle" class="toggle closed"></span><span><a href="test-file/test/index.test.js.html#lineNumber124"><p>ApiClient getSvg</p>
+  <td data-ice="testDescription" style="padding-left: 10px"><span data-ice="testInterfaceToggle" class="toggle closed"></span><span><a href="test-file/test/index.test.js.html#lineNumber123"><p>ApiClient getSvg</p>
 </a></span></td>
   <td data-ice="testTarget" class="test-target">-</td>
 </tr>
 
 <tr class="test-interface" data-ice="testInterface" style="display: none;" data-test-depth="1">
-  <td data-ice="testDescription" style="padding-left: 20px"><span><a href="test-file/test/index.test.js.html#lineNumber125"><p>Status 200</p>
+  <td data-ice="testDescription" style="padding-left: 20px"><span><a href="test-file/test/index.test.js.html#lineNumber124"><p>Status 200</p>
 </a></span></td>
   <td data-ice="testTarget" class="test-target">-</td>
 </tr>
 
 <tr class="test-interface" data-ice="testInterface" style="display: none;" data-test-depth="1">
-  <td data-ice="testDescription" style="padding-left: 20px"><span><a href="test-file/test/index.test.js.html#lineNumber136"><p>Status 404</p>
+  <td data-ice="testDescription" style="padding-left: 20px"><span><a href="test-file/test/index.test.js.html#lineNumber135"><p>Status 404</p>
 </a></span></td>
   <td data-ice="testTarget" class="test-target">-</td>
 </tr>
 
 <tr class="test-interface" data-ice="testInterface" style="display: none;" data-test-depth="0">
-  <td data-ice="testDescription" style="padding-left: 10px"><span data-ice="testInterfaceToggle" class="toggle closed"></span><span><a href="test-file/test/index.test.js.html#lineNumber149"><p>ApiClient getSvgCore</p>
+  <td data-ice="testDescription" style="padding-left: 10px"><span data-ice="testInterfaceToggle" class="toggle closed"></span><span><a href="test-file/test/index.test.js.html#lineNumber148"><p>ApiClient getSvgCore</p>
 </a></span></td>
   <td data-ice="testTarget" class="test-target">-</td>
 </tr>
 
 <tr class="test-interface" data-ice="testInterface" style="display: none;" data-test-depth="1">
-  <td data-ice="testDescription" style="padding-left: 20px"><span><a href="test-file/test/index.test.js.html#lineNumber150"><p>Status 200</p>
+  <td data-ice="testDescription" style="padding-left: 20px"><span><a href="test-file/test/index.test.js.html#lineNumber149"><p>Status 200</p>
 </a></span></td>
   <td data-ice="testTarget" class="test-target">-</td>
 </tr>
 
 <tr class="test-interface" data-ice="testInterface" style="display: none;" data-test-depth="1">
-  <td data-ice="testDescription" style="padding-left: 20px"><span><a href="test-file/test/index.test.js.html#lineNumber161"><p>Status 404</p>
+  <td data-ice="testDescription" style="padding-left: 20px"><span><a href="test-file/test/index.test.js.html#lineNumber160"><p>Status 404</p>
 </a></span></td>
   <td data-ice="testTarget" class="test-target">-</td>
 </tr>
 
 <tr class="test-interface" data-ice="testInterface" style="display: none;" data-test-depth="0">
-  <td data-ice="testDescription" style="padding-left: 10px"><span data-ice="testInterfaceToggle" class="toggle closed"></span><span><a href="test-file/test/index.test.js.html#lineNumber174"><p>ApiClient getSvgObsolete</p>
+  <td data-ice="testDescription" style="padding-left: 10px"><span data-ice="testInterfaceToggle" class="toggle closed"></span><span><a href="test-file/test/index.test.js.html#lineNumber173"><p>ApiClient getSvgObsolete</p>
 </a></span></td>
   <td data-ice="testTarget" class="test-target">-</td>
 </tr>
 
 <tr class="test-interface" data-ice="testInterface" style="display: none;" data-test-depth="1">
-  <td data-ice="testDescription" style="padding-left: 20px"><span><a href="test-file/test/index.test.js.html#lineNumber175"><p>Status 200</p>
+  <td data-ice="testDescription" style="padding-left: 20px"><span><a href="test-file/test/index.test.js.html#lineNumber174"><p>Status 200</p>
 </a></span></td>
   <td data-ice="testTarget" class="test-target">-</td>
 </tr>
 
 <tr class="test-interface" data-ice="testInterface" style="display: none;" data-test-depth="1">
-  <td data-ice="testDescription" style="padding-left: 20px"><span><a href="test-file/test/index.test.js.html#lineNumber186"><p>Status 404</p>
+  <td data-ice="testDescription" style="padding-left: 20px"><span><a href="test-file/test/index.test.js.html#lineNumber185"><p>Status 404</p>
 </a></span></td>
   <td data-ice="testTarget" class="test-target">-</td>
 </tr>
 
 <tr class="test-interface" data-ice="testInterface" style="display: none;" data-test-depth="0">
-  <td data-ice="testDescription" style="padding-left: 10px"><span data-ice="testInterfaceToggle" class="toggle closed"></span><span><a href="test-file/test/index.test.js.html#lineNumber201"><p>ApiClient getFzbs</p>
+  <td data-ice="testDescription" style="padding-left: 10px"><span data-ice="testInterfaceToggle" class="toggle closed"></span><span><a href="test-file/test/index.test.js.html#lineNumber200"><p>ApiClient getFzbs</p>
 </a></span></td>
   <td data-ice="testTarget" class="test-target">-</td>
 </tr>
 
 <tr class="test-interface" data-ice="testInterface" style="display: none;" data-test-depth="1">
-  <td data-ice="testDescription" style="padding-left: 20px"><span><a href="test-file/test/index.test.js.html#lineNumber202"><p>Status 200</p>
+  <td data-ice="testDescription" style="padding-left: 20px"><span><a href="test-file/test/index.test.js.html#lineNumber201"><p>Status 200</p>
 </a></span></td>
   <td data-ice="testTarget" class="test-target">-</td>
 </tr>

--- a/docs/variable/index.html
+++ b/docs/variable/index.html
@@ -1,0 +1,243 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <base data-ice="baseUrl" href="../">
+  <title data-ice="title">Variable | fritzing-parts-api-client-js</title>
+  <link type="text/css" rel="stylesheet" href="css/style.css">
+  <link type="text/css" rel="stylesheet" href="css/prettify-tomorrow.css">
+  <script src="script/prettify/prettify.js"></script>
+  <script src="script/manual.js"></script>
+<meta name="description" content="fritzing parts javascript api client"><meta property="twitter:card" content="summary"><meta property="twitter:title" content="fritzing-parts-api-client-js"><meta property="twitter:description" content="fritzing parts javascript api client"></head>
+<body class="layout-container" data-ice="rootContainer">
+
+<header>
+  <a href="./">Home</a>
+  
+  <a href="identifiers.html">Reference</a>
+  <a href="source.html">Source</a>
+  <a href="test.html" data-ice="testLink">Test</a>
+  <div class="search-box">
+  <span>
+    <img src="./image/search.png">
+    <span class="search-input-edge"></span><input class="search-input"><span class="search-input-edge"></span>
+  </span>
+    <ul class="search-result"></ul>
+  </div>
+<a style="position:relative; top:3px;" href="https://github.com/fritzing/fritzing-parts-api-client-js"><img width="20px" src="./image/github.png"></a></header>
+
+<nav class="navigation" data-ice="nav"><div>
+  <ul>
+    
+  <li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-getFzbs">getFzbs</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-getFzp">getFzp</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-getFzpCore">getFzpCore</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-getFzpObsolete">getFzpObsolete</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-getFzps">getFzps</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-getFzpsCore">getFzpsCore</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-getFzpsObsolete">getFzpsObsolete</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-getSvg">getSvg</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-getSvgCore">getSvgCore</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-function">F</span><span data-ice="name"><span><a href="function/index.html#static-function-getSvgObsolete">getSvgObsolete</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-variable">V</span><span data-ice="name"><span><a href="variable/index.html#static-variable-FritzingPartsAPI">FritzingPartsAPI</a></span></span></li>
+<li data-ice="doc"><span data-ice="kind" class="kind-variable">V</span><span data-ice="name"><span><a href="variable/index.html#static-variable-FritzingPartsAPIClient">FritzingPartsAPIClient</a></span></span></li>
+</ul>
+</div>
+</nav>
+
+<div class="content" data-ice="content"><h1 data-ice="title">Variable</h1>
+<div data-ice="summaries"><table class="summary" data-ice="summary">
+  <thead><tr><td data-ice="title" colspan="3">Static Public Summary</td></tr></thead>
+  <tbody>
+  
+  <tr data-ice="target">
+    <td>
+      <span class="access" data-ice="access">public</span>
+      
+      
+      
+      <span class="override" data-ice="override"></span>
+    </td>
+    <td>
+      <div>
+        <p>
+          
+          
+          
+          <span class="code" data-ice="name"><span><a href="variable/index.html#static-variable-FritzingPartsAPI">FritzingPartsAPI</a></span></span><span class="code" data-ice="signature">: <span><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">String</a></span></span>
+        </p>
+      </div>
+      <div>
+        
+        
+        <div data-ice="description"><p>The base url of the fritzing parts api</p>
+</div>
+      </div>
+    </td>
+    <td>
+      
+      
+    </td>
+  </tr>
+<tr data-ice="target">
+    <td>
+      <span class="access" data-ice="access">public</span>
+      
+      
+      
+      <span class="override" data-ice="override"></span>
+    </td>
+    <td>
+      <div>
+        <p>
+          
+          
+          
+          <span class="code" data-ice="name"><span><a href="variable/index.html#static-variable-FritzingPartsAPIClient">FritzingPartsAPIClient</a></span></span><span class="code" data-ice="signature">: {&quot;getFzps&quot;: <span>*</span>, &quot;getFzpsCore&quot;: <span>*</span>, &quot;getFzpsObsolete&quot;: <span>*</span>, &quot;getFzp&quot;: <span>*</span>, &quot;getFzpCore&quot;: <span>*</span>, &quot;getFzpObsolete&quot;: <span>*</span>, &quot;getSvg&quot;: <span>*</span>, &quot;getSvgCore&quot;: <span>*</span>, &quot;getSvgObsolete&quot;: <span>*</span>, &quot;getFzbs&quot;: <span>*</span>}</span>
+        </p>
+      </div>
+      <div>
+        
+        
+        <div data-ice="description"><p>Fritzing Parts API Client</p>
+</div>
+      </div>
+    </td>
+    <td>
+      
+      
+    </td>
+  </tr>
+</tbody>
+</table>
+</div>
+<div data-ice="details"><h2 data-ice="title">Static Public </h2>
+
+<div class="detail" data-ice="detail">
+  <h3 data-ice="anchor" id="static-variable-FritzingPartsAPI">
+    <span class="access" data-ice="access">public</span>
+    
+    
+    
+    
+    
+    <span class="code" data-ice="name">FritzingPartsAPI</span><span class="code" data-ice="signature">: <span><a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">String</a></span></span>
+    <span class="right-info">
+      
+      
+      <span data-ice="source"><span><a href="file/src/index.js.html#lineNumber15">source</a></span></span>
+    </span>
+  </h3>
+
+  
+  
+  
+  <div data-ice="description"><p>The base url of the fritzing parts api</p>
+</div>
+
+  
+
+  <div data-ice="properties">
+</div>
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  <div data-ice="example">
+    <h4>Example:</h4>
+    
+  <div class="example-doc" data-ice="exampleDoc">
+      
+      <pre class="prettyprint source-code"><code data-ice="exampleCode">const {FritzingPartsAPI} = require(&apos;fritzing-parts-api-client-js&apos;)
+
+console.log(FritzingPartsAPI)</code></pre>
+    </div>
+</div>
+
+  
+
+  
+  
+</div>
+<div class="detail" data-ice="detail">
+  <h3 data-ice="anchor" id="static-variable-FritzingPartsAPIClient">
+    <span class="access" data-ice="access">public</span>
+    
+    
+    
+    
+    
+    <span class="code" data-ice="name">FritzingPartsAPIClient</span><span class="code" data-ice="signature">: {&quot;getFzps&quot;: <span>*</span>, &quot;getFzpsCore&quot;: <span>*</span>, &quot;getFzpsObsolete&quot;: <span>*</span>, &quot;getFzp&quot;: <span>*</span>, &quot;getFzpCore&quot;: <span>*</span>, &quot;getFzpObsolete&quot;: <span>*</span>, &quot;getSvg&quot;: <span>*</span>, &quot;getSvgCore&quot;: <span>*</span>, &quot;getSvgObsolete&quot;: <span>*</span>, &quot;getFzbs&quot;: <span>*</span>}</span>
+    <span class="right-info">
+      
+      
+      <span data-ice="source"><span><a href="file/src/index.js.html#lineNumber169">source</a></span></span>
+    </span>
+  </h3>
+
+  
+  
+  
+  <div data-ice="description"><p>Fritzing Parts API Client</p>
+</div>
+
+  
+
+  <div data-ice="properties">
+</div>
+
+  
+
+  
+
+  
+
+  
+
+  
+
+  <div data-ice="example">
+    <h4>Example:</h4>
+    
+  <div class="example-doc" data-ice="exampleDoc">
+      
+      <pre class="prettyprint source-code"><code data-ice="exampleCode">const {FritzingPartsAPIClient} = require(&apos;fritzing-parts-api-client-js&apos;)
+
+FritzingPartsAPIClient.getFzps()
+.then((fzpz) =&gt; {
+  console.log(fzps)
+})
+.catch((err) =&gt; {
+  console.error(err)
+})</code></pre>
+    </div>
+</div>
+
+  
+
+  
+  
+</div>
+</div>
+</div>
+
+<footer class="footer">
+  Generated by <a href="https://esdoc.org">ESDoc<span data-ice="esdocVersion">(1.0.4)</span><img src="./image/esdoc-logo-mini-black.png"></a>
+</footer>
+
+<script src="script/search_index.js"></script>
+<script src="script/search.js"></script>
+<script src="script/pretty-print.js"></script>
+<script src="script/inherited-summary.js"></script>
+<script src="script/test-summary.js"></script>
+<script src="script/inner-link.js"></script>
+<script src="script/patch-for-local.js"></script>
+</body>
+</html>

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,159 +1,194 @@
 'use strict';
 
-var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
-
-function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
-
 var axios = require('axios');
 
 /**
- * Fritzing Parts API Client
+ * The base url of the fritzing parts api
+ *
+ * @example
+ * const {FritzingPartsAPI} = require('fritzing-parts-api-client-js')
+ *
+ * console.log(FritzingPartsAPI)
+ *
+ * @type {String}
  */
+var FritzingPartsAPI = 'https://fritzing.github.io/fritzing-parts';
 
-var ApiClient = function () {
-  /**
-   * Construct the ApiClient
-   */
-  function ApiClient() {
-    _classCallCheck(this, ApiClient);
+/**
+ * Get a list of all FZP files
+ *
+ * @type   {Function}
+ * @param  {String} url - The base URL of the parts api
+ * @return {Promise}
+ */
+var getFzps = function getFzps() {
+  var url = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : FritzingPartsAPI + '/fzp';
 
-    this.url = 'https://fritzing.github.io/fritzing-parts';
-  }
+  return axios.get(url, { responseType: 'json' }).then(function (res) {
+    return Promise.resolve(res.data);
+  });
+};
 
-  /**
-   * Get a list of all FZP files
-   * @return {Promise}
-   */
+/**
+ * Get a list of all Core-FZP files
+ *
+ * @param  {String} url - The base URL of the parts api
+ * @return {Promise}
+ */
+var getFzpsCore = function getFzpsCore() {
+  var url = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : FritzingPartsAPI + '/fzp/core';
 
+  return axios.get(url, { responseType: 'json' }).then(function (res) {
+    return Promise.resolve(res.data);
+  });
+};
 
-  _createClass(ApiClient, [{
-    key: 'getFzps',
-    value: function getFzps() {
-      return axios.get(this.url + '/fzp', { responseType: 'json' }).then(function (res) {
-        return res.data;
-      });
-    }
-    /**
-     * Get a list of all Core-FZP files
-     * @return {Promise}
-     */
+/**
+ * Get a list of all Obsolete-FZP files. for old sketches only!
+ *
+ * @param  {String} url - The base URL of the parts api
+ * @return {Promise}
+ */
+var getFzpsObsolete = function getFzpsObsolete() {
+  var url = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : FritzingPartsAPI + '/fzp/obsolete';
 
-  }, {
-    key: 'getFzpsCore',
-    value: function getFzpsCore() {
-      return axios.get(this.url + '/fzp/core', { responseType: 'json' }).then(function (res) {
-        return res.data;
-      });
-    }
-    /**
-     * Get a list of all Obsolete-FZP files. for old sketches only!
-     * @return {Promise}
-     */
+  return axios.get(url, { responseType: 'json' }).then(function (res) {
+    return Promise.resolve(res.data);
+  });
+};
 
-  }, {
-    key: 'getFzpsObsolete',
-    value: function getFzpsObsolete() {
-      return axios.get(this.url + '/fzp/obsolete', { responseType: 'json' }).then(function (res) {
-        return res.data;
-      });
-    }
+/**
+ * Get a single FZP and response the xml as a string
+ *
+ * @param  {String} src
+ * @param  {String} url - The base URL of the parts api
+ * @return {Promise} the fetch promise
+ */
+var getFzp = function getFzp(src) {
+  var url = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : FritzingPartsAPI;
 
-    /**
-     * Get a single FZP and response the xml as a string
-     * @param  {String} src
-     * @return {Promise} the fetch promise
-     */
+  return axios.get(url + '/' + src, { responseType: 'xml' }).then(function (res) {
+    return Promise.resolve(res.data);
+  });
+};
 
-  }, {
-    key: 'getFzp',
-    value: function getFzp(src) {
-      return axios.get(this.url + '/' + src, { responseType: 'xml' }).then(function (res) {
-        return res.data;
-      });
-    }
+/**
+ * Get a single part fzp from the core parts
+ *
+ * @param  {String} src
+ * @param  {String} url - The base URL of the parts api
+ * @return {Promise} the fetch promise returns xml
+ */
+var getFzpCore = function getFzpCore(src) {
+  var url = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : FritzingPartsAPI;
 
-    /**
-     * Get a single part fzp from the core parts
-     * @param  {String} src
-     * @return {Promise} the fetch promise returns xml
-     */
+  return axios.get(url + '/core/' + src, { responseType: 'xml' }).then(function (res) {
+    return Promise.resolve(res.data);
+  });
+};
 
-  }, {
-    key: 'getFzpCore',
-    value: function getFzpCore(src) {
-      return axios.get(this.url + '/core/' + src, { responseType: 'xml' }).then(function (res) {
-        return res.data;
-      });
-    }
-    /**
-     * Get a single part fzp from the obsolete parts, this is for old sketches only!
-     * @param  {String} src
-     * @return {Promise} the fetch promise returns xml
-     */
+/**
+ * Get a single part fzp from the obsolete parts, this is for old sketches only!
+ *
+ * @param  {String} src
+ * @param  {String} url - The base URL of the parts api
+ * @return {Promise} the fetch promise returns xml
+ */
+var getFzpObsolete = function getFzpObsolete(src) {
+  var url = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : FritzingPartsAPI;
 
-  }, {
-    key: 'getFzpObsolete',
-    value: function getFzpObsolete(src) {
-      return axios.get(this.url + '/obsolete/' + src, { responseType: 'xml' }).then(function (res) {
-        return res.data;
-      });
-    }
+  return axios.get(url + '/obsolete/' + src, { responseType: 'xml' }).then(function (res) {
+    return Promise.resolve(res.data);
+  });
+};
 
-    /**
-     * Get a single part svg and response the svg as a string
-     * @param  {String} src
-     * @return {Promise} the fetch promise
-     */
+/**
+ * Get a single part svg and response the svg as a string
+ *
+ * @param  {String} src
+ * @param  {String} url - The base URL of the parts api
+ * @return {Promise} the fetch promise
+ */
+var getSvg = function getSvg(src) {
+  var url = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : FritzingPartsAPI;
 
-  }, {
-    key: 'getSvg',
-    value: function getSvg(src) {
-      return axios.get(this.url + '/svg/' + src, { responseType: 'xml' }).then(function (res) {
-        return res.data;
-      });
-    }
-    /**
-     * Get a single part svg from the core parts as svg-string
-     * @param  {String} src
-     * @return {Promise} the fetch promise returns xml
-     */
+  return axios.get(url + '/svg/' + src, { responseType: 'xml' }).then(function (res) {
+    return Promise.resolve(res.data);
+  });
+};
 
-  }, {
-    key: 'getSvgCore',
-    value: function getSvgCore(src) {
-      return axios.get(this.url + '/svg/core/' + src, { responseType: 'xml' }).then(function (res) {
-        return res.data;
-      });
-    }
-    /**
-     * Get a single part svg from the obsolete svgs, this is for old-sketches only! the response is a svg-string
-     * @param  {String} src
-     * @return {Promise} the fetch promise
-     */
+/**
+ * Get a single part svg from the core parts as svg-string
+ *
+ * @param  {String} src
+ * @param  {String} url - The base URL of the parts api
+ * @return {Promise} the fetch promise returns xml
+ */
+var getSvgCore = function getSvgCore(src) {
+  var url = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : FritzingPartsAPI;
 
-  }, {
-    key: 'getSvgObsolete',
-    value: function getSvgObsolete(src) {
-      return axios.get(this.url + '/svg/obsolete/' + src, { responseType: 'xml' }).then(function (res) {
-        return res.data;
-      });
-    }
+  return axios.get(url + '/svg/core/' + src, { responseType: 'xml' }).then(function (res) {
+    return Promise.resolve(res.data);
+  });
+};
 
-    /**
-     * Get a list of all FZB files
-     * @return {Promise}
-     */
+/**
+ * Get a single part svg from the obsolete svgs, this is for old-sketches only! the response is a svg-string
+ *
+ * @param  {String} src
+ * @param  {String} url - The base URL of the parts api
+ * @return {Promise} the fetch promise
+ */
+var getSvgObsolete = function getSvgObsolete(src) {
+  var url = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : FritzingPartsAPI;
 
-  }, {
-    key: 'getFzbs',
-    value: function getFzbs() {
-      return axios.get(this.url + '/fzb', { responseType: 'json' }).then(function (res) {
-        return res.data;
-      });
-    }
-  }]);
+  return axios.get(url + '/svg/obsolete/' + src, { responseType: 'xml' }).then(function (res) {
+    return Promise.resolve(res.data);
+  });
+};
 
-  return ApiClient;
-}();
+/**
+ * Get a list of all FZB files
+ *
+ * @param  {String} url - The base URL of the parts api
+ * @return {Promise}
+ */
+var getFzbs = function getFzbs() {
+  var url = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : FritzingPartsAPI + '/fzb';
 
-module.exports = ApiClient;
+  return axios.get(url, { responseType: 'json' }).then(function (res) {
+    return Promise.resolve(res.data);
+  });
+};
+
+/**
+* Fritzing Parts API Client
+*
+* @example
+* const {FritzingPartsAPIClient} = require('fritzing-parts-api-client-js')
+*
+* FritzingPartsAPIClient.getFzps()
+* .then((fzpz) => {
+*   console.log(fzps)
+* })
+* .catch((err) => {
+*   console.error(err)
+* })
+*/
+var FritzingPartsAPIClient = {
+  getFzps: getFzps,
+  getFzpsCore: getFzpsCore,
+  getFzpsObsolete: getFzpsObsolete,
+  getFzp: getFzp,
+  getFzpCore: getFzpCore,
+  getFzpObsolete: getFzpObsolete,
+  getSvg: getSvg,
+  getSvgCore: getSvgCore,
+  getSvgObsolete: getSvgObsolete,
+  getFzbs: getFzbs
+};
+
+module.exports = {
+  FritzingPartsAPI: FritzingPartsAPI,
+  FritzingPartsAPIClient: FritzingPartsAPIClient
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
-  "name": "fritzing-parts-api-client",
-  "version": "0.1.0",
+  "name": "fritzing-parts-api-client-js",
+  "version": "0.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -413,6 +413,12 @@
         "lodash": "4.17.5"
       }
     },
+    "babel-helper-evaluate-path": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/babel-helper-evaluate-path/-/babel-helper-evaluate-path-0.3.0.tgz",
+      "integrity": "sha512-dRFlMTqUJRGzx5a2smKxmptDdNCXKSkPcXWzKLwAV72hvIZumrd/0z9RcewHkr7PmAEq+ETtpD1GK6wZ6ZUXzw==",
+      "dev": true
+    },
     "babel-helper-explode-assignable-expression": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-explode-assignable-expression/-/babel-helper-explode-assignable-expression-6.24.1.tgz",
@@ -457,6 +463,12 @@
         "babel-types": "6.26.0"
       }
     },
+    "babel-helper-mark-eval-scopes": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/babel-helper-mark-eval-scopes/-/babel-helper-mark-eval-scopes-0.3.0.tgz",
+      "integrity": "sha512-nrho5Dg4vl0VUgURVpGpEGiwbst5JX7efIyDHFxmkCx/ocQFnrPt8ze9Kxl6TKjR29bJ7D/XKY1NMlSxOQJRbQ==",
+      "dev": true
+    },
     "babel-helper-optimise-call-expression": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.24.1.tgz",
@@ -490,6 +502,12 @@
         "babel-traverse": "6.26.0",
         "babel-types": "6.26.0"
       }
+    },
+    "babel-helper-remove-or-void": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/babel-helper-remove-or-void/-/babel-helper-remove-or-void-0.3.0.tgz",
+      "integrity": "sha512-D68W1M3ibCcbg0ysh3ww4/O0g10X1CXK720oOuR8kpfY7w0yP4tVcpK7zDmI1JecynycTQYAZ1rhLJo9aVtIKQ==",
+      "dev": true
     },
     "babel-helper-replace-supers": {
       "version": "6.24.1",
@@ -559,6 +577,18 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-22.4.1.tgz",
       "integrity": "sha512-gmj5FvFflXSnRapWmF/jDjx5Lof1kX0OwXibCxMOx38V3CFMOnTxLTUrAFfLkhCey3FJvv0ACvv/+h4nzFRxhg==",
       "dev": true
+    },
+    "babel-plugin-minify-dead-code-elimination": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-minify-dead-code-elimination/-/babel-plugin-minify-dead-code-elimination-0.3.0.tgz",
+      "integrity": "sha512-SjM2Fzg85YZz+q/PNJ/HU4O3W98FKFOiP9K5z3sfonlamGOzvZw3Eup2OTiEBsbbqTeY8yzNCAv3qpJRYCgGmw==",
+      "dev": true,
+      "requires": {
+        "babel-helper-evaluate-path": "0.3.0",
+        "babel-helper-mark-eval-scopes": "0.3.0",
+        "babel-helper-remove-or-void": "0.3.0",
+        "lodash.some": "4.6.0"
+      }
     },
     "babel-plugin-syntax-async-functions": {
       "version": "6.13.0",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
   },
   "devDependencies": {
     "babel-cli": "^6.26.0",
+    "babel-plugin-minify-dead-code-elimination": "^0.3.0",
     "babel-preset-env": "^1.6.1",
     "esdoc": "^1.0.4",
     "esdoc-ecmascript-proposal-plugin": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fritzing-parts-api-client-js",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "fritzing-parts api client for frontend side",
   "contributors": [
     {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fritzing-parts-api-client-js",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "fritzing-parts api client for frontend side",
   "contributors": [
     {

--- a/src/index.js
+++ b/src/index.js
@@ -2,11 +2,32 @@
 
 const axios = require('axios');
 
+/**
+ * The base url of the fritzing parts api
+ *
+ * @example
+ * const {FritzingPartsAPI} = require('fritzing-parts-api-client-js')
+ *
+ * console.log(FritzingPartsAPI)
+ *
+ * @type {String}
+ */
 const FritzingPartsAPI = 'https://fritzing.github.io/fritzing-parts';
-const FritzingPartsAPISVG = FritzingPartsAPI+'/svg';
 
 /**
  * Fritzing Parts API Client
+ *
+ * @example
+ * const {ApiClient} = require('fritzing-parts-api-client-js')
+ *
+ * let client = new ApiClient()
+ * client.getFzps()
+ * .then((fzpz) => {
+ *   console.log(fzps)
+ * })
+ * .catch((err) => {
+ *   console.error(err)
+ * })
  */
 class ApiClient {
   /**
@@ -22,7 +43,7 @@ class ApiClient {
    * @return {Promise}
    */
   getFzps() {
-    return axios.get(this.url+'/fzp', {responseType: 'json'})
+    return axios.get(`${this.url}/fzp`, {responseType: 'json'})
     .then((res) => {
       return res.data;
     });
@@ -33,7 +54,7 @@ class ApiClient {
    * @return {Promise}
    */
   getFzpsCore() {
-    return axios.get(this.url+'/fzp/core', {responseType: 'json'})
+    return axios.get(`${this.url}/fzp/core`, {responseType: 'json'})
     .then((res) => {
       return res.data;
     });
@@ -44,7 +65,7 @@ class ApiClient {
    * @return {Promise}
    */
   getFzpsObsolete() {
-    return axios.get(this.url+'/fzp/obsolete', {responseType: 'json'})
+    return axios.get(`${this.url}/fzp/obsolete`, {responseType: 'json'})
     .then((res) => {
       return res.data;
     });
@@ -56,7 +77,7 @@ class ApiClient {
    * @return {Promise} the fetch promise
    */
    getFzp(src) {
-     return axios.get(this.url+'/'+src, {responseType: 'xml'})
+     return axios.get(`${this.url}/${src}`, {responseType: 'xml'})
      .then((res) => {
        return res.data;
      });
@@ -68,7 +89,7 @@ class ApiClient {
     * @return {Promise} the fetch promise returns xml
     */
   getFzpCore(src) {
-    return axios.get(this.url+'/core/'+src, {responseType: 'xml'})
+    return axios.get(`${this.url}/core/${src}`, {responseType: 'xml'})
     .then((res) => {
       return res.data;
     });
@@ -80,7 +101,7 @@ class ApiClient {
    * @return {Promise} the fetch promise returns xml
    */
   getFzpObsolete(src) {
-    return axios.get(this.url+'/obsolete/'+src, {responseType: 'xml'})
+    return axios.get(`${this.url}/obsolete/${src}`, {responseType: 'xml'})
     .then((res) => {
       return res.data;
     });
@@ -92,7 +113,7 @@ class ApiClient {
    * @return {Promise} the fetch promise
    */
    getSvg(src) {
-     return axios.get(this.url+'/svg/'+src, {responseType: 'xml'})
+     return axios.get(`${this.url}/svg/${src}`, {responseType: 'xml'})
      .then((res) => {
        return res.data;
      });
@@ -104,7 +125,7 @@ class ApiClient {
     * @return {Promise} the fetch promise returns xml
     */
   getSvgCore(src) {
-    return axios.get(this.url+'/svg/core/'+src, {responseType: 'xml'})
+    return axios.get(`${this.url}/svg/core/${src}`, {responseType: 'xml'})
     .then((res) => {
       return res.data;
     });
@@ -116,7 +137,7 @@ class ApiClient {
    * @return {Promise} the fetch promise
    */
   getSvgObsolete(src) {
-    return axios.get(this.url+'/svg/obsolete/'+src, {responseType: 'xml'})
+    return axios.get(`${this.url}/svg/obsolete/${src}`, {responseType: 'xml'})
     .then((res) => {
       return res.data;
     });
@@ -127,7 +148,7 @@ class ApiClient {
    * @return {Promise}
    */
   getFzbs() {
-    return axios.get(this.url+'/fzb', {responseType: 'json'})
+    return axios.get(`${this.url}/fzb`, {responseType: 'json'})
     .then((res) => {
       return res.data;
     });
@@ -137,5 +158,4 @@ class ApiClient {
 module.exports = {
   ApiClient,
   FritzingPartsAPI,
-  FritzingPartsAPISVG,
 };

--- a/src/index.js
+++ b/src/index.js
@@ -24,7 +24,7 @@ const FritzingPartsAPI = 'https://fritzing.github.io/fritzing-parts';
 const getFzps = function(url = `${FritzingPartsAPI}/fzp`) {
   return axios.get(url, {responseType: 'json'})
   .then((res) => {
-    return res.data;
+    return Promise.resolve(res.data);
   });
 };
 
@@ -37,7 +37,7 @@ const getFzps = function(url = `${FritzingPartsAPI}/fzp`) {
 const getFzpsCore = function(url = `${FritzingPartsAPI}/fzp/core`) {
   return axios.get(url, {responseType: 'json'})
   .then((res) => {
-    return res.data;
+    return Promise.resolve(res.data);
   });
 };
 
@@ -50,7 +50,7 @@ const getFzpsCore = function(url = `${FritzingPartsAPI}/fzp/core`) {
 const getFzpsObsolete = function(url = `${FritzingPartsAPI}/fzp/obsolete`) {
   return axios.get(url, {responseType: 'json'})
   .then((res) => {
-    return res.data;
+    return Promise.resolve(res.data);
   });
 };
 
@@ -64,7 +64,7 @@ const getFzpsObsolete = function(url = `${FritzingPartsAPI}/fzp/obsolete`) {
 const getFzp = function(src, url = FritzingPartsAPI) {
   return axios.get(`${url}/${src}`, {responseType: 'xml'})
   .then((res) => {
-    return res.data;
+    return Promise.resolve(res.data);
   });
 };
 
@@ -78,7 +78,7 @@ const getFzp = function(src, url = FritzingPartsAPI) {
 const getFzpCore = function(src, url = FritzingPartsAPI) {
   return axios.get(`${url}/core/${src}`, {responseType: 'xml'})
   .then((res) => {
-    return res.data;
+    return Promise.resolve(res.data);
   });
 };
 
@@ -92,7 +92,7 @@ const getFzpCore = function(src, url = FritzingPartsAPI) {
 const getFzpObsolete = function(src, url = FritzingPartsAPI) {
   return axios.get(`${url}/obsolete/${src}`, {responseType: 'xml'})
   .then((res) => {
-    return res.data;
+    return Promise.resolve(res.data);
   });
 };
 
@@ -106,7 +106,7 @@ const getFzpObsolete = function(src, url = FritzingPartsAPI) {
  const getSvg = function(src, url = FritzingPartsAPI) {
    return axios.get(`${url}/svg/${src}`, {responseType: 'xml'})
    .then((res) => {
-     return res.data;
+     return Promise.resolve(res.data);
    });
  };
 
@@ -120,7 +120,7 @@ const getFzpObsolete = function(src, url = FritzingPartsAPI) {
 const getSvgCore = function(src, url = FritzingPartsAPI) {
   return axios.get(`${url}/svg/core/${src}`, {responseType: 'xml'})
   .then((res) => {
-    return res.data;
+    return Promise.resolve(res.data);
   });
 };
 
@@ -134,7 +134,7 @@ const getSvgCore = function(src, url = FritzingPartsAPI) {
 const getSvgObsolete = function(src, url = FritzingPartsAPI) {
   return axios.get(`${url}/svg/obsolete/${src}`, {responseType: 'xml'})
   .then((res) => {
-    return res.data;
+    return Promise.resolve(res.data);
   });
 };
 
@@ -147,7 +147,7 @@ const getSvgObsolete = function(src, url = FritzingPartsAPI) {
 const getFzbs = function(url = `${FritzingPartsAPI}/fzb`) {
   return axios.get(url, {responseType: 'json'})
   .then((res) => {
-    return res.data;
+    return Promise.resolve(res.data);
   });
 };
 

--- a/src/index.js
+++ b/src/index.js
@@ -2,15 +2,19 @@
 
 const axios = require('axios');
 
+const FritzingPartsAPI = 'https://fritzing.github.io/fritzing-parts';
+const FritzingPartsAPISVG = FritzingPartsAPI+'/svg';
+
 /**
  * Fritzing Parts API Client
  */
 class ApiClient {
   /**
    * Construct the ApiClient
+   * @param {String} url
    */
-  constructor() {
-    this.url = 'https://fritzing.github.io/fritzing-parts';
+  constructor(url) {
+    this.url = url || FritzingPartsAPI;
   }
 
   /**
@@ -23,6 +27,7 @@ class ApiClient {
       return res.data;
     });
   }
+
   /**
    * Get a list of all Core-FZP files
    * @return {Promise}
@@ -33,6 +38,7 @@ class ApiClient {
       return res.data;
     });
   }
+
   /**
    * Get a list of all Obsolete-FZP files. for old sketches only!
    * @return {Promise}
@@ -67,6 +73,7 @@ class ApiClient {
       return res.data;
     });
   }
+
   /**
    * Get a single part fzp from the obsolete parts, this is for old sketches only!
    * @param  {String} src
@@ -79,7 +86,6 @@ class ApiClient {
     });
   }
 
-
   /**
    * Get a single part svg and response the svg as a string
    * @param  {String} src
@@ -91,6 +97,7 @@ class ApiClient {
        return res.data;
      });
    }
+
    /**
     * Get a single part svg from the core parts as svg-string
     * @param  {String} src
@@ -102,6 +109,7 @@ class ApiClient {
       return res.data;
     });
   }
+
   /**
    * Get a single part svg from the obsolete svgs, this is for old-sketches only! the response is a svg-string
    * @param  {String} src
@@ -126,4 +134,8 @@ class ApiClient {
   }
 }
 
-module.exports = ApiClient;
+module.exports = {
+  ApiClient,
+  FritzingPartsAPI,
+  FritzingPartsAPISVG,
+};

--- a/src/index.js
+++ b/src/index.js
@@ -15,147 +15,171 @@ const axios = require('axios');
 const FritzingPartsAPI = 'https://fritzing.github.io/fritzing-parts';
 
 /**
- * Fritzing Parts API Client
+ * Get a list of all FZP files
  *
- * @example
- * const {ApiClient} = require('fritzing-parts-api-client-js')
- *
- * let client = new ApiClient()
- * client.getFzps()
- * .then((fzpz) => {
- *   console.log(fzps)
- * })
- * .catch((err) => {
- *   console.error(err)
- * })
+ * @type   {Function}
+ * @param  {String} url - The base URL of the parts api
+ * @return {Promise}
  */
-class ApiClient {
-  /**
-   * Construct the ApiClient
-   * @param {String} url
-   */
-  constructor(url) {
-    this.url = url || FritzingPartsAPI;
-  }
+const getFzps = function(url = `${FritzingPartsAPI}/fzp`) {
+  return axios.get(url, {responseType: 'json'})
+  .then((res) => {
+    return res.data;
+  });
+};
 
-  /**
-   * Get a list of all FZP files
-   * @return {Promise}
-   */
-  getFzps() {
-    return axios.get(`${this.url}/fzp`, {responseType: 'json'})
-    .then((res) => {
-      return res.data;
-    });
-  }
+/**
+ * Get a list of all Core-FZP files
+ *
+ * @param  {String} url - The base URL of the parts api
+ * @return {Promise}
+ */
+const getFzpsCore = function(url = `${FritzingPartsAPI}/fzp/core`) {
+  return axios.get(url, {responseType: 'json'})
+  .then((res) => {
+    return res.data;
+  });
+};
 
-  /**
-   * Get a list of all Core-FZP files
-   * @return {Promise}
-   */
-  getFzpsCore() {
-    return axios.get(`${this.url}/fzp/core`, {responseType: 'json'})
-    .then((res) => {
-      return res.data;
-    });
-  }
+/**
+ * Get a list of all Obsolete-FZP files. for old sketches only!
+ *
+ * @param  {String} url - The base URL of the parts api
+ * @return {Promise}
+ */
+const getFzpsObsolete = function(url = `${FritzingPartsAPI}/fzp/obsolete`) {
+  return axios.get(url, {responseType: 'json'})
+  .then((res) => {
+    return res.data;
+  });
+};
 
-  /**
-   * Get a list of all Obsolete-FZP files. for old sketches only!
-   * @return {Promise}
-   */
-  getFzpsObsolete() {
-    return axios.get(`${this.url}/fzp/obsolete`, {responseType: 'json'})
-    .then((res) => {
-      return res.data;
-    });
-  }
+/**
+ * Get a single FZP and response the xml as a string
+ *
+ * @param  {String} src
+ * @param  {String} url - The base URL of the parts api
+ * @return {Promise} the fetch promise
+ */
+const getFzp = function(src, url = FritzingPartsAPI) {
+  return axios.get(`${url}/${src}`, {responseType: 'xml'})
+  .then((res) => {
+    return res.data;
+  });
+};
 
-  /**
-   * Get a single FZP and response the xml as a string
-   * @param  {String} src
-   * @return {Promise} the fetch promise
-   */
-   getFzp(src) {
-     return axios.get(`${this.url}/${src}`, {responseType: 'xml'})
-     .then((res) => {
-       return res.data;
-     });
-   }
+ /**
+  * Get a single part fzp from the core parts
+  *
+  * @param  {String} src
+  * @param  {String} url - The base URL of the parts api
+  * @return {Promise} the fetch promise returns xml
+  */
+const getFzpCore = function(src, url = FritzingPartsAPI) {
+  return axios.get(`${url}/core/${src}`, {responseType: 'xml'})
+  .then((res) => {
+    return res.data;
+  });
+};
 
-   /**
-    * Get a single part fzp from the core parts
-    * @param  {String} src
-    * @return {Promise} the fetch promise returns xml
-    */
-  getFzpCore(src) {
-    return axios.get(`${this.url}/core/${src}`, {responseType: 'xml'})
-    .then((res) => {
-      return res.data;
-    });
-  }
+/**
+ * Get a single part fzp from the obsolete parts, this is for old sketches only!
+ *
+ * @param  {String} src
+ * @param  {String} url - The base URL of the parts api
+ * @return {Promise} the fetch promise returns xml
+ */
+const getFzpObsolete = function(src, url = FritzingPartsAPI) {
+  return axios.get(`${url}/obsolete/${src}`, {responseType: 'xml'})
+  .then((res) => {
+    return res.data;
+  });
+};
 
-  /**
-   * Get a single part fzp from the obsolete parts, this is for old sketches only!
-   * @param  {String} src
-   * @return {Promise} the fetch promise returns xml
-   */
-  getFzpObsolete(src) {
-    return axios.get(`${this.url}/obsolete/${src}`, {responseType: 'xml'})
-    .then((res) => {
-      return res.data;
-    });
-  }
+/**
+ * Get a single part svg and response the svg as a string
+ *
+ * @param  {String} src
+ * @param  {String} url - The base URL of the parts api
+ * @return {Promise} the fetch promise
+ */
+ const getSvg = function(src, url = FritzingPartsAPI) {
+   return axios.get(`${url}/svg/${src}`, {responseType: 'xml'})
+   .then((res) => {
+     return res.data;
+   });
+ };
 
-  /**
-   * Get a single part svg and response the svg as a string
-   * @param  {String} src
-   * @return {Promise} the fetch promise
-   */
-   getSvg(src) {
-     return axios.get(`${this.url}/svg/${src}`, {responseType: 'xml'})
-     .then((res) => {
-       return res.data;
-     });
-   }
+ /**
+  * Get a single part svg from the core parts as svg-string
+  *
+  * @param  {String} src
+  * @param  {String} url - The base URL of the parts api
+  * @return {Promise} the fetch promise returns xml
+  */
+const getSvgCore = function(src, url = FritzingPartsAPI) {
+  return axios.get(`${url}/svg/core/${src}`, {responseType: 'xml'})
+  .then((res) => {
+    return res.data;
+  });
+};
 
-   /**
-    * Get a single part svg from the core parts as svg-string
-    * @param  {String} src
-    * @return {Promise} the fetch promise returns xml
-    */
-  getSvgCore(src) {
-    return axios.get(`${this.url}/svg/core/${src}`, {responseType: 'xml'})
-    .then((res) => {
-      return res.data;
-    });
-  }
+/**
+ * Get a single part svg from the obsolete svgs, this is for old-sketches only! the response is a svg-string
+ *
+ * @param  {String} src
+ * @param  {String} url - The base URL of the parts api
+ * @return {Promise} the fetch promise
+ */
+const getSvgObsolete = function(src, url = FritzingPartsAPI) {
+  return axios.get(`${url}/svg/obsolete/${src}`, {responseType: 'xml'})
+  .then((res) => {
+    return res.data;
+  });
+};
 
-  /**
-   * Get a single part svg from the obsolete svgs, this is for old-sketches only! the response is a svg-string
-   * @param  {String} src
-   * @return {Promise} the fetch promise
-   */
-  getSvgObsolete(src) {
-    return axios.get(`${this.url}/svg/obsolete/${src}`, {responseType: 'xml'})
-    .then((res) => {
-      return res.data;
-    });
-  }
+/**
+ * Get a list of all FZB files
+ *
+ * @param  {String} url - The base URL of the parts api
+ * @return {Promise}
+ */
+const getFzbs = function(url = `${FritzingPartsAPI}/fzb`) {
+  return axios.get(url, {responseType: 'json'})
+  .then((res) => {
+    return res.data;
+  });
+};
 
-  /**
-   * Get a list of all FZB files
-   * @return {Promise}
-   */
-  getFzbs() {
-    return axios.get(`${this.url}/fzb`, {responseType: 'json'})
-    .then((res) => {
-      return res.data;
-    });
-  }
-}
+
+/**
+* Fritzing Parts API Client
+*
+* @example
+* const {FritzingPartsAPIClient} = require('fritzing-parts-api-client-js')
+*
+* FritzingPartsAPIClient.getFzps()
+* .then((fzpz) => {
+*   console.log(fzps)
+* })
+* .catch((err) => {
+*   console.error(err)
+* })
+*/
+const FritzingPartsAPIClient = {
+  getFzps,
+  getFzpsCore,
+  getFzpsObsolete,
+  getFzp,
+  getFzpCore,
+  getFzpObsolete,
+  getSvg,
+  getSvgCore,
+  getSvgObsolete,
+  getFzbs,
+};
 
 module.exports = {
-  ApiClient,
   FritzingPartsAPI,
+  FritzingPartsAPIClient,
 };

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -58,7 +58,7 @@ describe('ApiClient getFzp', () => {
 
   test('Status 404', (done) => {
     FritzingPartsAPIClient.getFzp('not/found.fzp')
-    .then((data) => {
+    .then(() => {
       throw new Error('should be 404');
       done();
     })
@@ -83,7 +83,7 @@ describe('ApiClient getFzpCore', () => {
 
   test('Status 404', (done) => {
     FritzingPartsAPIClient.getFzpCore('not/found.fzp')
-    .then((data) => {
+    .then(() => {
       throw new Error('should be 404');
       done();
     })
@@ -108,7 +108,7 @@ describe('ApiClient getFzpObsolete', () => {
 
   test('Status 404', (done) => {
     FritzingPartsAPIClient.getFzpObsolete('not/found.fzp')
-    .then((data) => {
+    .then(() => {
       throw new Error('should be 404');
       done();
     })
@@ -134,7 +134,7 @@ describe('ApiClient getSvg', () => {
 
   test('Status 404', (done) => {
     FritzingPartsAPIClient.getSvg('not/found.svg')
-    .then((data) => {
+    .then(() => {
       throw new Error('should be 404');
       done();
     })
@@ -159,7 +159,7 @@ describe('ApiClient getSvgCore', () => {
 
   test('Status 404', (done) => {
     FritzingPartsAPIClient.getSvgCore('not/found.svg')
-    .then((data) => {
+    .then(() => {
       throw new Error('should be 404');
       done();
     })
@@ -184,7 +184,7 @@ describe('ApiClient getSvgObsolete', () => {
 
   test('Status 404', (done) => {
     FritzingPartsAPIClient.getSvgObsolete('not/found.svg')
-    .then((data) => {
+    .then(() => {
       throw new Error('should be 404');
       done();
     })

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const ApiClient = require('../src');
+const {ApiClient} = require('../src');
 let client = new ApiClient();
 
 // test for the lists of fritzing parts

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,12 +1,11 @@
 'use strict';
 
-const {ApiClient} = require('../src');
-let client = new ApiClient();
+const {FritzingPartsAPIClient} = require('../src');
 
 // test for the lists of fritzing parts
 describe('ApiClient getFzps', () => {
   test('Status 200', (done) => {
-    client.getFzps()
+    FritzingPartsAPIClient.getFzps()
     .then((data) => {
       expect(typeof data).toEqual('object');
       done();
@@ -19,7 +18,7 @@ describe('ApiClient getFzps', () => {
 
 describe('ApiClient getFzpsCore', () => {
   test('Status 200', (done) => {
-    client.getFzpsCore()
+    FritzingPartsAPIClient.getFzpsCore()
     .then((data) => {
       expect(typeof data).toEqual('object');
       done();
@@ -32,7 +31,7 @@ describe('ApiClient getFzpsCore', () => {
 
 describe('ApiClient getFzpsObsolete', () => {
   test('Status 200', (done) => {
-    client.getFzpsObsolete()
+    FritzingPartsAPIClient.getFzpsObsolete()
     .then((data) => {
       expect(typeof data).toEqual('object');
       done();
@@ -47,7 +46,7 @@ describe('ApiClient getFzpsObsolete', () => {
 // test for the fritzing parts api routes
 describe('ApiClient getFzp', () => {
   test('Status 200', (done) => {
-    client.getFzp('core/teensy_3.1.fzp')
+    FritzingPartsAPIClient.getFzp('core/teensy_3.1.fzp')
     .then((data) => {
       expect(typeof data).toEqual('string');
       done();
@@ -58,7 +57,7 @@ describe('ApiClient getFzp', () => {
   });
 
   test('Status 404', (done) => {
-    client.getFzp('not/found.fzp')
+    FritzingPartsAPIClient.getFzp('not/found.fzp')
     .then((data) => {
       throw new Error('should be 404');
       done();
@@ -72,7 +71,7 @@ describe('ApiClient getFzp', () => {
 
 describe('ApiClient getFzpCore', () => {
   test('Status 200', (done) => {
-    client.getFzpCore('teensy_3.1.fzp')
+    FritzingPartsAPIClient.getFzpCore('teensy_3.1.fzp')
     .then((data) => {
       expect(typeof data).toEqual('string');
       done();
@@ -83,7 +82,7 @@ describe('ApiClient getFzpCore', () => {
   });
 
   test('Status 404', (done) => {
-    client.getFzpCore('not/found.fzp')
+    FritzingPartsAPIClient.getFzpCore('not/found.fzp')
     .then((data) => {
       throw new Error('should be 404');
       done();
@@ -97,7 +96,7 @@ describe('ApiClient getFzpCore', () => {
 
 describe('ApiClient getFzpObsolete', () => {
   test('Status 200', (done) => {
-    client.getFzpObsolete('Arduino_Leonardo_Rev3.fzp')
+    FritzingPartsAPIClient.getFzpObsolete('Arduino_Leonardo_Rev3.fzp')
     .then((data) => {
       expect(typeof data).toEqual('string');
       done();
@@ -108,7 +107,7 @@ describe('ApiClient getFzpObsolete', () => {
   });
 
   test('Status 404', (done) => {
-    client.getFzpObsolete('not/found.fzp')
+    FritzingPartsAPIClient.getFzpObsolete('not/found.fzp')
     .then((data) => {
       throw new Error('should be 404');
       done();
@@ -123,7 +122,7 @@ describe('ApiClient getFzpObsolete', () => {
 // test for the fritzing parts svg api routes
 describe('ApiClient getSvg', () => {
   test('Status 200', (done) => {
-    client.getSvg('core/breadboard/teensy_3.1_breadboard.svg')
+    FritzingPartsAPIClient.getSvg('core/breadboard/teensy_3.1_breadboard.svg')
     .then((data) => {
       expect(typeof data).toEqual('string');
       done();
@@ -134,7 +133,7 @@ describe('ApiClient getSvg', () => {
   });
 
   test('Status 404', (done) => {
-    client.getSvg('not/found.svg')
+    FritzingPartsAPIClient.getSvg('not/found.svg')
     .then((data) => {
       throw new Error('should be 404');
       done();
@@ -148,7 +147,7 @@ describe('ApiClient getSvg', () => {
 
 describe('ApiClient getSvgCore', () => {
   test('Status 200', (done) => {
-    client.getSvgCore('breadboard/teensy_3.1_breadboard.svg')
+    FritzingPartsAPIClient.getSvgCore('breadboard/teensy_3.1_breadboard.svg')
     .then((data) => {
       expect(typeof data).toEqual('string');
       done();
@@ -159,7 +158,7 @@ describe('ApiClient getSvgCore', () => {
   });
 
   test('Status 404', (done) => {
-    client.getSvgCore('not/found.svg')
+    FritzingPartsAPIClient.getSvgCore('not/found.svg')
     .then((data) => {
       throw new Error('should be 404');
       done();
@@ -173,7 +172,7 @@ describe('ApiClient getSvgCore', () => {
 
 describe('ApiClient getSvgObsolete', () => {
   test('Status 200', (done) => {
-    client.getSvgObsolete('breadboard/Arduino_Fio.svg')
+    FritzingPartsAPIClient.getSvgObsolete('breadboard/Arduino_Fio.svg')
     .then((data) => {
       expect(typeof data).toEqual('string');
       done();
@@ -184,7 +183,7 @@ describe('ApiClient getSvgObsolete', () => {
   });
 
   test('Status 404', (done) => {
-    client.getSvgObsolete('not/found.svg')
+    FritzingPartsAPIClient.getSvgObsolete('not/found.svg')
     .then((data) => {
       throw new Error('should be 404');
       done();
@@ -200,7 +199,7 @@ describe('ApiClient getSvgObsolete', () => {
 // test for the fritzing parts binary api routes
 describe('ApiClient getFzbs', () => {
   test('Status 200', (done) => {
-    client.getFzbs()
+    FritzingPartsAPIClient.getFzbs()
     .then((data) => {
       expect(typeof data).toEqual('object');
       done();


### PR DESCRIPTION
### Context:

- This PR add the github pages url of the fritzing-parts api as a constant variable.
- We do not need to create a class instance if we want to send a request
to the api. to fix this, the class was refactored to a constant object with `getFzps(), getFzp('name')`


check out the changes at:
```
git checkout -b refactor-to-object
```


### Proposed Changes

- [x] implement feature
- [x] document feature
- [x] test feature
- [x] update version at the `Makefile`

The following command need to be exit with code `0` to be merged!
```
make
```
